### PR TITLE
Fix issues #25, #26, #27: Claude Code v2.1.89/v2.1.92 compat fixes

### DIFF
--- a/src-tauri/src/convert.rs
+++ b/src-tauri/src/convert.rs
@@ -41,6 +41,7 @@ pub struct FrontendDisplayItem {
     pub hook_command: String,
     pub is_orphan: bool,
     pub subagent_prompt: String,
+    pub is_deferred: bool,
 }
 
 /// Frontend last output.
@@ -248,6 +249,7 @@ fn convert_display_items(
                 hook_command: it.hook_command.clone(),
                 is_orphan: it.is_orphan,
                 subagent_prompt: String::new(),
+                is_deferred: it.is_deferred,
             };
 
             // Link subagent process if available (Subagent items and ToolCall items like Skill).
@@ -687,6 +689,58 @@ mod tests {
             b_items[0].subagent_messages.is_empty(),
             "cycle must be cut here"
         );
+    }
+
+    #[test]
+    fn deferred_flag_is_propagated_to_frontend_display_item() {
+        use crate::parser::chunk::{DisplayItem, DisplayItemType};
+
+        let items = vec![DisplayItem {
+            item_type: DisplayItemType::ToolCall,
+            tool_id: "toolu_defer".to_string(),
+            tool_name: "Read".to_string(),
+            is_deferred: true,
+            ..Default::default()
+        }];
+
+        let subagents = vec![];
+        let graph = ProcGraph::new(&subagents);
+        let color_map = std::collections::HashMap::new();
+        let mut pool_idx = 0;
+
+        let result =
+            convert_display_items(&items, &graph, &color_map, &mut pool_idx, &HashSet::new());
+
+        assert_eq!(result.len(), 1);
+        assert!(
+            result[0].is_deferred,
+            "is_deferred must be propagated to FrontendDisplayItem"
+        );
+    }
+
+    #[test]
+    fn non_deferred_flag_propagates_as_false() {
+        use crate::parser::chunk::{DisplayItem, DisplayItemType};
+
+        let items = vec![DisplayItem {
+            item_type: DisplayItemType::ToolCall,
+            tool_id: "toolu_normal".to_string(),
+            tool_name: "Bash".to_string(),
+            tool_result: "output".to_string(),
+            is_deferred: false,
+            ..Default::default()
+        }];
+
+        let subagents = vec![];
+        let graph = ProcGraph::new(&subagents);
+        let color_map = std::collections::HashMap::new();
+        let mut pool_idx = 0;
+
+        let result =
+            convert_display_items(&items, &graph, &color_map, &mut pool_idx, &HashSet::new());
+
+        assert_eq!(result.len(), 1);
+        assert!(!result[0].is_deferred);
     }
 
     #[test]

--- a/src-tauri/src/parser/chunk.rs
+++ b/src-tauri/src/parser/chunk.rs
@@ -43,6 +43,9 @@ pub struct DisplayItem {
     pub hook_name: String,
     pub hook_command: String,
     pub is_orphan: bool,
+    /// True when the session was suspended via a "defer" PreToolUse permission decision
+    /// before a tool_result arrived for this tool_use block.
+    pub is_deferred: bool,
 }
 
 impl Default for DisplayItem {
@@ -68,6 +71,7 @@ impl Default for DisplayItem {
             hook_name: String::new(),
             hook_command: String::new(),
             is_orphan: false,
+            is_deferred: false,
         }
     }
 }
@@ -349,6 +353,12 @@ fn merge_ai_buffer(buf: &[AIMsg]) -> Chunk {
         }
     }
 
+    // Any tool_use blocks still in pending have no matching tool_result — the session was
+    // suspended via a "defer" PreToolUse permission decision before the tool ran.
+    for p in pending.values() {
+        items[p.index].is_deferred = true;
+    }
+
     let first = buf.first().map(|m| m.timestamp).unwrap_or_else(Utc::now);
     let last = buf.last().map(|m| m.timestamp).unwrap_or(first);
     let dur = last.signed_duration_since(first).num_milliseconds();
@@ -445,5 +455,147 @@ pub fn is_team_task(item: &DisplayItem) -> bool {
     match &item.tool_input {
         Some(Value::Object(map)) => map.contains_key("team_name") && map.contains_key("name"),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::classify::{AIMsg, ClassifiedMsg, ContentBlock, Usage};
+    use chrono::Utc;
+
+    fn make_ai_msg(blocks: Vec<ContentBlock>, is_meta: bool) -> AIMsg {
+        AIMsg {
+            timestamp: Utc::now(),
+            model: if is_meta {
+                String::new()
+            } else {
+                "claude-test".to_string()
+            },
+            text: String::new(),
+            thinking_count: 0,
+            tool_calls: Vec::new(),
+            blocks,
+            usage: Usage::default(),
+            stop_reason: String::new(),
+            is_meta,
+        }
+    }
+
+    fn tool_use_block(id: &str, name: &str) -> ContentBlock {
+        ContentBlock {
+            block_type: "tool_use".to_string(),
+            tool_id: id.to_string(),
+            tool_name: name.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn tool_result_block(id: &str, content: &str) -> ContentBlock {
+        ContentBlock {
+            block_type: "tool_result".to_string(),
+            tool_id: id.to_string(),
+            content: content.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn tool_use_with_matching_result_is_not_deferred() {
+        // A complete pair: tool_use followed by a tool_result in a meta entry.
+        let tool_id = "toolu_001";
+        let msgs = vec![
+            ClassifiedMsg::AI(make_ai_msg(vec![tool_use_block(tool_id, "Bash")], false)),
+            ClassifiedMsg::AI(make_ai_msg(
+                vec![tool_result_block(tool_id, "output")],
+                true,
+            )),
+        ];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 1);
+        let items = &chunks[0].items;
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].item_type, DisplayItemType::ToolCall);
+        assert_eq!(items[0].tool_result, "output");
+        assert!(
+            !items[0].is_deferred,
+            "matched tool_use should not be deferred"
+        );
+    }
+
+    #[test]
+    fn tool_use_without_result_is_marked_deferred() {
+        // Session ends after tool_use with no tool_result — simulates "defer" suspension.
+        let tool_id = "toolu_defer_001";
+        let msgs = vec![ClassifiedMsg::AI(make_ai_msg(
+            vec![tool_use_block(tool_id, "Read")],
+            false,
+        ))];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 1);
+        let items = &chunks[0].items;
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].item_type, DisplayItemType::ToolCall);
+        assert!(items[0].tool_result.is_empty());
+        assert!(
+            items[0].is_deferred,
+            "dangling tool_use should be marked deferred"
+        );
+    }
+
+    #[test]
+    fn multiple_tool_uses_only_unmatched_are_deferred() {
+        // Two tool_use blocks: one gets a result, one doesn't.
+        let id_complete = "toolu_complete";
+        let id_deferred = "toolu_deferred";
+        let msgs = vec![
+            ClassifiedMsg::AI(make_ai_msg(
+                vec![
+                    tool_use_block(id_complete, "Bash"),
+                    tool_use_block(id_deferred, "Read"),
+                ],
+                false,
+            )),
+            ClassifiedMsg::AI(make_ai_msg(
+                vec![tool_result_block(id_complete, "done")],
+                true,
+            )),
+        ];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 1);
+        let items = &chunks[0].items;
+        assert_eq!(items.len(), 2);
+
+        let complete = items.iter().find(|i| i.tool_name == "Bash").unwrap();
+        let deferred = items.iter().find(|i| i.tool_name == "Read").unwrap();
+
+        assert_eq!(complete.tool_result, "done");
+        assert!(!complete.is_deferred);
+        assert!(deferred.tool_result.is_empty());
+        assert!(deferred.is_deferred);
+    }
+
+    #[test]
+    fn deferred_subagent_tool_use_is_marked_deferred() {
+        // A Task/Agent tool_use block without a matching result is also deferred.
+        let tool_id = "toolu_agent_deferred";
+        let msgs = vec![ClassifiedMsg::AI(make_ai_msg(
+            vec![ContentBlock {
+                block_type: "tool_use".to_string(),
+                tool_id: tool_id.to_string(),
+                tool_name: "Task".to_string(),
+                ..Default::default()
+            }],
+            false,
+        ))];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 1);
+        let items = &chunks[0].items;
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].item_type, DisplayItemType::Subagent);
+        assert!(
+            items[0].is_deferred,
+            "dangling Task tool_use should be marked deferred"
+        );
     }
 }

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -165,9 +165,8 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     .to_string();
                 let command = data
                     .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
+                    .map(resolve_hook_output)
+                    .unwrap_or_default();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event,
@@ -236,14 +235,24 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     .unwrap_or("")
                     .to_string();
                 // For blocking errors, extract the error message as the command context.
-                let command = att
-                    .get("blockingError")
-                    .and_then(|v| v.get("blockingError"))
-                    .and_then(|v| v.as_str())
-                    .or_else(|| att.get("stderr").and_then(|v| v.as_str()))
-                    .unwrap_or("")
-                    .trim()
-                    .to_string();
+                // From v2.1.89 these fields may be a {path, preview} file-reference object
+                // instead of a plain string when output exceeds 50 K characters.
+                let command = {
+                    let blocking = att
+                        .get("blockingError")
+                        .and_then(|v| v.get("blockingError"))
+                        .map(resolve_hook_output)
+                        .unwrap_or_default();
+                    if !blocking.trim().is_empty() {
+                        blocking
+                    } else {
+                        att.get("stderr")
+                            .map(resolve_hook_output)
+                            .unwrap_or_default()
+                    }
+                }
+                .trim()
+                .to_string();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event: hook_event.to_string(),
@@ -1150,6 +1159,111 @@ mod tests {
             ..Default::default()
         };
         assert!(classify(e).is_none(), "Non-hook attachment must be dropped");
+    }
+
+    // --- Hook output compat tests (v2.1.89+) ---
+
+    #[test]
+    fn classify_progress_hook_with_structured_command_returns_preview() {
+        // v2.1.89: hook stdout >50K is stored as {path, preview} object instead of a plain string.
+        // When the file is absent (tmp file already cleaned up), the preview must be returned.
+        let e = Entry {
+            entry_type: "progress".to_string(),
+            uuid: "uuid-hook-large".to_string(),
+            timestamp: "2025-01-15T10:30:00Z".to_string(),
+            data: Some(json!({
+                "type": "hook_progress",
+                "hookEvent": "PostToolUse",
+                "hookName": "my-large-hook",
+                "command": {"path": "/tmp/nonexistent_hook_12345.txt", "preview": "large output preview"}
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "PostToolUse");
+                assert_eq!(h.hook_name, "my-large-hook");
+                assert_eq!(h.command, "large output preview");
+            }
+            other => panic!("Expected Hook with preview, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_progress_hook_with_structured_command_reads_file_when_present() {
+        // When the file is still on disk, the full content must be returned.
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_classify_hook_large.txt");
+        std::fs::write(&path, "full large hook output").unwrap();
+        let e = Entry {
+            entry_type: "progress".to_string(),
+            uuid: "uuid-hook-file".to_string(),
+            timestamp: "2025-01-15T10:30:00Z".to_string(),
+            data: Some(json!({
+                "type": "hook_progress",
+                "hookEvent": "PreToolUse",
+                "hookName": "pre-hook",
+                "command": {"path": path.to_str().unwrap(), "preview": "truncated..."}
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.command, "full large hook output");
+            }
+            other => panic!("Expected Hook, got {:?}", other),
+        }
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn classify_attachment_blocking_error_with_structured_blocking_error_field() {
+        // v2.1.89: blockingError.blockingError may be a {path, preview} object.
+        let e = Entry {
+            entry_type: "attachment".to_string(),
+            uuid: "uuid-att-large-block".to_string(),
+            timestamp: "2025-01-15T10:30:00Z".to_string(),
+            attachment: Some(json!({
+                "type": "hook_blocking_error",
+                "hookEvent": "PostToolUse",
+                "hookName": "post-lint",
+                "blockingError": {
+                    "blockingError": {"path": "/tmp/nonexistent_block.txt", "preview": "lint error preview"}
+                }
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "PostToolUse");
+                assert_eq!(h.command, "lint error preview");
+            }
+            other => panic!("Expected Hook, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_attachment_blocking_error_with_structured_stderr_field() {
+        // v2.1.89: stderr may also be a {path, preview} object when output is large.
+        let e = Entry {
+            entry_type: "attachment".to_string(),
+            uuid: "uuid-att-large-stderr".to_string(),
+            timestamp: "2025-01-15T10:30:00Z".to_string(),
+            attachment: Some(json!({
+                "type": "hook_non_blocking_error",
+                "hookEvent": "PreToolUse",
+                "hookName": "pre-check",
+                "stderr": {"path": "/tmp/nonexistent_stderr.txt", "preview": "stderr preview text"}
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "PreToolUse");
+                assert_eq!(h.command, "stderr preview text");
+            }
+            other => panic!("Expected Hook, got {:?}", other),
+        }
     }
 
     // --- Unknown / structural entry type tests (compat: v2.1.79-v2.1.83) ---

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -527,6 +527,33 @@ fn extract_tool_search_matches(raw: &Option<Value>) -> Option<Vec<String>> {
     }
 }
 
+/// Normalizes a `tool_use.input` value to handle the pre-v2.1.92 streaming bug where
+/// array/object fields were emitted as JSON-encoded strings instead of native JSON types.
+///
+/// For example, `"env": "[\"KEY=val\"]"` is parsed back to `"env": ["KEY=val"]`.
+/// Values that are already arrays or objects, or strings that don't parse as
+/// arrays/objects, are left unchanged.
+fn normalize_tool_input(input: Value) -> Value {
+    match input {
+        Value::Object(mut map) => {
+            for val in map.values_mut() {
+                if let Value::String(s) = val {
+                    let trimmed = s.trim_start();
+                    if trimmed.starts_with('[') || trimmed.starts_with('{') {
+                        if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+                            if matches!(parsed, Value::Array(_) | Value::Object(_)) {
+                                *val = parsed;
+                            }
+                        }
+                    }
+                }
+            }
+            Value::Object(map)
+        }
+        other => other,
+    }
+}
+
 fn extract_assistant_details(content: &Option<Value>) -> (usize, Vec<ToolCall>, Vec<ContentBlock>) {
     let blocks = match content {
         Some(Value::Array(arr)) => arr,
@@ -584,7 +611,7 @@ fn extract_assistant_details(content: &Option<Value>) -> (usize, Vec<ToolCall>, 
                     block_type: "tool_use".to_string(),
                     tool_id: id,
                     tool_name: name,
-                    tool_input: b.get("input").cloned(),
+                    tool_input: b.get("input").cloned().map(normalize_tool_input),
                     ..Default::default()
                 });
             }
@@ -1207,6 +1234,98 @@ mod tests {
                 "Expected meta AI for unknown entry with role, got {:?}",
                 other
             ),
+        }
+    }
+
+    // --- normalize_tool_input tests (compat: pre-v2.1.92 streaming bug) ---
+
+    #[test]
+    fn normalize_tool_input_leaves_native_array_unchanged() {
+        let input = json!({"command": "ls", "env": ["KEY=val"]});
+        let result = normalize_tool_input(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn normalize_tool_input_leaves_native_object_unchanged() {
+        let input = json!({"options": {"flag": true}});
+        let result = normalize_tool_input(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn normalize_tool_input_parses_json_encoded_array_string() {
+        // Pre-v2.1.92: array field emitted as JSON-encoded string
+        let input = json!({"command": "ls", "env": "[\"KEY=val\"]"});
+        let result = normalize_tool_input(input);
+        assert_eq!(result["env"], json!(["KEY=val"]));
+        assert_eq!(result["command"], json!("ls"));
+    }
+
+    #[test]
+    fn normalize_tool_input_parses_json_encoded_object_string() {
+        // Pre-v2.1.92: object field emitted as JSON-encoded string
+        let input = json!({"options": "{\"flag\": true, \"count\": 3}"});
+        let result = normalize_tool_input(input);
+        assert_eq!(result["options"], json!({"flag": true, "count": 3}));
+    }
+
+    #[test]
+    fn normalize_tool_input_leaves_plain_string_unchanged() {
+        let input = json!({"command": "ls -la", "description": "List files"});
+        let result = normalize_tool_input(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn normalize_tool_input_leaves_string_that_looks_like_array_but_invalid_json_unchanged() {
+        let input = json!({"bad": "[not valid json"});
+        let result = normalize_tool_input(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn normalize_tool_input_leaves_non_object_input_unchanged() {
+        // input that is an array or scalar at the top level is returned as-is
+        let input = json!(["a", "b"]);
+        let result = normalize_tool_input(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn classify_tool_use_block_with_pre_v2_1_92_encoded_array_is_normalized() {
+        // Integration test: full classify path normalizes legacy encoded array
+        let content = json!([{
+            "type": "tool_use",
+            "id": "tool1",
+            "name": "Bash",
+            "input": {
+                "command": "ls",
+                "env": "[\"KEY=val\"]"
+            }
+        }]);
+        let mut e = make_entry("assistant", Some(content));
+        e.message.model = "claude-sonnet-4-20250514".to_string();
+        e.message.stop_reason = Some("tool_use".to_string());
+        match classify(e) {
+            Some(ClassifiedMsg::AI(ai)) => {
+                let block = ai
+                    .blocks
+                    .iter()
+                    .find(|b| b.block_type == "tool_use")
+                    .expect("should have tool_use block");
+                let env = block
+                    .tool_input
+                    .as_ref()
+                    .and_then(|v| v.get("env"))
+                    .expect("env field should exist");
+                assert_eq!(
+                    *env,
+                    json!(["KEY=val"]),
+                    "env should be a native array, not a string"
+                );
+            }
+            other => panic!("Expected AI, got {:?}", other),
         }
     }
 }

--- a/src-tauri/src/parser/sanitize.rs
+++ b/src-tauri/src/parser/sanitize.rs
@@ -169,6 +169,31 @@ pub fn stringify_content(raw: &Option<Value>) -> String {
     val.to_string()
 }
 
+/// Resolves a hook output field that may be either a plain string or a structured
+/// file-reference object introduced in Claude Code v2.1.89.
+///
+/// From v2.1.89, hook stdout over 50,000 characters is saved to a temporary file
+/// and the field contains `{"path": "/tmp/...", "preview": "...(truncated)"}` instead
+/// of a plain string. This function reads the full file when it is still on disk,
+/// otherwise falls back to the `preview` string from the object.
+pub fn resolve_hook_output(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Object(map) => {
+            if let Some(path) = map.get("path").and_then(|p| p.as_str()) {
+                if let Ok(content) = fs::read_to_string(path) {
+                    return content;
+                }
+            }
+            map.get("preview")
+                .and_then(|p| p.as_str())
+                .unwrap_or("")
+                .to_string()
+        }
+        _ => String::new(),
+    }
+}
+
 /// Detects `<persisted-output>` markers in tool result content and resolves
 /// the file reference by reading the persisted file from disk.
 /// Returns the full file content if found, otherwise the original string.
@@ -340,6 +365,45 @@ mod tests {
         let result = stringify_content(&v);
         assert!(result.contains("key"));
         assert!(result.contains("value"));
+    }
+
+    // ---- resolve_hook_output tests ----
+
+    #[test]
+    fn resolve_hook_output_plain_string_returned_as_is() {
+        let v = json!("hook output text");
+        assert_eq!(resolve_hook_output(&v), "hook output text");
+    }
+
+    #[test]
+    fn resolve_hook_output_object_returns_preview_when_file_missing() {
+        let v =
+            json!({"path": "/tmp/nonexistent_hook_file_xyz.txt", "preview": "preview text here"});
+        assert_eq!(resolve_hook_output(&v), "preview text here");
+    }
+
+    #[test]
+    fn resolve_hook_output_object_reads_file_when_exists() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test_hook_output_file.txt");
+        std::fs::write(&path, "full hook output content").unwrap();
+        let v = json!({"path": path.to_str().unwrap(), "preview": "truncated preview"});
+        let result = resolve_hook_output(&v);
+        assert_eq!(result, "full hook output content");
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn resolve_hook_output_non_string_non_object_returns_empty() {
+        assert_eq!(resolve_hook_output(&json!(42)), "");
+        assert_eq!(resolve_hook_output(&json!(null)), "");
+        assert_eq!(resolve_hook_output(&json!([1, 2])), "");
+    }
+
+    #[test]
+    fn resolve_hook_output_object_without_preview_returns_empty() {
+        let v = json!({"path": "/tmp/missing.txt"});
+        assert_eq!(resolve_hook_output(&v), "");
     }
 
     // ---- resolve_persisted_output tests ----


### PR DESCRIPTION
## Summary

Compatibility fixes for Claude Code v2.1.89 and v2.1.92 regressions affecting transcript parsing.

## Fixes

- **#27** — `[Compat] Claude Code v2.1.92`: Add `normalize_tool_input()` in `classify.rs` to parse JSON-encoded array/object strings back to native types in `tool_use.input` fields, fixing a streaming bug where Claude Code wrote `"[\"KEY=val\"]"` instead of `["KEY=val"]`.

- **#26** — `[Compat] Claude Code v2.1.89`: Detect suspended transcripts caused by the new `defer` PreToolUse permission by marking any unmatched `tool_use` block (no corresponding `tool_result` at buffer flush) as `is_deferred = true` on both `DisplayItem` and `FrontendDisplayItem`.

- **#25** — `[Compat] Claude Code v2.1.89`: Add `resolve_hook_output()` in `sanitize.rs` to handle the new `{path, preview}` file-reference format used when hook stdout exceeds 50 K characters, falling back to the `preview` string when the temp file is no longer on disk.

## Files Changed

| File | Change |
|---|---|
| `src-tauri/src/parser/classify.rs` | `normalize_tool_input()`, `resolve_hook_output()` usage for hook `command` field |
| `src-tauri/src/parser/sanitize.rs` | New `resolve_hook_output()` helper |
| `src-tauri/src/parser/chunk.rs` | `is_deferred` field on `DisplayItem`, deferred detection in `merge_ai_buffer()` |
| `src-tauri/src/convert.rs` | Propagate `is_deferred` to `FrontendDisplayItem` |

## Tests

- 304 Rust unit tests pass (`cargo test`)
- 335 frontend tests pass (`vitest`)
- New tests added for each fix covering the regression scenario, edge cases, and the happy path
