### PR TITLE
fix: correct inverted j/k and arrow key navigation in session message list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -219,13 +219,13 @@ export function App() {
   } else {
     switch (view) {
       case "list": {
-        const listDown = () => setSelectedMessage((i) => Math.max(i - 1, 0));
-        const listUp = () =>
+        const moveDown = () =>
           setSelectedMessage((i) => Math.min(i + 1, session.messages.length - 1));
-        keyMap["j"] = listUp;
-        keyMap["ArrowDown"] = listUp;
-        keyMap["k"] = listDown;
-        keyMap["ArrowUp"] = listDown;
+        const moveUp = () => setSelectedMessage((i) => Math.max(i - 1, 0));
+        keyMap["j"] = moveDown;
+        keyMap["ArrowDown"] = moveDown;
+        keyMap["k"] = moveUp;
+        keyMap["ArrowUp"] = moveUp;
         keyMap["G"] = jumpToTop;
         keyMap["g"] = jumpToBottom;
         keyMap["Tab"] = () => toggleMessage(selectedMessage);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -222,10 +222,10 @@ export function App() {
         const listDown = () => setSelectedMessage((i) => Math.max(i - 1, 0));
         const listUp = () =>
           setSelectedMessage((i) => Math.min(i + 1, session.messages.length - 1));
-        keyMap["j"] = listDown;
-        keyMap["ArrowDown"] = listDown;
-        keyMap["k"] = listUp;
-        keyMap["ArrowUp"] = listUp;
+        keyMap["j"] = listUp;
+        keyMap["ArrowDown"] = listUp;
+        keyMap["k"] = listDown;
+        keyMap["ArrowUp"] = listDown;
         keyMap["G"] = jumpToTop;
         keyMap["g"] = jumpToBottom;
         keyMap["Tab"] = () => toggleMessage(selectedMessage);


### PR DESCRIPTION
## Summary | 概要

修复 session 消息列表视图中 `j`/`k` 和方向键导航方向颠倒的问题。

### 问题描述 | Problem Description

在 session 消息列表视图中（user/assistant 消息列表），按 `j` 或 `↓` 时光标跳到了更旧的消息，而按 `k` 或 `↑` 跳到了更新的消息。这与常规的 TUI 操作习惯（j/↓ 向新内容前进）相反。

**对比：**
- `projects` 列表页：上下键正常工作
- `sessions` 列表页（picker）：上下键正常工作
- **session 详情页的 user/assistant 消息列表**：上下键颠倒 ← **这是 bug**

**复现步骤：**
1. 打开 claude-code-trace，进入任意 session
2. 进入消息列表视图（user/assistant 消息列表）
3. 按 `j` 或 `↓`，发现跳到了更旧的消息（应该跳到更新）
4. 按 `k` 或 `↑`，发现跳到了更新的消息（应该跳到更旧）
5. 对比：在 picker 视图和 projects 视图中，上下键行为正常

### 修改内容 | Changes

在 `src/App.tsx` 的 `list` view 分支中，将 j/k 和 ArrowUp/Down 的绑定互换：

```diff
-        keyMap["j"] = listDown;
-        keyMap["ArrowDown"] = listDown;
-        keyMap["k"] = listUp;
-        keyMap["ArrowUp"] = listUp;
+        keyMap["j"] = listUp;
+        keyMap["ArrowDown"] = listUp;
+        keyMap["k"] = listDown;
+        keyMap["ArrowUp"] = listDown;
```

### 影响面 | Impact

- **影响范围**：仅 `list` 视图（session 消息列表）
- **其他视图不受影响**：`picker`（session 列表）使用了相同的逻辑但绑定正确；`detail` 视图使用独立的键盘处理
- **G/g 键**：`jumpToTop`/`jumpToBottom` 函数命名虽然与实际行为反序（jumpToTop 跳到 index n-1），但 G/g 绑定产生的视觉效果是正确的，故本次不修改

### 测试建议 | Testing

1. 打开任意 session
2. 确认消息列表按正序显示（最旧在顶部，最新在底部）
3. 按 j 确认光标向更新消息移动
4. 按 k 确认光标向更旧消息移动
5. 按 G 确认跳到最新消息，按 g 确认跳到最旧消息

---

Thanks for building this tool! | 感谢维护这个工具！
