### PR TITLE
fix(clippy): resolve all Rust lint warnings (-D warnings)

### DIFF
--- a/src-tauri/src/parser/cache.rs
+++ b/src-tauri/src/parser/cache.rs
@@ -73,7 +73,7 @@ impl SessionCache {
                 all.extend(sessions);
             }
         }
-        all.sort_by(|a, b| b.mod_time.cmp(&a.mod_time));
+        all.sort_by_key(|b| std::cmp::Reverse(b.mod_time));
         Ok(all)
     }
 }

--- a/src-tauri/src/parser/chunk.rs
+++ b/src-tauri/src/parser/chunk.rs
@@ -264,18 +264,16 @@ fn merge_ai_buffer(buf: &[AIMsg]) -> Chunk {
         if !m.is_meta {
             for b in &m.blocks {
                 match b.block_type.as_str() {
-                    "thinking" => {
-                        // Extended thinking blocks store an encrypted signature in the JSONL
-                        // but redact the actual text (thinking field is ""). Only emit a
-                        // Thinking DisplayItem when there is real content to show; thinking_count
-                        // already tracks the presence of thinking blocks regardless.
-                        if !b.text.is_empty() {
-                            items.push(DisplayItem {
-                                item_type: DisplayItemType::Thinking,
-                                text: b.text.clone(),
-                                ..Default::default()
-                            });
-                        }
+                    // Extended thinking blocks store an encrypted signature in the JSONL
+                    // but redact the actual text (thinking field is ""). Only emit a
+                    // Thinking DisplayItem when there is real content to show; thinking_count
+                    // already tracks the presence of thinking blocks regardless.
+                    "thinking" if !b.text.is_empty() => {
+                        items.push(DisplayItem {
+                            item_type: DisplayItemType::Thinking,
+                            text: b.text.clone(),
+                            ..Default::default()
+                        });
                     }
                     "text" => {
                         items.push(DisplayItem {

--- a/src-tauri/src/parser/ongoing.rs
+++ b/src-tauri/src/parser/ongoing.rs
@@ -325,17 +325,14 @@ impl<'a> OngoingChecker<'a> {
                     continue;
                 }
                 match item.item_type {
-                    DisplayItemType::Subagent => {
-                        if item.tool_result.is_empty() {
-                            return true;
-                        }
+                    DisplayItemType::Subagent if item.tool_result.is_empty() => {
+                        return true;
                     }
-                    DisplayItemType::ToolCall => {
+                    DisplayItemType::ToolCall
                         if (item.tool_name == "Task" || item.tool_name == "Agent")
-                            && item.tool_result.is_empty()
-                        {
-                            return true;
-                        }
+                            && item.tool_result.is_empty() =>
+                    {
+                        return true;
                     }
                     _ => {}
                 }

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -808,6 +808,12 @@ pub struct IncrementalTokenScanner {
     subagent_offsets: HashMap<String, u64>,
 }
 
+impl Default for IncrementalTokenScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl IncrementalTokenScanner {
     pub fn new() -> Self {
         Self {
@@ -1500,7 +1506,7 @@ mod tests {
         // Should terminate without panicking.
         let set = resolve_live_chain_uuids(&entries);
         // Both are referenced as parents, so neither is a leaf → no live tip → empty set.
-        assert!(set.is_empty() || !set.is_empty()); // just verify no panic/hang
+        assert!(set.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -353,7 +353,7 @@ pub fn discover_project_sessions(project_dir: &str) -> Result<Vec<SessionInfo>, 
         });
     }
 
-    sessions.sort_by(|a, b| b.mod_time.cmp(&a.mod_time));
+    sessions.sort_by_key(|b| std::cmp::Reverse(b.mod_time));
     Ok(sessions)
 }
 
@@ -365,7 +365,7 @@ pub fn discover_all_project_sessions(project_dirs: &[String]) -> Result<Vec<Sess
             all.extend(sessions);
         }
     }
-    all.sort_by(|a, b| b.mod_time.cmp(&a.mod_time));
+    all.sort_by_key(|b| std::cmp::Reverse(b.mod_time));
     Ok(all)
 }
 
@@ -443,7 +443,7 @@ where
         }
     }
 
-    sessions.sort_by(|a, b| b.mod_time.cmp(&a.mod_time));
+    sessions.sort_by_key(|b| std::cmp::Reverse(b.mod_time));
     Ok(sessions)
 }
 

--- a/src-tauri/src/parser/subagent.rs
+++ b/src-tauri/src/parser/subagent.rs
@@ -11,7 +11,7 @@ use super::classify::*;
 use super::entry::parse_entry;
 
 /// Per-requestId token snapshot used for deduplication across JSONL files.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct TokenSnapshot {
     pub input: i64,
     pub output: i64,

--- a/src-tauri/src/parser/subagent.rs
+++ b/src-tauri/src/parser/subagent.rs
@@ -319,7 +319,7 @@ pub fn discover_subagents(session_path: &str) -> Result<Vec<SubagentProcess>, St
         procs.push(proc);
     }
 
-    procs.sort_by(|a, b| a.start_time.cmp(&b.start_time));
+    procs.sort_by_key(|a| a.start_time);
     Ok(procs)
 }
 
@@ -992,7 +992,7 @@ pub fn discover_team_sessions(
         procs.push(proc);
     }
 
-    procs.sort_by(|a, b| a.start_time.cmp(&b.start_time));
+    procs.sort_by_key(|a| a.start_time);
     Ok(procs)
 }
 


### PR DESCRIPTION
Fixes all clippy errors surfaced by `cargo clippy -- -D warnings` in CI run [24551861884](https://github.com/delexw/claude-code-trace/actions/runs/24551861884/job/71779217475).

## Changes

### `clippy::new_without_default`
- `parser/subagent.rs` — derive `Default` for `TokenSnapshot` (all fields are zero/empty)
- `parser/session.rs` — add `impl Default for IncrementalTokenScanner` delegating to `Self::new()`

### `clippy::nonminimal_bool`
- `parser/session.rs` — replace tautological `assert!(set.is_empty() || !set.is_empty())` with `assert!(set.is_empty())` (cycle guard always yields empty set)

### `clippy::unnecessary_sort_by`
- `parser/cache.rs` — `sort_by(|a, b| b.mod_time.cmp(&a.mod_time))` → `sort_by_key(|b| Reverse(b.mod_time))`
- `parser/session.rs` (×3) — same pattern
- `parser/subagent.rs` (×2) — `sort_by(|a, b| a.start_time.cmp(&b.start_time))` → `sort_by_key(|a| a.start_time)`

### `clippy::collapsible_match`
- `parser/chunk.rs` — collapse `if !b.text.is_empty()` inside `"thinking"` arm into a match guard
- `parser/ongoing.rs` (×2) — collapse nested `if` blocks inside `Subagent` and `ToolCall` arms into match guards