### PR TITLE
Fix issues #49, #48: session recap entries and PreCompact hook event compat

### DIFF
--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -153,8 +153,8 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
 
     // Rescue hook events from noise filter before discarding all "progress" entries.
     // All existing hooks use data.type="hook_progress", but guard on hookEvent presence
-    // so that future hook types (e.g. TaskCreated added in v2.1.84) are also rescued
-    // without needing to enumerate data.type values.
+    // so that future hook types (e.g. TaskCreated added in v2.1.84, PreCompact in v2.1.105)
+    // are also rescued without needing to enumerate data.type values.
     if e.entry_type == "progress" {
         if let Some(ref data) = e.data {
             let is_hook = data.get("type").and_then(|v| v.as_str()) == Some("hook_progress")
@@ -1552,6 +1552,75 @@ mod tests {
         }));
         // classify must not panic; it returns None (tool-loaded noise) or a SystemMsg.
         let _ = classify(e);
+    }
+
+    // --- Issue #48: PreCompact hook event (v2.1.105) is handled generically ---
+
+    #[test]
+    fn classify_rescues_pre_compact_progress_hook_event() {
+        // v2.1.105: PreCompact fires as a progress entry before session compaction.
+        // The generic hookEvent presence check must rescue it without an explicit match arm.
+        let e = Entry {
+            entry_type: "progress".to_string(),
+            uuid: "uuid-pre-compact".to_string(),
+            timestamp: "2026-04-13T10:00:00Z".to_string(),
+            data: Some(json!({
+                "type": "hook_progress",
+                "hookEvent": "PreCompact",
+                "hookName": "my-compact-hook",
+                "command": "echo compacting"
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "PreCompact");
+                assert_eq!(h.hook_name, "my-compact-hook");
+            }
+            other => panic!(
+                "Expected Hook for PreCompact progress entry, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_rescues_pre_compact_attachment_with_decision_block() {
+        // v2.1.105: PreCompact hooks can block compaction by returning {"decision":"block"}.
+        // The attachment entry must be rescued and its metadata must preserve the decision field.
+        let e = Entry {
+            entry_type: "attachment".to_string(),
+            uuid: "uuid-pre-compact-block".to_string(),
+            timestamp: "2026-04-13T10:00:01Z".to_string(),
+            attachment: Some(json!({
+                "type": "hook_blocking_error",
+                "hookEvent": "PreCompact",
+                "hookName": "my-compact-hook",
+                "decision": "block",
+                "reason": "Not ready to compact"
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "PreCompact");
+                assert_eq!(h.hook_name, "my-compact-hook");
+                let meta = h.metadata.expect("metadata must be present");
+                assert_eq!(
+                    meta.get("decision").and_then(|v| v.as_str()),
+                    Some("block"),
+                    "decision:block payload must be preserved in metadata"
+                );
+                assert_eq!(
+                    meta.get("reason").and_then(|v| v.as_str()),
+                    Some("Not ready to compact")
+                );
+            }
+            other => panic!(
+                "Expected Hook for PreCompact attachment with decision:block, got {:?}",
+                other
+            ),
+        }
     }
 
     // --- Issue #37: document content block is recognised as user content ---

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -188,6 +188,16 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
     // Rescue hook-related system entries before the NOISE_ENTRY_TYPES filter drops them.
     if e.entry_type == "system" {
         match e.subtype.as_str() {
+            // away_summary: written by v2.1.108+ when the user returns after being idle,
+            // or when /recap is invoked manually. The recap text lives in the top-level
+            // `content` field (not `message.content`). Display as a CompactMsg so it
+            // appears inline in the transcript like a context summary.
+            "away_summary" => {
+                return Some(ClassifiedMsg::Compact(CompactMsg {
+                    timestamp: ts,
+                    text: e.content.clone(),
+                }));
+            }
             // stop_hook_summary: written every time Stop hooks run (success or failure).
             // hookInfos contains [{command, durationMs}, ...] for each hook that ran.
             "stop_hook_summary" if e.hook_count > 0 => {
@@ -1321,7 +1331,7 @@ mod tests {
     #[test]
     fn classify_drops_rate_limit_event_silently() {
         // rate_limit_event has a uuid but no message role — must be dropped, not shown as AI.
-        let mut e = Entry {
+        let e = Entry {
             entry_type: "rate_limit_event".to_string(),
             uuid: "uuid-rate".to_string(),
             timestamp: "2025-01-15T10:30:00Z".to_string(),
@@ -1352,7 +1362,7 @@ mod tests {
     #[test]
     fn classify_keeps_unknown_entry_with_message_role_as_meta() {
         // An unknown entry type that carries actual message content should still be shown.
-        let mut e = Entry {
+        let e = Entry {
             entry_type: "channel_message".to_string(),
             uuid: "uuid-chan".to_string(),
             timestamp: "2025-01-15T10:30:00Z".to_string(),
@@ -1463,6 +1473,46 @@ mod tests {
                 );
             }
             other => panic!("Expected AI, got {:?}", other),
+        }
+    }
+
+    // --- Issue #49: session recap (away_summary) entries are displayed as CompactMsg ---
+
+    #[test]
+    fn classify_away_summary_returns_compact_msg() {
+        // v2.1.108+: recap entries use type:"system", subtype:"away_summary", content:"<text>"
+        let e = Entry {
+            entry_type: "system".to_string(),
+            uuid: "uuid-recap".to_string(),
+            timestamp: "2026-04-14T10:00:00Z".to_string(),
+            subtype: "away_summary".to_string(),
+            content: "Working on a bug fix in entry.rs.".to_string(),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Compact(c)) => {
+                assert_eq!(c.text, "Working on a bug fix in entry.rs.");
+            }
+            other => panic!("Expected Compact for away_summary, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_away_summary_with_empty_content_returns_compact_msg() {
+        // Empty content is preserved consistently with how "summary" entries are handled.
+        let e = Entry {
+            entry_type: "system".to_string(),
+            uuid: "uuid-recap-empty".to_string(),
+            timestamp: "2026-04-14T10:00:00Z".to_string(),
+            subtype: "away_summary".to_string(),
+            content: String::new(),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Compact(c)) => {
+                assert_eq!(c.text, "");
+            }
+            other => panic!("Expected Compact for empty away_summary, got {:?}", other),
         }
     }
 

--- a/src-tauri/src/parser/debuglog.rs
+++ b/src-tauri/src/parser/debuglog.rs
@@ -214,7 +214,7 @@ pub fn filter_by_text(entries: &[DebugEntry], query: &str) -> Vec<DebugEntry> {
 /// execution in `~/.claude/debug/{session_id}.txt` (only when run with `--debug`).
 /// This function reads those lines and returns HookMsg entries that can be merged
 /// into the session's classified message list to surface non-Stop hooks (PreToolUse,
-/// PostToolUse, UserPromptSubmit, SessionStart, etc.) that are not recorded in JSONL.
+/// PostToolUse, UserPromptSubmit, SessionStart, PreCompact, etc.) that are not recorded in JSONL.
 ///
 /// Stop hooks are excluded because they are already captured via `stop_hook_summary`
 /// system entries in the JSONL file.
@@ -386,5 +386,31 @@ prompt captured\n\
             .map(|i| &hook_name_full[i + 1..])
             .unwrap_or(hook_name_full);
         assert_eq!(hook_name, "UserPromptSubmit");
+    }
+
+    #[test]
+    fn extract_hook_msgs_parses_pre_compact_hook_event() {
+        // v2.1.105: PreCompact fires before session compaction. The debug log captures it
+        // with the same format as other hooks. The generic regex must match it.
+        let content = "\
+2026-04-13T10:00:00.000Z [DEBUG] Hook PreCompact (PreCompact) success:\n\
+compaction allowed\n\
+";
+        let f = write_debug_file(content);
+        let (entries, _) = read_debug_log(f.path().to_str().unwrap()).unwrap();
+
+        let caps = HOOK_MSG_RE.captures(&entries[0].message).unwrap();
+        assert_eq!(caps.get(2).unwrap().as_str(), "PreCompact");
+
+        // Must not be excluded (only Stop is excluded).
+        let hook_event = caps.get(2).unwrap().as_str();
+        assert_ne!(hook_event, "Stop");
+
+        let hook_name_full = caps.get(1).unwrap().as_str();
+        let hook_name = hook_name_full
+            .find(':')
+            .map(|i| &hook_name_full[i + 1..])
+            .unwrap_or(hook_name_full);
+        assert_eq!(hook_name, "PreCompact");
     }
 }

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -71,6 +71,11 @@ pub struct Entry {
     // "hook_non_blocking_error"|"hook_blocking_error"|"hook_cancelled", hookEvent, hookName, ...}}
     #[serde(default)]
     pub attachment: Option<Value>,
+    // Present in type:"system", subtype:"away_summary" entries (v2.1.108+). Claude Code writes
+    // a recap entry when the user returns after being idle; the recap text is at top-level
+    // `content`, not inside `message.content`.
+    #[serde(default)]
+    pub content: String,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -217,6 +222,27 @@ mod tests {
             ..Default::default()
         };
         assert!(e.tool_use_result_map().is_none());
+    }
+
+    #[test]
+    fn parse_entry_captures_content_field_for_away_summary() {
+        // v2.1.108+: {type:"system",subtype:"away_summary",content:"<text>",uuid:"...",timestamp:"..."}
+        let line = json!({
+            "type": "system",
+            "subtype": "away_summary",
+            "uuid": "recap-uuid-123",
+            "timestamp": "2026-04-14T10:00:00Z",
+            "isMeta": false,
+            "content": "Working on issue #49 — fixing recap entry parsing."
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse away_summary entry");
+        assert_eq!(entry.entry_type, "system");
+        assert_eq!(entry.subtype, "away_summary");
+        assert_eq!(
+            entry.content,
+            "Working on issue #49 — fixing recap entry parsing."
+        );
     }
 
     #[test]

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -60,8 +60,8 @@ pub fn read_session(path: &str) -> Result<Vec<Chunk>, String> {
 /// Full session load: JSONL classified messages merged with hook events from the
 /// debug log (if one exists at `~/.claude/debug/{session_id}.txt`).
 ///
-/// Non-Stop hooks (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart) are
-/// only written to the debug log (not the JSONL) in Claude Code v2.1.84+. This
+/// Non-Stop hooks (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, PreCompact,
+/// etc.) are only written to the debug log (not the JSONL) in Claude Code v2.1.84+. This
 /// function surfaces them by reading the debug log and merging by timestamp.
 pub fn read_session_with_debug_hooks(path: &str) -> Result<(Vec<ClassifiedMsg>, u64, u64), String> {
     let (mut msgs, offset, bytes) = read_session_incremental(path, 0)?;


### PR DESCRIPTION
Fixes two Claude Code compatibility issues reported against recent versions.

## Issues Fixed

- **#49 — [Compat] Claude Code v2.1.108/v2.1.110: Session recap entries may use unknown type or summary variant**
  Added `content: String` field to `Entry` so the top-level `content` present in `type:"system", subtype:"away_summary"` recap entries is captured. Added an `away_summary` classify arm that returns `CompactMsg`, making recap entries visible inline in the transcript instead of being silently dropped as noise.

- **#48 — [Compat] Claude Code v2.1.105: PreCompact hook event type unhandled in parser**
  The existing generic `hookEvent` presence check already routes `PreCompact` correctly — no logic change was needed. Added tests for progress and attachment (including `decision:block`) variants, updated comments in `classify.rs` and `session.rs`, and added a `debuglog.rs` test confirming `HOOK_MSG_RE` matches PreCompact debug log lines.

## Changes

| File | What changed |
|------|-------------|
| `src-tauri/src/parser/entry.rs` | Add `content: String` field (serde default) to `Entry` |
| `src-tauri/src/parser/classify.rs` | Add `away_summary` classify arm; add tests for issues #49 and #48 |
| `src-tauri/src/parser/debuglog.rs` | Add PreCompact debug log test |
| `src-tauri/src/parser/session.rs` | Update doc comment to include PreCompact |
