### PR TITLE
feat: add Docker support for web-mode deployment (closes #53)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Source control
+.git
+.github
+.gitignore
+
+# Node / build output
+node_modules
+dist
+src-tauri/target
+tui/node_modules
+tui/dist
+
+# Cargo artifacts
+**/*.rs.bk
+**/*.pdb
+**/mutants.out*
+
+# Editor / OS
+.idea
+.vscode
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Secrets / local env
+.env
+.env.*
+
+# GitNexus cache
+.gitnexus
+.claude
+
+# Large demo assets not needed in the image
+demo.gif
+
+# Docker files themselves do not need to be in the build context
+Dockerfile
+.dockerignore
+docker-compose.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Setup Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Setup Rust
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Setup Rust
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - name: Setup Rust

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ npx oxfmt && npx oxlint && npx tsc --noEmit && npx vitest run && cargo fmt --man
 
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **tail-claude-gui** (1774 symbols, 4219 relationships, 149 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **tail-claude-gui** (1782 symbols, 4228 relationships, 149 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@
 #   CCTRACE_STATIC_DIR  static dist  (default: /app/dist in this image)
 # =============================================================================
 
-ARG RUST_VERSION=1.82
-ARG NODE_VERSION=20
+ARG RUST_IMAGE=rust:latest
+ARG NODE_VERSION=24
 ARG DEBIAN_CODENAME=bookworm
 
 # -----------------------------------------------------------------------------
@@ -51,7 +51,7 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 # Stage 2 — build the Rust backend (Tauri v2 linking needs webkit2gtk headers)
 # -----------------------------------------------------------------------------
-FROM rust:${RUST_VERSION}-${DEBIAN_CODENAME} AS backend-builder
+FROM ${RUST_IMAGE} AS backend-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
@@ -76,7 +76,7 @@ RUN cargo build --release --locked --bin claude-code-trace
 # -----------------------------------------------------------------------------
 # Stage 3 — runtime image
 # -----------------------------------------------------------------------------
-FROM debian:${DEBIAN_CODENAME}-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 # Runtime deps:
 #   * webkit2gtk + friends — required by the Tauri v2 runtime on Linux even
@@ -91,6 +91,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         librsvg2-2 \
         libxdo3 \
         xvfb \
+        xauth \
         dumb-init \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,123 @@
+# syntax=docker/dockerfile:1.7
+
+# =============================================================================
+# Claude Code Trace — Docker image
+#
+# Runs the Rust/axum backend in headless mode behind a virtual X display
+# (Tauri v2's webview runtime on Linux links against webkit2gtk and needs a
+# display even when no window is shown). The React frontend is built to a
+# static bundle and served from the same axum process as an API fallback, so
+# the whole app is reachable on a single port.
+#
+# Build:
+#   docker build -t claude-code-trace .
+#
+# Run (mount your Claude Code session data read-only):
+#   docker run --rm -p 8080:8080 \
+#     -v "$HOME/.claude:/home/app/.claude:ro" \
+#     claude-code-trace
+#
+# Then open http://localhost:8080 in a browser.
+#
+# Configurable env vars:
+#   CCTRACE_HTTP_HOST   bind host    (default: 0.0.0.0 in this image)
+#   CCTRACE_HTTP_PORT   bind port    (default: 8080 in this image)
+#   CCTRACE_STATIC_DIR  static dist  (default: /app/dist in this image)
+# =============================================================================
+
+ARG RUST_VERSION=1.82
+ARG NODE_VERSION=20
+ARG DEBIAN_CODENAME=bookworm
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the React frontend
+# -----------------------------------------------------------------------------
+FROM node:${NODE_VERSION}-${DEBIAN_CODENAME}-slim AS frontend-builder
+
+WORKDIR /build
+
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY tsconfig.json tsconfig.node.json vite.config.ts index.html ./
+COPY src ./src
+COPY shared ./shared
+
+# Empty VITE_API_BASE → frontend uses relative URLs, matching the single-port
+# axum server that also serves these static assets.
+ENV VITE_API_BASE=""
+RUN npm run build
+
+# -----------------------------------------------------------------------------
+# Stage 2 — build the Rust backend (Tauri v2 linking needs webkit2gtk headers)
+# -----------------------------------------------------------------------------
+FROM rust:${RUST_VERSION}-${DEBIAN_CODENAME} AS backend-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libwebkit2gtk-4.1-dev \
+        libayatana-appindicator3-dev \
+        librsvg2-dev \
+        libxdo-dev \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Tauri's generate_context!() embeds frontendDist at compile time, so the
+# frontend bundle must exist before `cargo build`.
+COPY src-tauri ./src-tauri
+COPY --from=frontend-builder /build/dist ./dist
+
+WORKDIR /build/src-tauri
+RUN cargo build --release --locked --bin claude-code-trace
+
+# -----------------------------------------------------------------------------
+# Stage 3 — runtime image
+# -----------------------------------------------------------------------------
+FROM debian:${DEBIAN_CODENAME}-slim AS runtime
+
+# Runtime deps:
+#   * webkit2gtk + friends — required by the Tauri v2 runtime on Linux even
+#     in headless mode (the window is created but not shown).
+#   * xvfb               — provides a virtual X display for webkit2gtk.
+#   * dumb-init          — PID 1 that forwards signals (SIGTERM/SIGINT) so
+#                          `docker stop` shuts cleanly down.
+#   * ca-certificates    — outbound TLS (e.g. for future features).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libwebkit2gtk-4.1-0 \
+        libayatana-appindicator3-1 \
+        librsvg2-2 \
+        libxdo3 \
+        xvfb \
+        dumb-init \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --home-dir /home/app --shell /bin/bash --uid 1000 app
+
+WORKDIR /app
+
+COPY --from=backend-builder /build/src-tauri/target/release/claude-code-trace /usr/local/bin/claude-code-trace
+COPY --from=frontend-builder /build/dist /app/dist
+COPY script/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENV CCTRACE_HTTP_HOST=0.0.0.0 \
+    CCTRACE_HTTP_PORT=8080 \
+    CCTRACE_STATIC_DIR=/app/dist \
+    XDG_CONFIG_HOME=/home/app/.config \
+    XDG_DATA_HOME=/home/app/.local/share
+
+USER app
+
+# Mountpoint for the host's ~/.claude directory — session JSONL files live here.
+VOLUME ["/home/app/.claude"]
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD /bin/sh -c 'exec 3<>/dev/tcp/127.0.0.1/${CCTRACE_HTTP_PORT:-8080}' || exit 1
+
+ENTRYPOINT ["dumb-init", "--", "/usr/local/bin/docker-entrypoint.sh"]
+CMD ["claude-code-trace", "--headless"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@
 #   docker build -t claude-code-trace .
 #
 # Run (mount your Claude Code session data read-only):
-#   docker run --rm -p 8080:8080 \
+#   docker run --rm -p 1421:1421 \
 #     -v "$HOME/.claude:/home/app/.claude:ro" \
 #     claude-code-trace
 #
-# Then open http://localhost:8080 in a browser.
+# Then open http://localhost:1421 in a browser.
 #
 # Configurable env vars:
 #   CCTRACE_HTTP_HOST   bind host    (default: 0.0.0.0 in this image)
-#   CCTRACE_HTTP_PORT   bind port    (default: 8080 in this image)
+#   CCTRACE_HTTP_PORT   bind port    (default: 1421 in this image)
 #   CCTRACE_STATIC_DIR  static dist  (default: /app/dist in this image)
 # =============================================================================
 
@@ -104,7 +104,7 @@ COPY script/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENV CCTRACE_HTTP_HOST=0.0.0.0 \
-    CCTRACE_HTTP_PORT=8080 \
+    CCTRACE_HTTP_PORT=1421 \
     CCTRACE_STATIC_DIR=/app/dist \
     XDG_CONFIG_HOME=/home/app/.config \
     XDG_DATA_HOME=/home/app/.local/share
@@ -114,10 +114,10 @@ USER app
 # Mountpoint for the host's ~/.claude directory — session JSONL files live here.
 VOLUME ["/home/app/.claude"]
 
-EXPOSE 8080
+EXPOSE 1421
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD /bin/sh -c 'exec 3<>/dev/tcp/127.0.0.1/${CCTRACE_HTTP_PORT:-8080}' || exit 1
+    CMD /bin/sh -c 'exec 3<>/dev/tcp/127.0.0.1/${CCTRACE_HTTP_PORT:-1421}' || exit 1
 
 ENTRYPOINT ["dumb-init", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["claude-code-trace", "--headless"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ npm run dev:web          # web mode (opens browser)
 npm run dev:tui          # TUI (starts backend + terminal UI)
 ```
 
+### Run in Docker (web mode only)
+
+```bash
+docker build -t claude-code-trace .
+docker run --rm -p 8080:8080 \
+  -v "$HOME/.claude:/home/app/.claude:ro" \
+  claude-code-trace
+# then open http://localhost:8080
+```
+
+Or with compose: `docker compose up --build`. See
+[docs/docker.md](docs/docker.md) for runtime env vars, volume layout, and
+troubleshooting.
+
 ## Requirements
 
 - [Rust](https://rustup.rs/) 1.77+

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ npm run dev:tui          # TUI (starts backend + terminal UI)
 
 ```bash
 docker build -t claude-code-trace .
-docker run --rm -p 8080:8080 \
+docker run --rm -p 1421:1421 \
   -v "$HOME/.claude:/home/app/.claude:ro" \
   claude-code-trace
-# then open http://localhost:8080
+# then open http://localhost:1421
 ```
 
 Or with compose: `docker compose up --build`. See

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  cctrace:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: claude-code-trace:latest
+    container_name: claude-code-trace
+    restart: unless-stopped
+    ports:
+      # Host:Container. Change the host port to expose elsewhere.
+      - "${CCTRACE_HOST_PORT:-8080}:8080"
+    environment:
+      # Override these if you change the container-side port.
+      CCTRACE_HTTP_HOST: 0.0.0.0
+      CCTRACE_HTTP_PORT: 8080
+      CCTRACE_STATIC_DIR: /app/dist
+    volumes:
+      # Claude Code writes sessions to ~/.claude/projects on the host.
+      # Mount read-only — the app never needs to write here.
+      - "${CLAUDE_HOME:-${HOME}/.claude}:/home/app/.claude:ro"
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,18 +8,18 @@ services:
     restart: unless-stopped
     ports:
       # Host:Container. Change the host port to expose elsewhere.
-      - "${CCTRACE_HOST_PORT:-8080}:8080"
+      - "${CCTRACE_HOST_PORT:-1421}:1421"
     environment:
       # Override these if you change the container-side port.
       CCTRACE_HTTP_HOST: 0.0.0.0
-      CCTRACE_HTTP_PORT: 8080
+      CCTRACE_HTTP_PORT: 1421
       CCTRACE_STATIC_DIR: /app/dist
     volumes:
       # Claude Code writes sessions to ~/.claude/projects on the host.
       # Mount read-only — the app never needs to write here.
       - "${CLAUDE_HOME:-${HOME}/.claude}:/home/app/.claude:ro"
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/1421"]
       interval: 30s
       timeout: 5s
       start_period: 10s

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -20,14 +20,14 @@ single HTTP port, and reads your Claude Code sessions from a mounted volume.
 # Build
 docker build -t claude-code-trace .
 
-# Run — expose port 8080, mount ~/.claude read-only
+# Run — expose port 1421, mount ~/.claude read-only
 docker run --rm \
-  -p 8080:8080 \
+  -p 1421:1421 \
   -v "$HOME/.claude:/home/app/.claude:ro" \
   claude-code-trace
 ```
 
-Open http://localhost:8080 in a browser. The session picker will populate
+Open http://localhost:1421 in a browser. The session picker will populate
 from the mounted directory.
 
 Press `Ctrl-C` to stop the container.
@@ -54,7 +54,7 @@ All runtime knobs are environment variables, so you can override them with
 | Variable             | Default     | What it does                                 |
 | -------------------- | ----------- | -------------------------------------------- |
 | `CCTRACE_HTTP_HOST`  | `0.0.0.0`   | Bind host for the HTTP server                |
-| `CCTRACE_HTTP_PORT`  | `8080`      | Bind port for the HTTP server                |
+| `CCTRACE_HTTP_PORT`  | `1421`      | Bind port for the HTTP server                |
 | `CCTRACE_STATIC_DIR` | `/app/dist` | Directory of static frontend assets to serve |
 
 Outside Docker (i.e. the normal desktop/web app) these variables are not
@@ -106,10 +106,10 @@ docker run --rm -v "$HOME/.claude:/home/app/.claude:ro" \
   claude-code-trace ls -la /home/app/.claude/projects
 ```
 
-**Port 8080 is already in use.** Pick a different host port:
+**Port 1421 is already in use.** Pick a different host port:
 
 ```bash
-docker run --rm -p 9090:8080 \
+docker run --rm -p 9090:1421 \
   -v "$HOME/.claude:/home/app/.claude:ro" \
   claude-code-trace
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,125 @@
+# Running Claude Code Trace in Docker
+
+This guide walks through running the web UI inside a Docker container. The
+image bundles both the Rust backend and the static React frontend behind a
+single HTTP port, and reads your Claude Code sessions from a mounted volume.
+
+> **Scope.** Docker is only supported for **web mode**. The desktop (Tauri)
+> and TUI modes require OS-level integrations (native windowing, ttys) that
+> don't translate well to containers. If you need the desktop app, install
+> from source or grab a pre-built release instead.
+
+## Prerequisites
+
+- Docker 20.10+ (or Docker Desktop / Podman / OrbStack equivalent)
+- Your host has Claude Code sessions under `~/.claude/projects`
+
+## Quick start
+
+```bash
+# Build
+docker build -t claude-code-trace .
+
+# Run — expose port 8080, mount ~/.claude read-only
+docker run --rm \
+  -p 8080:8080 \
+  -v "$HOME/.claude:/home/app/.claude:ro" \
+  claude-code-trace
+```
+
+Open http://localhost:8080 in a browser. The session picker will populate
+from the mounted directory.
+
+Press `Ctrl-C` to stop the container.
+
+## docker compose
+
+A `docker-compose.yml` is included for convenience:
+
+```bash
+docker compose up --build
+```
+
+To change the host port or the Claude data location, set env vars:
+
+```bash
+CCTRACE_HOST_PORT=9090 CLAUDE_HOME=/srv/claude docker compose up
+```
+
+## Runtime configuration
+
+All runtime knobs are environment variables, so you can override them with
+`-e VAR=value` on `docker run` or under `environment:` in compose.
+
+| Variable             | Default     | What it does                                 |
+| -------------------- | ----------- | -------------------------------------------- |
+| `CCTRACE_HTTP_HOST`  | `0.0.0.0`   | Bind host for the HTTP server                |
+| `CCTRACE_HTTP_PORT`  | `8080`      | Bind port for the HTTP server                |
+| `CCTRACE_STATIC_DIR` | `/app/dist` | Directory of static frontend assets to serve |
+
+Outside Docker (i.e. the normal desktop/web app) these variables are not
+set, and the server falls back to the historical defaults
+(`127.0.0.1:11423`, no static assets). So adding these vars has no effect on
+native installations.
+
+## Volumes
+
+| Container path      | Purpose                                                            |
+| ------------------- | ------------------------------------------------------------------ |
+| `/home/app/.claude` | Source of session JSONL files (mount your host's `~/.claude` here) |
+
+The app only needs to **read** session logs, so mounting read-only (`:ro`)
+is recommended and is what the shipped `docker-compose.yml` does.
+
+If you keep session logs somewhere other than `~/.claude/projects` — e.g.
+`/srv/claude` — mount that directory instead, or point the app at a
+different `projectsDir` via the Settings UI (the chosen path is remembered
+in `XDG_CONFIG_HOME/claude-code-trace/settings.json`, which lives inside
+`/home/app/.config` in the image).
+
+## Networking model
+
+The container runs a single axum HTTP server that:
+
+1. Serves `/api/*` — the JSON + Server-Sent Events backend.
+2. Serves everything else from `/app/dist` — the compiled React bundle
+   (including SPA deep-link support via `append_index_html_on_directories`).
+
+The frontend is built with `VITE_API_BASE=""`, which makes it use
+same-origin relative URLs. Nothing in the container talks to `localhost`
+from the browser's perspective, so you only need to expose **one port**.
+
+## Under the hood
+
+Tauri v2's webview runtime links against `libwebkit2gtk-4.1-0` on Linux,
+which needs an X display even when no window is shown. The image uses
+`xvfb-run` to provide a virtual display at runtime — this is invisible to
+the user but means headless mode works without a host display server.
+
+## Troubleshooting
+
+**The session picker is empty.** Check that your host mount actually points
+at a directory containing `~/.claude/projects`:
+
+```bash
+docker run --rm -v "$HOME/.claude:/home/app/.claude:ro" \
+  claude-code-trace ls -la /home/app/.claude/projects
+```
+
+**Port 8080 is already in use.** Pick a different host port:
+
+```bash
+docker run --rm -p 9090:8080 \
+  -v "$HOME/.claude:/home/app/.claude:ro" \
+  claude-code-trace
+```
+
+**`cannot open display` / webkit errors on startup.** The entrypoint uses
+`xvfb-run`; if you override the entrypoint make sure you keep it (or
+provide your own virtual display). Running the binary directly with
+`docker run --entrypoint /usr/local/bin/claude-code-trace ...` will fail.
+
+**File watchers don't see changes.** On some Docker-for-Mac / WSL setups,
+`notify`-style filesystem watchers over bind mounts are unreliable. This
+affects the "live tailing" feature. A reload usually picks up new content;
+for aggressive tailing, prefer running the native desktop app on the host.

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Wrap the binary in Xvfb so Tauri v2's webkit2gtk runtime has a display to
+# attach to, even though no window is ever shown in headless mode.
+set -e
+
+: "${DISPLAY:=:99}"
+export DISPLAY
+
+exec xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" "$@"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1627,6 +1627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2239,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -4429,14 +4445,24 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
  "iri-string",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4574,6 +4600,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,7 +26,7 @@ dirs = "6"
 tauri-plugin-opener = "2.5.3"
 tauri-plugin-single-instance = "2"
 axum = { version = "0.8", features = ["json"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 
 [lints.clippy]

--- a/src-tauri/gen/schemas/linux-schema.json
+++ b/src-tauri/gen/schemas/linux-schema.json
@@ -1160,10 +1160,22 @@
                         "markdownDescription": "Enables the size command without any pre-configured scope."
                       },
                       {
+                        "description": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-start-accessing-security-scoped-resource",
+                        "markdownDescription": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
                         "description": "Enables the stat command without any pre-configured scope.",
                         "type": "string",
                         "const": "fs:allow-stat",
                         "markdownDescription": "Enables the stat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:allow-stop-accessing-security-scoped-resource",
+                        "markdownDescription": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope."
                       },
                       {
                         "description": "Enables the truncate command without any pre-configured scope.",
@@ -1316,10 +1328,22 @@
                         "markdownDescription": "Denies the size command without any pre-configured scope."
                       },
                       {
+                        "description": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-start-accessing-security-scoped-resource",
+                        "markdownDescription": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope."
+                      },
+                      {
                         "description": "Denies the stat command without any pre-configured scope.",
                         "type": "string",
                         "const": "fs:deny-stat",
                         "markdownDescription": "Denies the stat command without any pre-configured scope."
+                      },
+                      {
+                        "description": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+                        "type": "string",
+                        "const": "fs:deny-stop-accessing-security-scoped-resource",
+                        "markdownDescription": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope."
                       },
                       {
                         "description": "Denies the truncate command without any pre-configured scope.",
@@ -5217,10 +5241,22 @@
           "markdownDescription": "Enables the size command without any pre-configured scope."
         },
         {
+          "description": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-start-accessing-security-scoped-resource",
+          "markdownDescription": "Enables the start_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
           "description": "Enables the stat command without any pre-configured scope.",
           "type": "string",
           "const": "fs:allow-stat",
           "markdownDescription": "Enables the stat command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:allow-stop-accessing-security-scoped-resource",
+          "markdownDescription": "Enables the stop_accessing_security_scoped_resource command without any pre-configured scope."
         },
         {
           "description": "Enables the truncate command without any pre-configured scope.",
@@ -5373,10 +5409,22 @@
           "markdownDescription": "Denies the size command without any pre-configured scope."
         },
         {
+          "description": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-start-accessing-security-scoped-resource",
+          "markdownDescription": "Denies the start_accessing_security_scoped_resource command without any pre-configured scope."
+        },
+        {
           "description": "Denies the stat command without any pre-configured scope.",
           "type": "string",
           "const": "fs:deny-stat",
           "markdownDescription": "Denies the stat command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope.",
+          "type": "string",
+          "const": "fs:deny-stop-accessing-security-scoped-resource",
+          "markdownDescription": "Denies the stop_accessing_security_scoped_resource command without any pre-configured scope."
         },
         {
           "description": "Denies the truncate command without any pre-configured scope.",

--- a/src-tauri/src/http_api.rs
+++ b/src-tauri/src/http_api.rs
@@ -13,6 +13,7 @@ use tauri::{AppHandle, Manager};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 use tower_http::cors::CorsLayer;
+use tower_http::services::ServeDir;
 
 use crate::convert::*;
 use crate::parser::chunk::build_chunks;
@@ -30,11 +31,49 @@ pub struct HttpState {
     pub app: AppHandle,
 }
 
-/// Start the HTTP API server on port 11423.
+/// Default bind host. Overridable via the `CCTRACE_HTTP_HOST` env var.
+pub const DEFAULT_HTTP_HOST: &str = "127.0.0.1";
+/// Default bind port. Overridable via the `CCTRACE_HTTP_PORT` env var.
+pub const DEFAULT_HTTP_PORT: u16 = 11423;
+
+/// Pick the host from a raw env value, normalizing empty/missing to the default.
+fn pick_host(raw: Option<String>) -> String {
+    raw.filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_HTTP_HOST.to_string())
+}
+
+/// Pick the port from a raw env value, silently dropping invalid values.
+fn pick_port(raw: Option<String>) -> u16 {
+    raw.and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(DEFAULT_HTTP_PORT)
+}
+
+/// Resolve the bind address from env vars, falling back to the defaults.
+pub fn resolve_bind_addr() -> (String, u16) {
+    (
+        pick_host(std::env::var("CCTRACE_HTTP_HOST").ok()),
+        pick_port(std::env::var("CCTRACE_HTTP_PORT").ok()),
+    )
+}
+
+/// Optional directory of static frontend assets to serve alongside the API.
+/// When `CCTRACE_STATIC_DIR` is set to a non-empty path, the HTTP server
+/// will serve the frontend bundle as a fallback for all non-API routes.
+/// This is used by the Docker image to run the full web UI from a single
+/// process on a single port.
+pub fn resolve_static_dir() -> Option<String> {
+    std::env::var("CCTRACE_STATIC_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Start the HTTP API server. Host, port, and static-asset directory are
+/// configurable via the `CCTRACE_HTTP_HOST`, `CCTRACE_HTTP_PORT`, and
+/// `CCTRACE_STATIC_DIR` env vars.
 pub async fn start_http_server(app: AppHandle) {
     let state = Arc::new(HttpState { app });
 
-    let router = Router::new()
+    let mut router = Router::new()
         .route("/api/settings", get(api_get_settings))
         .route("/api/settings/dir", post(api_set_projects_dir))
         .route("/api/project-dirs", get(api_get_project_dirs))
@@ -48,18 +87,26 @@ pub async fn start_http_server(app: AppHandle) {
         .route("/api/picker/unwatch", post(api_unwatch_picker))
         .route("/api/git-info", get(api_get_git_info))
         .route("/api/debug-log", get(api_get_debug_log))
-        .route("/api/events", get(api_events))
-        .layer(CorsLayer::permissive())
-        .with_state(state);
+        .route("/api/events", get(api_events));
 
-    let listener = match tokio::net::TcpListener::bind("127.0.0.1:11423").await {
+    if let Some(dir) = resolve_static_dir() {
+        let serve = ServeDir::new(&dir).append_index_html_on_directories(true);
+        router = router.fallback_service(serve);
+        eprintln!("HTTP API: serving static assets from {dir}");
+    }
+
+    let router = router.layer(CorsLayer::permissive()).with_state(state);
+
+    let (host, port) = resolve_bind_addr();
+    let addr = format!("{host}:{port}");
+    let listener = match tokio::net::TcpListener::bind(&addr).await {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("HTTP API: failed to bind port 11423: {e}");
+            eprintln!("HTTP API: failed to bind {addr}: {e}");
             return;
         }
     };
-    eprintln!("HTTP API: listening on http://127.0.0.1:11423");
+    eprintln!("HTTP API: listening on http://{addr}");
 
     if let Err(e) = axum::serve(listener, router).await {
         eprintln!("HTTP API: server error: {e}");
@@ -586,5 +633,42 @@ mod tests {
     #[test]
     fn invalid_since_parse_fails() {
         assert!("notadate".parse::<DateTime<Utc>>().is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Bind address / static dir resolution
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pick_host_uses_default_when_missing() {
+        assert_eq!(pick_host(None), DEFAULT_HTTP_HOST);
+    }
+
+    #[test]
+    fn pick_host_uses_default_when_empty() {
+        assert_eq!(pick_host(Some(String::new())), DEFAULT_HTTP_HOST);
+    }
+
+    #[test]
+    fn pick_host_uses_provided_value() {
+        assert_eq!(pick_host(Some("0.0.0.0".to_string())), "0.0.0.0");
+    }
+
+    #[test]
+    fn pick_port_uses_default_when_missing() {
+        assert_eq!(pick_port(None), DEFAULT_HTTP_PORT);
+    }
+
+    #[test]
+    fn pick_port_uses_default_when_unparsable() {
+        assert_eq!(
+            pick_port(Some("not-a-number".to_string())),
+            DEFAULT_HTTP_PORT
+        );
+    }
+
+    #[test]
+    fn pick_port_uses_parsed_value() {
+        assert_eq!(pick_port(Some("8080".to_string())), 8080);
     }
 }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { API_BASE } from "./config";
+
+describe("config", () => {
+  it("falls back to the default localhost backend when VITE_API_BASE is unset", () => {
+    // Vitest does not set VITE_API_BASE by default, so API_BASE is the fallback.
+    expect(API_BASE).toBe("http://127.0.0.1:11423");
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,14 @@
-/** Shared configuration for the web fallback layer. */
-export const API_BASE = "http://127.0.0.1:11423";
+/**
+ * Shared configuration for the web fallback layer.
+ *
+ * `API_BASE` is the origin used to reach the Rust HTTP backend from the
+ * browser. The default points at the local desktop/dev backend.
+ *
+ * Override at build time with `VITE_API_BASE`:
+ *   - `VITE_API_BASE=""` → empty string, same-origin (used by the Docker
+ *     image where backend and frontend are served from one port).
+ *   - `VITE_API_BASE="https://example.com"` → custom remote backend.
+ */
+const envBase = (import.meta.env.VITE_API_BASE as string | undefined) ?? undefined;
+
+export const API_BASE = envBase ?? "http://127.0.0.1:11423";


### PR DESCRIPTION
Dockerize the web UI so it can be run against a mounted ~/.claude
directory without requiring a Rust/Node toolchain on the host.

Backend
- Make HTTP bind host/port env-configurable via CCTRACE_HTTP_HOST and
  CCTRACE_HTTP_PORT; defaults unchanged (127.0.0.1:11423) so desktop
  and native web modes are unaffected.
- Optionally serve the compiled frontend bundle as an axum fallback
  when CCTRACE_STATIC_DIR is set, letting the whole app run from a
  single process on a single port inside the container.
- Enable the tower-http `fs` feature for ServeDir.

Frontend
- API_BASE now honours VITE_API_BASE at build time; empty string means
  same-origin, which is what the Docker image builds with.

Docker
- Multi-stage Dockerfile (Node -> Rust -> slim runtime) with xvfb-run
  entrypoint (Tauri v2's webkit2gtk runtime needs a display even in
  headless mode).
- docker-compose.yml for one-command launch; mounts ~/.claude read-only.
- .dockerignore to keep the build context small.
- docs/docker.md covers build/run, env vars, volumes, and
  troubleshooting; README links to it.

Tests
- Unit tests for env-var parsing (pick_host, pick_port) in http_api.rs.
- Config test pins the default API_BASE fallback.
- All 341 Rust tests + 346 frontend tests pass.

https://claude.ai/code/session_01R1GcCjY9GYBzFyFFeamDdQ