### PR TITLE
Fix issues #66, #67: JSONL resilience and orphaned tool_use handling

### DIFF
--- a/bin/cctrace.mjs
+++ b/bin/cctrace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = resolve(__dirname, "..");
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(currentDir, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web", "--tui"].includes(a)) ?? "--app";

--- a/bin/cctrace.mjs
+++ b/bin/cctrace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const currentDir = dirname(fileURLToPath(import.meta.url));
-const root = resolve(currentDir, "..");
+const binDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(binDir, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web", "--tui"].includes(a)) ?? "--app";

--- a/src-tauri/src/parser/chunk.rs
+++ b/src-tauri/src/parser/chunk.rs
@@ -137,18 +137,24 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     let mut ai_buf: Vec<AIMsg> = Vec::new();
 
-    let flush = |buf: &mut Vec<AIMsg>, chunks: &mut Vec<Chunk>| {
+    // orphan_pending: when true, any tool_use blocks in the buffer that never received a
+    // tool_result are marked is_orphan (conversation continued past them — pre-v2.1.122
+    // /branch fork sessions can leave these from rewound timelines). When false, they are
+    // marked is_deferred (session was suspended mid-tool via a "defer" permission decision).
+    let flush = |buf: &mut Vec<AIMsg>, chunks: &mut Vec<Chunk>, orphan_pending: bool| {
         if buf.is_empty() {
             return;
         }
-        chunks.push(merge_ai_buffer(buf));
+        chunks.push(merge_ai_buffer(buf, orphan_pending));
         buf.clear();
     };
 
     for msg in msgs {
         match msg {
             ClassifiedMsg::User(m) => {
-                flush(&mut ai_buf, &mut chunks);
+                // A user message means the conversation continued: any still-pending
+                // tool_use blocks in the AI buffer are orphans, not deferred sessions.
+                flush(&mut ai_buf, &mut chunks, true);
                 chunks.push(Chunk {
                     chunk_type: ChunkType::User,
                     timestamp: m.timestamp,
@@ -157,7 +163,7 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
                 });
             }
             ClassifiedMsg::System(m) => {
-                flush(&mut ai_buf, &mut chunks);
+                flush(&mut ai_buf, &mut chunks, false);
                 chunks.push(Chunk {
                     chunk_type: ChunkType::System,
                     timestamp: m.timestamp,
@@ -216,7 +222,7 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
                 });
             }
             ClassifiedMsg::Compact(m) => {
-                flush(&mut ai_buf, &mut chunks);
+                flush(&mut ai_buf, &mut chunks, false);
                 chunks.push(Chunk {
                     chunk_type: if m.is_recap {
                         ChunkType::Recap
@@ -230,7 +236,7 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
             }
         }
     }
-    flush(&mut ai_buf, &mut chunks);
+    flush(&mut ai_buf, &mut chunks, false);
     chunks
 }
 
@@ -239,7 +245,7 @@ struct PendingTool {
     timestamp: DateTime<Utc>,
 }
 
-fn merge_ai_buffer(buf: &[AIMsg]) -> Chunk {
+fn merge_ai_buffer(buf: &[AIMsg], orphan_pending: bool) -> Chunk {
     let mut texts: Vec<String> = Vec::new();
     let mut thinking = 0usize;
     let mut tool_calls: Vec<ToolCall> = Vec::new();
@@ -373,10 +379,17 @@ fn merge_ai_buffer(buf: &[AIMsg]) -> Chunk {
         }
     }
 
-    // Any tool_use blocks still in pending have no matching tool_result — the session was
-    // suspended via a "defer" PreToolUse permission decision before the tool ran.
+    // Any tool_use blocks still in pending have no matching tool_result.
     for p in pending.values() {
-        items[p.index].is_deferred = true;
+        if orphan_pending {
+            // The conversation continued past this turn without supplying a tool_result —
+            // the tool_use is an orphan from a rewound timeline (pre-v2.1.122 /branch bug).
+            // Mark is_orphan so the activity log skips it and the session is not shown as ongoing.
+            items[p.index].is_orphan = true;
+        } else {
+            // Session ended with this tool_use still pending — "defer" suspension.
+            items[p.index].is_deferred = true;
+        }
     }
 
     let first = buf.first().map(|m| m.timestamp).unwrap_or_else(Utc::now);
@@ -481,7 +494,7 @@ pub fn is_team_task(item: &DisplayItem) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::classify::{AIMsg, ClassifiedMsg, ContentBlock, Usage};
+    use crate::parser::classify::{AIMsg, ClassifiedMsg, ContentBlock, SystemMsg, Usage, UserMsg};
     use chrono::Utc;
 
     fn make_ai_msg(blocks: Vec<ContentBlock>, is_meta: bool) -> AIMsg {
@@ -616,6 +629,97 @@ mod tests {
         assert!(
             items[0].is_deferred,
             "dangling Task tool_use should be marked deferred"
+        );
+    }
+
+    // --- Issue #67: pre-v2.1.122 /branch fork sessions with rewound-timeline orphans ---
+
+    #[test]
+    fn tool_use_without_result_before_user_message_is_marked_orphan() {
+        // Pre-v2.1.122 /branch fork sessions can contain tool_use blocks from rewound
+        // timelines with no corresponding tool_result anywhere in the file. When a user
+        // message follows (the conversation continued), the pending tool_use is an orphan —
+        // it must be marked is_orphan, not is_deferred, so the session is not shown as ongoing.
+        let tool_id = "toolu_orphan_001";
+        let msgs = vec![
+            ClassifiedMsg::AI(make_ai_msg(vec![tool_use_block(tool_id, "Bash")], false)),
+            ClassifiedMsg::User(UserMsg {
+                timestamp: Utc::now(),
+                text: "hello".to_string(),
+                permission_mode: String::new(),
+            }),
+            ClassifiedMsg::AI(make_ai_msg(
+                vec![ContentBlock {
+                    block_type: "text".to_string(),
+                    text: "hi".to_string(),
+                    ..Default::default()
+                }],
+                false,
+            )),
+        ];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 3, "expected AI, User, AI chunks");
+        let ai_chunk = &chunks[0];
+        assert_eq!(ai_chunk.items.len(), 1);
+        assert_eq!(ai_chunk.items[0].item_type, DisplayItemType::ToolCall);
+        assert!(
+            ai_chunk.items[0].is_orphan,
+            "tool_use without result before user message must be is_orphan"
+        );
+        assert!(
+            !ai_chunk.items[0].is_deferred,
+            "orphaned tool_use must not be is_deferred"
+        );
+    }
+
+    #[test]
+    fn orphaned_tool_use_does_not_make_session_appear_ongoing() {
+        // End-to-end: build_chunks + is_chunks_ongoing must return false when the only
+        // unmatched tool_use is an orphan that precedes a User message.
+        use crate::parser::ongoing::OngoingChecker;
+
+        let tool_id = "toolu_orphan_002";
+        let msgs = vec![
+            ClassifiedMsg::AI(make_ai_msg(vec![tool_use_block(tool_id, "Read")], false)),
+            ClassifiedMsg::User(UserMsg {
+                timestamp: Utc::now(),
+                text: "what now?".to_string(),
+                permission_mode: String::new(),
+            }),
+            ClassifiedMsg::AI(make_ai_msg(
+                vec![ContentBlock {
+                    block_type: "text".to_string(),
+                    text: "Here you go".to_string(),
+                    ..Default::default()
+                }],
+                false,
+            )),
+        ];
+        let chunks = build_chunks(&msgs);
+        assert!(
+            !OngoingChecker::is_chunks_ongoing(&chunks),
+            "session with orphaned tool_use before user message must not appear ongoing"
+        );
+    }
+
+    #[test]
+    fn tool_use_without_result_at_end_of_session_is_still_deferred() {
+        // Verify that the fix does not break the genuine deferred case: a session that ends
+        // with a pending tool_use (no subsequent user message) must remain is_deferred.
+        let tool_id = "toolu_deferred_end";
+        let msgs = vec![ClassifiedMsg::AI(make_ai_msg(
+            vec![tool_use_block(tool_id, "Write")],
+            false,
+        ))];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            chunks[0].items[0].is_deferred,
+            "tool_use at end of session (no subsequent user message) must remain is_deferred"
+        );
+        assert!(
+            !chunks[0].items[0].is_orphan,
+            "tool_use at end of session must not be is_orphan"
         );
     }
 }

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -189,6 +189,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_entry_truncated_json_returns_none() {
+        // Simulates a line partially written before an unclean shutdown (kill -9, OOM).
+        // The JSON object is cut mid-string — must return None, not panic or error.
+        let bytes = b"{\"type\":\"assistant\",\"uuid\":\"a1\",\"message\":{\"role\":\"assistant\"";
+        assert!(parse_entry(bytes).is_none());
+    }
+
+    #[test]
     fn parse_entry_without_uuid_or_leaf_uuid_returns_none() {
         let line = json!({
             "type": "user",

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -789,8 +789,11 @@ pub(crate) fn scan_session_metadata(path: &str) -> SessionMetadata {
     } else {
         meta.is_ongoing = has_activity_after_last_ending;
     }
-    // Pending tool calls override.
-    if !meta.is_ongoing && !pending_tool_ids.is_empty() {
+    // Pending tool calls override — only when no text/ending response was seen after them.
+    // If last_ending_index is set, remaining pending IDs appeared before the ending marker;
+    // they are orphaned (e.g. from rewound timelines in pre-v2.1.122 /branch fork sessions)
+    // rather than genuinely awaiting results, so we must not treat them as ongoing.
+    if !meta.is_ongoing && !pending_tool_ids.is_empty() && last_ending_index.is_none() {
         meta.is_ongoing = true;
     }
 
@@ -1212,6 +1215,12 @@ fn scan_ongoing_user(
             *last_ending_index = Some(*activity_index);
             *has_after = false;
             *activity_index += 1;
+        } else if !text.trim().is_empty() {
+            // A regular user text message means the conversation continued past any
+            // pending tool_uses. Those tool_uses are orphans from a rewound timeline
+            // (pre-v2.1.122 /branch fork sessions) — clear them so the session is not
+            // falsely marked as ongoing.
+            pending_tool_ids.clear();
         }
         return;
     }
@@ -1259,6 +1268,20 @@ fn scan_ongoing_user(
             }
             _ => {}
         }
+    }
+
+    // If the user entry has continuation content (text, image, or document — not only
+    // tool_results), any still-pending tool_use IDs are orphans from a rewound timeline:
+    // the conversation moved forward without supplying their results. Pre-v2.1.122 /branch
+    // fork sessions can produce this when the source session had rewound timeline entries.
+    let has_continuation_content = blocks.iter().any(|b| {
+        matches!(
+            b.get("type").and_then(|v| v.as_str()).unwrap_or(""),
+            "text" | "image" | "document"
+        )
+    });
+    if has_continuation_content {
+        pending_tool_ids.clear();
     }
 }
 
@@ -1956,6 +1979,133 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
+    // --- Issue #67: pre-v2.1.122 /branch fork sessions with orphaned tool_use blocks ---
+
+    #[test]
+    fn orphaned_tool_use_before_user_text_does_not_mark_session_ongoing() {
+        // Pre-v2.1.122 /branch fork sessions can contain assistant entries with tool_use
+        // blocks from rewound timelines — the corresponding tool_result is absent. A
+        // subsequent user text entry continues the conversation: those pending tool_use IDs
+        // must be cleared so scan_session_metadata does not falsely mark the session ongoing.
+        let tmp = env::temp_dir().join("tail-test-issue67-ongoing");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        // Orphaned assistant: tool_use with no matching tool_result anywhere in the file.
+        let orphan = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // User entry with text continuing the conversation (no tool_result for toolu_orphan).
+        let user_text = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-04-28T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"hello\"}}\n";
+        // Final assistant with text ending.
+        let final_asst = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-04-28T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":20,\"output_tokens\":3,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan}{user_text}{final_asst}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            !meta.is_ongoing,
+            "session with orphaned tool_use before user text must not be marked ongoing (got is_ongoing=true)"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn orphaned_tool_use_with_array_content_user_does_not_mark_ongoing() {
+        // Same as above but the user entry uses array content instead of a string.
+        let tmp = env::temp_dir().join("tail-test-issue67-array");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let orphan = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan2\",\"name\":\"Read\",\"input\":{\"file_path\":\"/tmp/x\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // User entry with array content containing a text block (new user turn).
+        let user_array = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-04-28T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"what now?\"}]}}\n";
+        let final_asst = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-04-28T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"here\"}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":20,\"output_tokens\":3,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan}{user_array}{final_asst}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            !meta.is_ongoing,
+            "session with orphaned tool_use before array-content user entry must not be ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn genuine_deferred_tool_use_still_marks_session_ongoing() {
+        // A session that genuinely ends mid-tool-use (no subsequent user message) should
+        // still be marked ongoing. The orphan fix must not affect this case.
+        let tmp = env::temp_dir().join("tail-test-issue67-deferred");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        // Only an assistant entry with tool_use — no user message follows.
+        let asst = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_defer\",\"name\":\"Bash\",\"input\":{\"command\":\"sleep 10\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{asst}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            meta.is_ongoing,
+            "session ending mid-tool-use (no subsequent user message) must remain ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn read_session_incremental_orphaned_tool_use_before_user_is_orphan_in_chunks() {
+        // End-to-end: a fork session with an orphaned tool_use followed by a user text message
+        // must produce an AI chunk where the tool_use item is is_orphan=true, not is_deferred.
+        // Verify the session does not appear ongoing.
+        use crate::parser::chunk::build_chunks;
+        use crate::parser::ongoing::OngoingChecker;
+
+        let tmp = env::temp_dir().join("tail-test-issue67-e2e");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let orphan = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"isSidechain\":false,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_e2e\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        let user_text = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":\"a1\",\"isSidechain\":false,\"timestamp\":\"2026-04-28T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"new question\"}}\n";
+        let final_asst = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u1\",\"isSidechain\":false,\"timestamp\":\"2026-04-28T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"answer\"}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":20,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan}{user_text}{final_asst}")).unwrap();
+
+        let (msgs, _, _) = read_session_incremental(path.to_str().unwrap(), 0).unwrap();
+        let chunks = build_chunks(&msgs);
+
+        // Find the AI chunk that contains the orphaned tool_use.
+        let orphan_chunk = chunks.iter().find(|c| {
+            c.chunk_type == crate::parser::chunk::ChunkType::AI
+                && c.items
+                    .iter()
+                    .any(|i| i.item_type == crate::parser::chunk::DisplayItemType::ToolCall)
+        });
+        assert!(
+            orphan_chunk.is_some(),
+            "must have an AI chunk with a tool_use item"
+        );
+        let item = orphan_chunk
+            .unwrap()
+            .items
+            .iter()
+            .find(|i| i.item_type == crate::parser::chunk::DisplayItemType::ToolCall)
+            .unwrap();
+        assert!(
+            item.is_orphan,
+            "tool_use without result before user message must be is_orphan"
+        );
+        assert!(!item.is_deferred, "must not be is_deferred");
+
+        assert!(
+            !OngoingChecker::is_chunks_ongoing(&chunks),
+            "session must not appear ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
     #[test]
     fn forked_session_conversation_view_includes_all_entries() {
         // read_session_incremental must include inherited entries — they provide fork context.
@@ -1986,6 +2136,100 @@ mod tests {
         assert_eq!(
             ai_count, 2,
             "both inherited and new AI messages must appear"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // --- Issue #67: orphaned tool_use blocks from pre-v2.1.122 /branch fork sessions ---
+
+    #[test]
+    fn orphaned_tool_use_before_end_turn_does_not_mark_session_ongoing() {
+        // Pre-v2.1.122 /branch forks may contain tool_use blocks from rewound timelines
+        // with no matching tool_result in any subsequent user message. If the fork's own
+        // conversation ends normally (text response), the session must NOT be marked ongoing.
+        let tmp = env::temp_dir().join("tail-test-orphan-tool-use-ongoing");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        // Orphaned assistant entry: tool_use block with no subsequent tool_result.
+        let orphan_a = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-05-01T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":50,\"output_tokens\":20,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // Fork's own user message (no tool_result for toolu_orphan).
+        let new_u = "{\"type\":\"user\",\"uuid\":\"u2\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-05-01T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"What else can you do?\"}}\n";
+        // Fork's own assistant response — ends the conversation with a text block.
+        let new_a = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u2\",\"timestamp\":\"2026-05-01T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I can help with many things.\"}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tokens\":30,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan_a}{new_u}{new_a}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            !meta.is_ongoing,
+            "session with orphaned tool_use before end_turn must not be marked ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn genuine_pending_tool_use_at_session_end_marks_session_ongoing() {
+        // A session that genuinely ends mid-tool-call (Claude invoked a tool but the result
+        // has not yet been written to the JSONL) must still be marked as ongoing.
+        let tmp = env::temp_dir().join("tail-test-genuine-pending-tool-use");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let asst = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-05-01T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_genuine\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":50,\"output_tokens\":20,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // No subsequent user message — session ends with the pending tool call.
+
+        std::fs::write(&path, asst).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            meta.is_ongoing,
+            "session genuinely ending with pending tool_use must be marked ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn orphaned_tool_use_in_conversation_is_rendered_as_orphan() {
+        // When an orphaned tool_use block (no matching tool_result) is followed by a user
+        // message (conversation continued), build_chunks must mark the DisplayItem as
+        // is_orphan=true so the activity log skips it and the session is not shown as ongoing.
+        let tmp = env::temp_dir().join("tail-test-orphan-tool-use-orphan");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let orphan_a = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-05-01T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":50,\"output_tokens\":20,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        let new_u = "{\"type\":\"user\",\"uuid\":\"u2\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-05-01T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"What else can you do?\"}}\n";
+        let new_a = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u2\",\"timestamp\":\"2026-05-01T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I can help.\"}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan_a}{new_u}{new_a}")).unwrap();
+
+        let chunks = read_session(path.to_str().unwrap()).expect("read_session must succeed");
+        let ai_chunk = chunks
+            .iter()
+            .find(|c| matches!(c.chunk_type, crate::parser::chunk::ChunkType::AI))
+            .expect("must have at least one AI chunk");
+
+        let orphan_item = ai_chunk
+            .items
+            .iter()
+            .find(|it| it.tool_name == "Bash")
+            .expect("orphaned Bash tool_use must appear in AI chunk items");
+
+        assert!(
+            orphan_item.is_orphan,
+            "orphaned tool_use before a user message must be marked is_orphan=true"
+        );
+        assert!(
+            !orphan_item.is_deferred,
+            "orphaned tool_use before a user message must not be is_deferred"
+        );
+        assert!(
+            orphan_item.tool_result.is_empty(),
+            "orphaned tool_use must have empty tool_result"
         );
 
         std::fs::remove_dir_all(&tmp).ok();

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -173,9 +173,10 @@ pub fn read_session_incremental(
 
     loop {
         line.clear();
-        let n = reader
-            .read_line(&mut line)
-            .map_err(|e| format!("reading: {e}"))?;
+        let n = match reader.read_line(&mut line) {
+            Ok(n) => n,
+            Err(_) => break, // unreadable bytes (e.g. invalid UTF-8) — return what we have
+        };
         if n == 0 {
             break;
         }
@@ -525,7 +526,7 @@ pub(crate) fn scan_session_metadata(path: &str) -> SessionMetadata {
     for line_result in reader.lines() {
         let line = match line_result {
             Ok(l) => l,
-            Err(_) => break,
+            Err(_) => continue, // unreadable line (e.g. invalid UTF-8) — skip and continue
         };
         lines_read += 1;
 
@@ -1680,6 +1681,104 @@ mod tests {
             completed_msgs.len(),
             1,
             "completed line should produce a message"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // --- Issue #66: corrupt/truncated JSONL lines from unclean shutdowns ---
+
+    #[test]
+    fn read_session_incremental_skips_corrupt_mid_file_line() {
+        // A corrupt (invalid JSON but valid UTF-8) line in the middle of the file
+        // must be skipped. Valid entries before AND after it must still be parsed.
+        let tmp = env::temp_dir().join("tail-test-corrupt-mid-file");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let u1 = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":null,\"isSidechain\":false,\"timestamp\":\"2025-01-15T10:00:00Z\",\"message\":{\"role\":\"user\",\"content\":\"Hello\"}}\n";
+        let corrupt = "{truncated-invalid-json-cut-mid-write\n"; // valid UTF-8, invalid JSON
+        let u2 = "{\"type\":\"user\",\"uuid\":\"u2\",\"parentUuid\":\"u1\",\"isSidechain\":false,\"timestamp\":\"2025-01-15T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"World\"}}\n";
+
+        std::fs::write(&path, format!("{u1}{corrupt}{u2}")).unwrap();
+
+        let result = read_session_incremental(path.to_str().unwrap(), 0);
+        assert!(
+            result.is_ok(),
+            "corrupt mid-file line must not cause a session load error"
+        );
+
+        let (msgs, _, _) = result.unwrap();
+        let user_count = msgs
+            .iter()
+            .filter(|m| matches!(m, ClassifiedMsg::User(_)))
+            .count();
+        assert_eq!(
+            user_count, 2,
+            "both valid user entries must be parsed; corrupt line must be skipped"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn read_session_incremental_skips_multiple_corrupt_lines() {
+        // Multiple corrupt lines scattered throughout the file must all be skipped.
+        let tmp = env::temp_dir().join("tail-test-multiple-corrupt");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let u1 = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":null,\"isSidechain\":false,\"timestamp\":\"2025-01-15T10:00:00Z\",\"message\":{\"role\":\"user\",\"content\":\"Hello\"}}\n";
+        let corrupt1 = "{\"truncated line 1\n";
+        let corrupt2 = "not json at all\n";
+        let corrupt3 = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"message\":{\"role\":\"assistan\n"; // cut mid-value
+        let u2 = "{\"type\":\"user\",\"uuid\":\"u2\",\"parentUuid\":\"u1\",\"isSidechain\":false,\"timestamp\":\"2025-01-15T10:00:05Z\",\"message\":{\"role\":\"user\",\"content\":\"World\"}}\n";
+
+        std::fs::write(&path, format!("{u1}{corrupt1}{corrupt2}{corrupt3}{u2}")).unwrap();
+
+        let result = read_session_incremental(path.to_str().unwrap(), 0);
+        assert!(
+            result.is_ok(),
+            "multiple corrupt lines must not cause a load error"
+        );
+
+        let (msgs, _, _) = result.unwrap();
+        let user_count = msgs
+            .iter()
+            .filter(|m| matches!(m, ClassifiedMsg::User(_)))
+            .count();
+        assert_eq!(
+            user_count, 2,
+            "both valid user entries must survive; all corrupt lines must be skipped"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn scan_session_metadata_skips_corrupt_lines() {
+        // scan_session_metadata must skip corrupt JSON lines and continue processing
+        // valid entries that appear after them in the file.
+        let tmp = env::temp_dir().join("tail-test-meta-corrupt");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let valid_user = "{\"type\":\"user\",\"uuid\":\"u1\",\"timestamp\":\"2025-01-15T10:00:00Z\",\"message\":{\"role\":\"user\",\"content\":\"Hello world\"}}\n";
+        let corrupt = "{\"type\":\"user\",\"uuid\":\"u2\",\"timestamp\":\"2025-01-15T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"CORRUPT truncated\n"; // truncated
+        let valid_assistant = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"requestId\":\"r1\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"role\":\"assistant\",\"content\":[],\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0},\"stop_reason\":\"end_turn\"}}\n";
+
+        std::fs::write(&path, format!("{valid_user}{corrupt}{valid_assistant}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            meta.first_msg.contains("Hello world"),
+            "first_msg must come from the valid user entry before the corrupt line; got: {:?}",
+            meta.first_msg
+        );
+        assert_eq!(
+            meta.input_tokens, 10,
+            "tokens from the valid assistant entry after the corrupt line must be counted (got {})",
+            meta.input_tokens
         );
 
         std::fs::remove_dir_all(&tmp).ok();


### PR DESCRIPTION
## Summary

Batch fix for two Claude Code compatibility issues affecting the JSONL parser.

## Fixes

- **#66** — Skip corrupt/truncated JSONL lines from unclean shutdowns instead of aborting the parse. Both `read_session_incremental` (UTF-8 decode errors) and `scan_session_metadata` (mid-line breaks) now recover and continue rather than failing the entire session load.

- **#67** — Treat unmatched `tool_use` blocks in pre-v2.1.122 `/branch` fork sessions as orphans rather than evidence of an ongoing session. When a `tool_use` ID has no corresponding `tool_result` in the current conversation chain (because the result lives in a sibling rewound-timeline fork), the session is no longer incorrectly marked as ongoing/stuck.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/parser/session.rs` | Skip corrupt JSONL lines (#66); detect orphaned `tool_use` IDs (#67) |
| `src-tauri/src/parser/entry.rs` | Resilient JSONL line reading for unclean shutdowns (#66) |
| `src-tauri/src/parser/chunk.rs` | Orphan `tool_use` detection logic (#67) |
| `bin/cctrace.mjs` | Rename `__dirname` → `binDir` for clarity |

## Tests

- Added tests for corrupt/truncated mid-file JSONL lines (issue #66)
- Added tests for orphaned `tool_use` blocks in fork sessions (issue #67)
- All 351 frontend + 377 Rust tests pass
