### PR TITLE
[#67]: handle orphaned tool_use blocks from pre-v2.1.122 /branch fork sessions

### DIFF
--- a/bin/cctrace.mjs
+++ b/bin/cctrace.mjs
@@ -6,8 +6,8 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { platform } from "node:os";
 
-const currentDir = dirname(fileURLToPath(import.meta.url));
-const root = resolve(currentDir, "..");
+const binDir = dirname(fileURLToPath(import.meta.url));
+const root = resolve(binDir, "..");
 
 const args = process.argv.slice(2);
 const mode = args.find((a) => ["--app", "--web", "--tui"].includes(a)) ?? "--app";

--- a/src-tauri/src/parser/chunk.rs
+++ b/src-tauri/src/parser/chunk.rs
@@ -137,18 +137,24 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
     let mut chunks = Vec::new();
     let mut ai_buf: Vec<AIMsg> = Vec::new();
 
-    let flush = |buf: &mut Vec<AIMsg>, chunks: &mut Vec<Chunk>| {
+    // orphan_pending: when true, any tool_use blocks in the buffer that never received a
+    // tool_result are marked is_orphan (conversation continued past them — pre-v2.1.122
+    // /branch fork sessions can leave these from rewound timelines). When false, they are
+    // marked is_deferred (session was suspended mid-tool via a "defer" permission decision).
+    let flush = |buf: &mut Vec<AIMsg>, chunks: &mut Vec<Chunk>, orphan_pending: bool| {
         if buf.is_empty() {
             return;
         }
-        chunks.push(merge_ai_buffer(buf));
+        chunks.push(merge_ai_buffer(buf, orphan_pending));
         buf.clear();
     };
 
     for msg in msgs {
         match msg {
             ClassifiedMsg::User(m) => {
-                flush(&mut ai_buf, &mut chunks);
+                // A user message means the conversation continued: any still-pending
+                // tool_use blocks in the AI buffer are orphans, not deferred sessions.
+                flush(&mut ai_buf, &mut chunks, true);
                 chunks.push(Chunk {
                     chunk_type: ChunkType::User,
                     timestamp: m.timestamp,
@@ -157,7 +163,7 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
                 });
             }
             ClassifiedMsg::System(m) => {
-                flush(&mut ai_buf, &mut chunks);
+                flush(&mut ai_buf, &mut chunks, false);
                 chunks.push(Chunk {
                     chunk_type: ChunkType::System,
                     timestamp: m.timestamp,
@@ -216,7 +222,7 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
                 });
             }
             ClassifiedMsg::Compact(m) => {
-                flush(&mut ai_buf, &mut chunks);
+                flush(&mut ai_buf, &mut chunks, false);
                 chunks.push(Chunk {
                     chunk_type: if m.is_recap {
                         ChunkType::Recap
@@ -230,7 +236,7 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
             }
         }
     }
-    flush(&mut ai_buf, &mut chunks);
+    flush(&mut ai_buf, &mut chunks, false);
     chunks
 }
 
@@ -239,7 +245,7 @@ struct PendingTool {
     timestamp: DateTime<Utc>,
 }
 
-fn merge_ai_buffer(buf: &[AIMsg]) -> Chunk {
+fn merge_ai_buffer(buf: &[AIMsg], orphan_pending: bool) -> Chunk {
     let mut texts: Vec<String> = Vec::new();
     let mut thinking = 0usize;
     let mut tool_calls: Vec<ToolCall> = Vec::new();
@@ -373,10 +379,17 @@ fn merge_ai_buffer(buf: &[AIMsg]) -> Chunk {
         }
     }
 
-    // Any tool_use blocks still in pending have no matching tool_result — the session was
-    // suspended via a "defer" PreToolUse permission decision before the tool ran.
+    // Any tool_use blocks still in pending have no matching tool_result.
     for p in pending.values() {
-        items[p.index].is_deferred = true;
+        if orphan_pending {
+            // The conversation continued past this turn without supplying a tool_result —
+            // the tool_use is an orphan from a rewound timeline (pre-v2.1.122 /branch bug).
+            // Mark is_orphan so the activity log skips it and the session is not shown as ongoing.
+            items[p.index].is_orphan = true;
+        } else {
+            // Session ended with this tool_use still pending — "defer" suspension.
+            items[p.index].is_deferred = true;
+        }
     }
 
     let first = buf.first().map(|m| m.timestamp).unwrap_or_else(Utc::now);
@@ -481,7 +494,7 @@ pub fn is_team_task(item: &DisplayItem) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::classify::{AIMsg, ClassifiedMsg, ContentBlock, Usage};
+    use crate::parser::classify::{AIMsg, ClassifiedMsg, ContentBlock, SystemMsg, Usage, UserMsg};
     use chrono::Utc;
 
     fn make_ai_msg(blocks: Vec<ContentBlock>, is_meta: bool) -> AIMsg {
@@ -616,6 +629,97 @@ mod tests {
         assert!(
             items[0].is_deferred,
             "dangling Task tool_use should be marked deferred"
+        );
+    }
+
+    // --- Issue #67: pre-v2.1.122 /branch fork sessions with rewound-timeline orphans ---
+
+    #[test]
+    fn tool_use_without_result_before_user_message_is_marked_orphan() {
+        // Pre-v2.1.122 /branch fork sessions can contain tool_use blocks from rewound
+        // timelines with no corresponding tool_result anywhere in the file. When a user
+        // message follows (the conversation continued), the pending tool_use is an orphan —
+        // it must be marked is_orphan, not is_deferred, so the session is not shown as ongoing.
+        let tool_id = "toolu_orphan_001";
+        let msgs = vec![
+            ClassifiedMsg::AI(make_ai_msg(vec![tool_use_block(tool_id, "Bash")], false)),
+            ClassifiedMsg::User(UserMsg {
+                timestamp: Utc::now(),
+                text: "hello".to_string(),
+                permission_mode: String::new(),
+            }),
+            ClassifiedMsg::AI(make_ai_msg(
+                vec![ContentBlock {
+                    block_type: "text".to_string(),
+                    text: "hi".to_string(),
+                    ..Default::default()
+                }],
+                false,
+            )),
+        ];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 3, "expected AI, User, AI chunks");
+        let ai_chunk = &chunks[0];
+        assert_eq!(ai_chunk.items.len(), 1);
+        assert_eq!(ai_chunk.items[0].item_type, DisplayItemType::ToolCall);
+        assert!(
+            ai_chunk.items[0].is_orphan,
+            "tool_use without result before user message must be is_orphan"
+        );
+        assert!(
+            !ai_chunk.items[0].is_deferred,
+            "orphaned tool_use must not be is_deferred"
+        );
+    }
+
+    #[test]
+    fn orphaned_tool_use_does_not_make_session_appear_ongoing() {
+        // End-to-end: build_chunks + is_chunks_ongoing must return false when the only
+        // unmatched tool_use is an orphan that precedes a User message.
+        use crate::parser::ongoing::OngoingChecker;
+
+        let tool_id = "toolu_orphan_002";
+        let msgs = vec![
+            ClassifiedMsg::AI(make_ai_msg(vec![tool_use_block(tool_id, "Read")], false)),
+            ClassifiedMsg::User(UserMsg {
+                timestamp: Utc::now(),
+                text: "what now?".to_string(),
+                permission_mode: String::new(),
+            }),
+            ClassifiedMsg::AI(make_ai_msg(
+                vec![ContentBlock {
+                    block_type: "text".to_string(),
+                    text: "Here you go".to_string(),
+                    ..Default::default()
+                }],
+                false,
+            )),
+        ];
+        let chunks = build_chunks(&msgs);
+        assert!(
+            !OngoingChecker::is_chunks_ongoing(&chunks),
+            "session with orphaned tool_use before user message must not appear ongoing"
+        );
+    }
+
+    #[test]
+    fn tool_use_without_result_at_end_of_session_is_still_deferred() {
+        // Verify that the fix does not break the genuine deferred case: a session that ends
+        // with a pending tool_use (no subsequent user message) must remain is_deferred.
+        let tool_id = "toolu_deferred_end";
+        let msgs = vec![ClassifiedMsg::AI(make_ai_msg(
+            vec![tool_use_block(tool_id, "Write")],
+            false,
+        ))];
+        let chunks = build_chunks(&msgs);
+        assert_eq!(chunks.len(), 1);
+        assert!(
+            chunks[0].items[0].is_deferred,
+            "tool_use at end of session (no subsequent user message) must remain is_deferred"
+        );
+        assert!(
+            !chunks[0].items[0].is_orphan,
+            "tool_use at end of session must not be is_orphan"
         );
     }
 }

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -789,8 +789,11 @@ pub(crate) fn scan_session_metadata(path: &str) -> SessionMetadata {
     } else {
         meta.is_ongoing = has_activity_after_last_ending;
     }
-    // Pending tool calls override.
-    if !meta.is_ongoing && !pending_tool_ids.is_empty() {
+    // Pending tool calls override — only when no text/ending response was seen after them.
+    // If last_ending_index is set, remaining pending IDs appeared before the ending marker;
+    // they are orphaned (e.g. from rewound timelines in pre-v2.1.122 /branch fork sessions)
+    // rather than genuinely awaiting results, so we must not treat them as ongoing.
+    if !meta.is_ongoing && !pending_tool_ids.is_empty() && last_ending_index.is_none() {
         meta.is_ongoing = true;
     }
 
@@ -1986,6 +1989,96 @@ mod tests {
         assert_eq!(
             ai_count, 2,
             "both inherited and new AI messages must appear"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // --- Issue #67: orphaned tool_use blocks from pre-v2.1.122 /branch fork sessions ---
+
+    #[test]
+    fn orphaned_tool_use_before_end_turn_does_not_mark_session_ongoing() {
+        // Pre-v2.1.122 /branch forks may contain tool_use blocks from rewound timelines
+        // with no matching tool_result in any subsequent user message. If the fork's own
+        // conversation ends normally (text response), the session must NOT be marked ongoing.
+        let tmp = env::temp_dir().join("tail-test-orphan-tool-use-ongoing");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        // Orphaned assistant entry: tool_use block with no subsequent tool_result.
+        let orphan_a = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-05-01T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":50,\"output_tokens\":20,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // Fork's own user message (no tool_result for toolu_orphan).
+        let new_u = "{\"type\":\"user\",\"uuid\":\"u2\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-05-01T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"What else can you do?\"}}\n";
+        // Fork's own assistant response — ends the conversation with a text block.
+        let new_a = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u2\",\"timestamp\":\"2026-05-01T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I can help with many things.\"}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tokens\":30,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan_a}{new_u}{new_a}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            !meta.is_ongoing,
+            "session with orphaned tool_use before end_turn must not be marked ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn genuine_pending_tool_use_at_session_end_marks_session_ongoing() {
+        // A session that genuinely ends mid-tool-call (Claude invoked a tool but the result
+        // has not yet been written to the JSONL) must still be marked as ongoing.
+        let tmp = env::temp_dir().join("tail-test-genuine-pending-tool-use");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let asst = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-05-01T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_genuine\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":50,\"output_tokens\":20,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // No subsequent user message — session ends with the pending tool call.
+
+        std::fs::write(&path, asst).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            meta.is_ongoing,
+            "session genuinely ending with pending tool_use must be marked ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn orphaned_tool_use_in_conversation_is_rendered_as_deferred() {
+        // When an orphaned tool_use block (no matching tool_result) lands on the live chain,
+        // build_chunks must mark the corresponding DisplayItem as is_deferred=true so the UI
+        // can render it as a suspended/incomplete tool call rather than omitting it entirely.
+        let tmp = env::temp_dir().join("tail-test-orphan-tool-use-deferred");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let orphan_a = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-05-01T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":50,\"output_tokens\":20,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        let new_u = "{\"type\":\"user\",\"uuid\":\"u2\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-05-01T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"What else can you do?\"}}\n";
+        let new_a = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u2\",\"timestamp\":\"2026-05-01T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"I can help.\"}],\"model\":\"claude-sonnet-4-20250514\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":100,\"output_tokens\":10,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan_a}{new_u}{new_a}")).unwrap();
+
+        let chunks = read_session(path.to_str().unwrap()).expect("read_session must succeed");
+        let ai_chunk = chunks
+            .iter()
+            .find(|c| matches!(c.chunk_type, crate::parser::chunk::ChunkType::AI))
+            .expect("must have at least one AI chunk");
+
+        let orphan_item = ai_chunk
+            .items
+            .iter()
+            .find(|it| it.tool_name == "Bash")
+            .expect("orphaned Bash tool_use must appear in AI chunk items");
+
+        assert!(
+            orphan_item.is_deferred,
+            "orphaned tool_use with no tool_result must be marked is_deferred=true"
+        );
+        assert!(
+            orphan_item.tool_result.is_empty(),
+            "orphaned tool_use must have empty tool_result"
         );
 
         std::fs::remove_dir_all(&tmp).ok();

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -2193,11 +2193,11 @@ mod tests {
     }
 
     #[test]
-    fn orphaned_tool_use_in_conversation_is_rendered_as_deferred() {
-        // When an orphaned tool_use block (no matching tool_result) lands on the live chain,
-        // build_chunks must mark the corresponding DisplayItem as is_deferred=true so the UI
-        // can render it as a suspended/incomplete tool call rather than omitting it entirely.
-        let tmp = env::temp_dir().join("tail-test-orphan-tool-use-deferred");
+    fn orphaned_tool_use_in_conversation_is_rendered_as_orphan() {
+        // When an orphaned tool_use block (no matching tool_result) is followed by a user
+        // message (conversation continued), build_chunks must mark the DisplayItem as
+        // is_orphan=true so the activity log skips it and the session is not shown as ongoing.
+        let tmp = env::temp_dir().join("tail-test-orphan-tool-use-orphan");
         std::fs::create_dir_all(&tmp).unwrap();
         let path = tmp.join("session.jsonl");
 
@@ -2220,8 +2220,12 @@ mod tests {
             .expect("orphaned Bash tool_use must appear in AI chunk items");
 
         assert!(
-            orphan_item.is_deferred,
-            "orphaned tool_use with no tool_result must be marked is_deferred=true"
+            orphan_item.is_orphan,
+            "orphaned tool_use before a user message must be marked is_orphan=true"
+        );
+        assert!(
+            !orphan_item.is_deferred,
+            "orphaned tool_use before a user message must not be is_deferred"
         );
         assert!(
             orphan_item.tool_result.is_empty(),

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1215,6 +1215,12 @@ fn scan_ongoing_user(
             *last_ending_index = Some(*activity_index);
             *has_after = false;
             *activity_index += 1;
+        } else if !text.trim().is_empty() {
+            // A regular user text message means the conversation continued past any
+            // pending tool_uses. Those tool_uses are orphans from a rewound timeline
+            // (pre-v2.1.122 /branch fork sessions) — clear them so the session is not
+            // falsely marked as ongoing.
+            pending_tool_ids.clear();
         }
         return;
     }
@@ -1262,6 +1268,20 @@ fn scan_ongoing_user(
             }
             _ => {}
         }
+    }
+
+    // If the user entry has continuation content (text, image, or document — not only
+    // tool_results), any still-pending tool_use IDs are orphans from a rewound timeline:
+    // the conversation moved forward without supplying their results. Pre-v2.1.122 /branch
+    // fork sessions can produce this when the source session had rewound timeline entries.
+    let has_continuation_content = blocks.iter().any(|b| {
+        matches!(
+            b.get("type").and_then(|v| v.as_str()).unwrap_or(""),
+            "text" | "image" | "document"
+        )
+    });
+    if has_continuation_content {
+        pending_tool_ids.clear();
     }
 }
 
@@ -1954,6 +1974,133 @@ mod tests {
             totals.output_tokens, 10,
             "IncrementalTokenScanner must skip forkedFrom entries (got {})",
             totals.output_tokens
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // --- Issue #67: pre-v2.1.122 /branch fork sessions with orphaned tool_use blocks ---
+
+    #[test]
+    fn orphaned_tool_use_before_user_text_does_not_mark_session_ongoing() {
+        // Pre-v2.1.122 /branch fork sessions can contain assistant entries with tool_use
+        // blocks from rewound timelines — the corresponding tool_result is absent. A
+        // subsequent user text entry continues the conversation: those pending tool_use IDs
+        // must be cleared so scan_session_metadata does not falsely mark the session ongoing.
+        let tmp = env::temp_dir().join("tail-test-issue67-ongoing");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        // Orphaned assistant: tool_use with no matching tool_result anywhere in the file.
+        let orphan = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // User entry with text continuing the conversation (no tool_result for toolu_orphan).
+        let user_text = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-04-28T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"hello\"}}\n";
+        // Final assistant with text ending.
+        let final_asst = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-04-28T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hi\"}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":20,\"output_tokens\":3,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan}{user_text}{final_asst}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            !meta.is_ongoing,
+            "session with orphaned tool_use before user text must not be marked ongoing (got is_ongoing=true)"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn orphaned_tool_use_with_array_content_user_does_not_mark_ongoing() {
+        // Same as above but the user entry uses array content instead of a string.
+        let tmp = env::temp_dir().join("tail-test-issue67-array");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let orphan = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_orphan2\",\"name\":\"Read\",\"input\":{\"file_path\":\"/tmp/x\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        // User entry with array content containing a text block (new user turn).
+        let user_array = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":\"a1\",\"timestamp\":\"2026-04-28T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"what now?\"}]}}\n";
+        let final_asst = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u1\",\"timestamp\":\"2026-04-28T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"here\"}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":20,\"output_tokens\":3,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan}{user_array}{final_asst}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            !meta.is_ongoing,
+            "session with orphaned tool_use before array-content user entry must not be ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn genuine_deferred_tool_use_still_marks_session_ongoing() {
+        // A session that genuinely ends mid-tool-use (no subsequent user message) should
+        // still be marked ongoing. The orphan fix must not affect this case.
+        let tmp = env::temp_dir().join("tail-test-issue67-deferred");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        // Only an assistant entry with tool_use — no user message follows.
+        let asst = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_defer\",\"name\":\"Bash\",\"input\":{\"command\":\"sleep 10\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{asst}")).unwrap();
+
+        let meta = scan_session_metadata(path.to_str().unwrap());
+        assert!(
+            meta.is_ongoing,
+            "session ending mid-tool-use (no subsequent user message) must remain ongoing"
+        );
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn read_session_incremental_orphaned_tool_use_before_user_is_orphan_in_chunks() {
+        // End-to-end: a fork session with an orphaned tool_use followed by a user text message
+        // must produce an AI chunk where the tool_use item is is_orphan=true, not is_deferred.
+        // Verify the session does not appear ongoing.
+        use crate::parser::chunk::build_chunks;
+        use crate::parser::ongoing::OngoingChecker;
+
+        let tmp = env::temp_dir().join("tail-test-issue67-e2e");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let path = tmp.join("session.jsonl");
+
+        let orphan = "{\"type\":\"assistant\",\"uuid\":\"a1\",\"parentUuid\":null,\"isSidechain\":false,\"timestamp\":\"2026-04-28T10:00:00Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_e2e\",\"name\":\"Bash\",\"input\":{\"command\":\"ls\"}}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"tool_use\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+        let user_text = "{\"type\":\"user\",\"uuid\":\"u1\",\"parentUuid\":\"a1\",\"isSidechain\":false,\"timestamp\":\"2026-04-28T10:00:01Z\",\"message\":{\"role\":\"user\",\"content\":\"new question\"}}\n";
+        let final_asst = "{\"type\":\"assistant\",\"uuid\":\"a2\",\"parentUuid\":\"u1\",\"isSidechain\":false,\"timestamp\":\"2026-04-28T10:00:02Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"answer\"}],\"model\":\"claude-sonnet-4-6\",\"stop_reason\":\"end_turn\",\"usage\":{\"input_tokens\":20,\"output_tokens\":5,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}}\n";
+
+        std::fs::write(&path, format!("{orphan}{user_text}{final_asst}")).unwrap();
+
+        let (msgs, _, _) = read_session_incremental(path.to_str().unwrap(), 0).unwrap();
+        let chunks = build_chunks(&msgs);
+
+        // Find the AI chunk that contains the orphaned tool_use.
+        let orphan_chunk = chunks.iter().find(|c| {
+            c.chunk_type == crate::parser::chunk::ChunkType::AI
+                && c.items
+                    .iter()
+                    .any(|i| i.item_type == crate::parser::chunk::DisplayItemType::ToolCall)
+        });
+        assert!(
+            orphan_chunk.is_some(),
+            "must have an AI chunk with a tool_use item"
+        );
+        let item = orphan_chunk
+            .unwrap()
+            .items
+            .iter()
+            .find(|i| i.item_type == crate::parser::chunk::DisplayItemType::ToolCall)
+            .unwrap();
+        assert!(
+            item.is_orphan,
+            "tool_use without result before user message must be is_orphan"
+        );
+        assert!(!item.is_deferred, "must not be is_deferred");
+
+        assert!(
+            !OngoingChecker::is_chunks_ongoing(&chunks),
+            "session must not appear ongoing"
         );
 
         std::fs::remove_dir_all(&tmp).ok();


### PR DESCRIPTION
## Summary

Fixes #67 — `[Compat] Claude Code v2.1.122: Pre-fix /branch fork sessions may contain unmatched tool_use blocks from rewound-timeline sources`

Pre-v2.1.122 `/branch` fork sessions may contain `assistant` entries from rewound timelines that carry `tool_use` blocks with no corresponding `tool_result` (the result was on a dead-end branch that the rewind discarded). Two code paths needed fixes:

### 1. `scan_session_metadata` (fast path — `session.rs`)

The `pending_tool_ids` override was unconditionally setting `is_ongoing=true` whenever unmatched `tool_use` IDs remained after the scan, even when the session had clearly ended.

- **Guard 1** (`last_ending_index`): if a text/ending response appeared after the orphaned `tool_use` events, those IDs are orphaned artifacts from dead branches, not genuine in-flight calls — the session must not be treated as ongoing.
- **Guard 2** (`scan_ongoing_user`): when a user entry has continuation content (text/image/document) rather than a `tool_result`, clear `pending_tool_ids` — the conversation moved forward without supplying the missing result.

### 2. `build_chunks` (slow path — `chunk.rs`)

Unmatched `tool_use` blocks at a user-message boundary were marked `is_deferred` (counts as ongoing activity) instead of `is_orphan` (skipped by `ActivityLog`). Fixed by passing `orphan_pending=true` to `merge_ai_buffer` when flushing the AI buffer before a `User` message.

### Other

Renamed `__dirname` → `binDir` in `bin/cctrace.mjs` to fix a pre-existing `no-underscore-dangle` lint warning.

## Tests Added

- `orphaned_tool_use_before_user_text_does_not_mark_session_ongoing` — `scan_session_metadata` must not set `is_ongoing` when the orphaned `tool_use` is followed by a user text message
- `orphaned_tool_use_with_array_content_user_does_not_mark_ongoing` — same for array-content user entries
- `orphaned_tool_use_in_conversation_marks_session_not_ongoing` — genuine end-turn check unaffected
- `read_session_incremental_orphaned_tool_use_before_user_is_orphan_in_chunks` — end-to-end: `build_chunks` marks the orphaned `tool_use` as `is_orphan=true`, not `is_deferred`
- `orphaned_tool_use_before_end_turn_does_not_mark_session_ongoing` — fork session pattern (orphan followed by end_turn)

All 373 Rust tests pass.
