### PR TITLE
fix(parser): add explicit lifetime to Cow return type (fixes clippy lint)

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -172,7 +172,7 @@ fn hex4_to_u16(bytes: &[u8]) -> Option<u16> {
 /// the tool-error truncation logic split a multi-byte emoji at an offset
 /// boundary. serde_json rejects lone surrogates per RFC 8259; this pass makes
 /// such lines parseable before they reach the deserializer.
-fn sanitize_lone_surrogates(s: &str) -> Cow<str> {
+fn sanitize_lone_surrogates(s: &str) -> Cow<'_, str> {
     let bytes = s.as_bytes();
     let len = bytes.len();
     let mut i = 0;


### PR DESCRIPTION
## Summary

- Changes `Cow<str>` → `Cow<'_, str>` in `sanitize_lone_surrogates` return type
- Fixes `mismatched_lifetime_syntaxes` lint that was failing CI under `cargo clippy -- -D warnings`
- The elided lifetime on the `&str` input must be consistently expressed in the return type

## Root cause

PR #88 introduced `sanitize_lone_surrogates(s: &str) -> Cow<str>`. Rust's `mismatched_lifetime_syntaxes` lint (enabled via `-D warnings`) requires that the lifetime hidden in `&str` and the lifetime in `Cow<str>` be written consistently — either both elided or both explicit. The fix uses `Cow<'_, str>` to make the connection explicit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fmh1aPCyB1xMDwNQbk56in)_