### PR TITLE
fix(release): sync tauri.conf.json into the version-bump set

### DIFF
--- a/.claude/skills/cut-release/references/project-shape.md
+++ b/.claude/skills/cut-release/references/project-shape.md
@@ -15,17 +15,21 @@ codebase, this file points at the source of truth rather than repeating it.
 
 ## Version-bearing files (skill-specific rule)
 
-Three files must agree on the next-version string. Nothing in the codebase enforces this
+Four files must agree on the next-version string. Nothing in the codebase enforces this
 sync — the skill does.
 
-| File                   | Owns                             | Bumps with                                 |
-| ---------------------- | -------------------------------- | ------------------------------------------ |
-| `package.json` (root)  | Node/TS workspace + binary entry | the Rust crate (lockstep)                  |
-| `src-tauri/Cargo.toml` | Rust crate version               | root `package.json` (lockstep)             |
-| `tui/package.json`     | Terminal UI subpackage           | independently; bumps when TUI code changes |
+| File                        | Owns                                 | Bumps with                                 |
+| --------------------------- | ------------------------------------ | ------------------------------------------ |
+| `package.json` (root)       | Node/TS workspace + binary entry     | the Rust crate (lockstep)                  |
+| `src-tauri/Cargo.toml`      | Rust crate version                   | root `package.json` (lockstep)             |
+| `src-tauri/tauri.conf.json` | Tauri bundle filenames + app version | the Rust crate (lockstep)                  |
+| `tui/package.json`          | Terminal UI subpackage               | independently; bumps when TUI code changes |
 
-Root + Cargo move together because the desktop binary the user installs is built from
-both. `tui/package.json` tracks separately because it's shipped as its own npm package.
+Root + Cargo + `tauri.conf.json` move together because the desktop binary the user installs
+is built from all three — `tauri.conf.json`'s `version` field is what `tauri-action`
+templates into the released artifact filenames (`Claude.Code.Trace_<version>_*.dmg`, etc.).
+Missing this file silently ships a release whose artifacts are stamped with the previous
+version. `tui/package.json` tracks separately because it's shipped as its own npm package.
 
 ## Lockfile regen after a version bump
 

--- a/.claude/skills/cut-release/steps/phase3-bump-versions.md
+++ b/.claude/skills/cut-release/steps/phase3-bump-versions.md
@@ -6,7 +6,7 @@ lockfiles.
 Refer to `${CLAUDE_SKILL_DIR}/references/project-shape.md` for the rules on which files
 move in lockstep and which move independently.
 
-## Step 3.1 — Bump root + Cargo (always lockstep)
+## Step 3.1 — Bump root + Cargo + Tauri config (always lockstep)
 
 ```bash
 # Root package.json
@@ -14,10 +14,17 @@ move in lockstep and which move independently.
 
 # src-tauri/Cargo.toml
 # Edit: version = "<old>" → version = "<NEXT_VERSION>"
+
+# src-tauri/tauri.conf.json
+# Edit: "version": "<old>" → "version": "<NEXT_VERSION>"
 ```
 
 Use the Edit tool with `old_string`/`new_string` rather than sed — safer for surrounding
 context.
+
+`tauri.conf.json` is the field `tauri-action` reads when stamping artifact filenames at
+build time (`Claude.Code.Trace_<version>_*.dmg`, etc.). Skipping it produces a release
+whose artifacts are still named with the previous version — the symptom seen on v0.5.1.
 
 ## Step 3.2 — Bump TUI version
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Claude Code Trace",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.claudecodetrace.app",
   "build": {
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
## Why

`src-tauri/tauri.conf.json` was missing from the `cut-release` skill's
version-bearing files table, so v0.5.1 shipped with all artifacts named
`Claude.Code.Trace_0.5.0_*` even though `package.json` and
`src-tauri/Cargo.toml` had been bumped to `0.5.1`. `tauri-action` reads
`tauri.conf.json`'s `version` field when stamping bundle filenames at
build time, so it has to bump in lockstep with the other version files.

## What

- Bump `src-tauri/tauri.conf.json` from `0.5.0` to `0.5.1` to bring main
  in sync with the rest of the workspace.
- Add the file to `.claude/skills/cut-release/references/project-shape.md`
  (now four version-bearing files instead of three) and to
  `.claude/skills/cut-release/steps/phase3-bump-versions.md` so future
  `cut-release` runs include it automatically.

## Test plan

- [x] `npx oxfmt` clean
- [x] `npx oxlint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 366 passed
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml` — 0 warnings
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 397 passed

A separate force-push of tag `v0.5.1` (onto `release/v0.5.1-rebuild`)
re-runs the release pipeline so the v0.5.1 release page gets correctly
named artifacts.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZc7eCjNNS9jjiNwirxKDB)_