### PR TITLE
fix(tui): subscribe to picker-refresh event for picker auto-update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,60 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to dry-run, e.g. 0.5.1 (no v prefix). Only the notes job runs; nothing is built or published."
+        required: true
+        type: string
 
 jobs:
+  notes:
+    name: Extract release notes from CHANGELOG
+    runs-on: ubuntu-latest
+    outputs:
+      body: ${{ steps.extract.outputs.body }}
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - id: extract
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          echo "Resolving CHANGELOG section for v$VERSION"
+          BODY=$(awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { inside=1; print; next }
+            inside && /^## \[/ { exit }
+            inside { print }
+          ' CHANGELOG.md 2>/dev/null || true)
+          if [ -z "$BODY" ]; then
+            echo "::error file=CHANGELOG.md::No CHANGELOG section found for version $VERSION. Add a '## [$VERSION] — YYYY-MM-DD' heading before tagging."
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo 'body<<RELEASE_NOTES_EOF'
+            printf '%s\n' "$BODY"
+            echo RELEASE_NOTES_EOF
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Release notes preview for v$VERSION"
+            echo
+            echo '```markdown'
+            printf '%s\n' "$BODY"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
   build-macos:
+    needs: notes
+    if: github.event_name == 'push'
     runs-on: macos-latest
     permissions:
       contents: write
@@ -37,11 +88,13 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: ${{ github.ref_name }}
-          releaseBody: "See the assets below to download the app."
+          releaseBody: ${{ needs.notes.outputs.body }}
           releaseDraft: true
           prerelease: false
 
   build-linux:
+    needs: notes
+    if: github.event_name == 'push'
     runs-on: ubuntu-22.04
     permissions:
       contents: write
@@ -77,11 +130,13 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: ${{ github.ref_name }}
-          releaseBody: "See the assets below to download the app."
+          releaseBody: ${{ needs.notes.outputs.body }}
           releaseDraft: true
           prerelease: false
 
   build-windows:
+    needs: notes
+    if: github.event_name == 'push'
     runs-on: windows-latest
     permissions:
       contents: write
@@ -112,6 +167,23 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: ${{ github.ref_name }}
-          releaseBody: "See the assets below to download the app."
+          releaseBody: ${{ needs.notes.outputs.body }}
           releaseDraft: true
           prerelease: false
+
+  publish:
+    name: Publish release (flip draft → public)
+    needs: [build-macos, build-linux, build-windows]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --draft=false \
+            --latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to claude-code-trace are documented here. Versions follow
+[semantic versioning](https://semver.org/).
+
+## [0.5.1] — 2026-05-20
+
+A release focused entirely on the session-watcher / picker-refresh path. Brings the picker
+closer to a live view: the cards you can see on screen update without waiting for filesystem
+events, and a long-standing TUI bug that silently disabled picker auto-refresh is fixed.
+
+### Added
+
+- **Viewport-driven picker refresh in the web frontend**. The picker now wraps every session
+  card in a shared `IntersectionObserver` (`useVisibleSessions` hook) and re-fetches the
+  session list whenever the visible set changes — debounced 150 ms — plus a 2 s heartbeat
+  while any cards are visible. This means the cards the user is actually looking at stay
+  fresh without paying the cost of polling everything all the time, and ongoing-status /
+  token-count badges update much closer to real time. Verified end-to-end in a real browser
+  (Chromium): 549/549 cards observed, scroll triggers a `POST /api/sessions` at ~T+1.3 s,
+  then the heartbeat keeps the list fresh while the picker is mounted.
+
+### Fixed
+
+- **TUI picker auto-refresh**
+  ([`ebb2ca5`](https://github.com/delexw/claude-code-trace/commit/ebb2ca5)). The terminal UI
+  subscribed to a non-existent `picker-update` event and destructured `payload.sessions` from
+  it, while the backend emits `picker-refresh` with an empty payload
+  (`src-tauri/src/watcher.rs:340`). The TUI picker never auto-updated when sessions changed
+  on disk — it only refreshed when the user re-entered the picker view. The TUI now
+  subscribes to `picker-refresh` and re-fetches via `api.discoverSessions(dirs)`, mirroring
+  the web frontend pattern in `src/hooks/usePicker.ts`.
+
+- **Web picker re-fetch on `picker-refresh` signal**
+  ([`01f8212`](https://github.com/delexw/claude-code-trace/commit/01f8212)). Memoise the most
+  recent `projectDirs` in a ref so the SSE handler can re-issue `discover_sessions` without
+  the caller needing to thread state through.
+
+[0.5.1]: https://github.com/delexw/claude-code-trace/releases/tag/v0.5.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-trace",
-  "version": "0.4.13",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-trace",
-      "version": "0.4.13",
+      "version": "0.5.1",
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-fs": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-trace",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "bin": {
     "cctrace": "./bin/cctrace.mjs"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "claude-code-trace"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-code-trace"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.77.2"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Claude Code Trace",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.claudecodetrace.app",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -312,6 +312,7 @@ export function App() {
             onSelect={handleSelectSession}
             onSearchChange={picker.setSearchQuery}
             onSelectIndex={setPickerSelectedIndex}
+            onVisiblePathsChange={picker.refresh}
           />
         );
 

--- a/src/components/SessionPicker.test.tsx
+++ b/src/components/SessionPicker.test.tsx
@@ -1,7 +1,43 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { SessionPicker } from "./SessionPicker";
 import type { SessionInfo } from "../types";
+
+type IOCallback = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => void;
+
+class FakeIO {
+  static last: FakeIO | null = null;
+  cb: IOCallback;
+  observed: Element[] = [];
+  observe = (el: Element) => {
+    this.observed.push(el);
+  };
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => [] as IntersectionObserverEntry[]);
+  root = null;
+  rootMargin = "";
+  thresholds: number[] = [];
+  constructor(cb: IOCallback) {
+    this.cb = cb;
+    FakeIO.last = this;
+  }
+  trigger(els: Element[]) {
+    const entries = els.map(
+      (el) =>
+        ({
+          target: el,
+          isIntersecting: true,
+          intersectionRatio: 1,
+          boundingClientRect: new DOMRect(),
+          intersectionRect: new DOMRect(),
+          rootBounds: new DOMRect(),
+          time: 0,
+        }) as unknown as IntersectionObserverEntry,
+    );
+    this.cb(entries, this as unknown as IntersectionObserver);
+  }
+}
 
 function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
   return {
@@ -190,5 +226,61 @@ describe("SessionPicker", () => {
       />,
     );
     expect(screen.queryByText(/Discovering sessions/)).not.toBeInTheDocument();
+  });
+
+  describe("viewport-aware visibility tracking", () => {
+    beforeEach(() => {
+      FakeIO.last = null;
+      (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = FakeIO;
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("observes each session card and reports visible paths via onVisiblePathsChange", () => {
+      const onVisible = vi.fn();
+      const sessions = [
+        makeSession({ path: "/a.jsonl", session_id: "a", first_message: "alpha" }),
+        makeSession({ path: "/b.jsonl", session_id: "b", first_message: "beta" }),
+      ];
+      render(
+        <SessionPicker
+          sessions={sessions}
+          loading={false}
+          searchQuery=""
+          selectedIndex={0}
+          onSelect={vi.fn()}
+          onSearchChange={vi.fn()}
+          onVisiblePathsChange={onVisible}
+        />,
+      );
+      expect(FakeIO.last).not.toBeNull();
+      expect(FakeIO.last!.observed).toHaveLength(2);
+
+      act(() => {
+        FakeIO.last!.trigger(FakeIO.last!.observed);
+        vi.advanceTimersByTime(150);
+      });
+      expect(onVisible).toHaveBeenCalledExactlyOnceWith(
+        expect.arrayContaining(["/a.jsonl", "/b.jsonl"]),
+      );
+    });
+
+    it("works without onVisiblePathsChange (no-op observer)", () => {
+      const sessions = [makeSession()];
+      expect(() =>
+        render(
+          <SessionPicker
+            sessions={sessions}
+            loading={false}
+            searchQuery=""
+            selectedIndex={0}
+            onSelect={vi.fn()}
+            onSearchChange={vi.fn()}
+          />,
+        ),
+      ).not.toThrow();
+    });
   });
 });

--- a/src/components/SessionPicker.tsx
+++ b/src/components/SessionPicker.tsx
@@ -1,5 +1,6 @@
 import { useRef, useMemo } from "react";
 import { useScrollToSelected } from "../hooks/useScrollToSelected";
+import { useVisibleSessions } from "../hooks/useVisibleSessions";
 import type { SessionInfo } from "../types";
 import { OngoingDots } from "./OngoingDots";
 import {
@@ -12,6 +13,7 @@ import {
   shortModel,
 } from "../lib/format";
 import { getModelColor } from "../lib/theme";
+import { mergeRefs } from "../lib/mergeRefs";
 import { BsClaude } from "react-icons/bs";
 import { TokensIcon, CostIcon, ForwardIcon } from "./Icons";
 
@@ -23,6 +25,12 @@ interface SessionPickerProps {
   onSelect: (session: SessionInfo) => void;
   onSearchChange: (query: string) => void;
   onSelectIndex?: (index: number) => void;
+  /**
+   * Called (debounced) with the paths of session cards currently in the viewport,
+   * and again periodically on a heartbeat while any cards remain visible. The caller
+   * uses this as a cue to refresh fresh session info.
+   */
+  onVisiblePathsChange?: (paths: string[]) => void;
 }
 
 export function SessionPicker({
@@ -33,10 +41,12 @@ export function SessionPicker({
   onSelect,
   onSearchChange,
   onSelectIndex,
+  onVisiblePathsChange,
 }: SessionPickerProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const selectedRef = useScrollToSelected(selectedIndex);
   const searchRef = useRef<HTMLInputElement>(null);
+  const registerVisible = useVisibleSessions(onVisiblePathsChange ?? noop);
 
   const dateGroups = groupByDate(sessions);
 
@@ -106,7 +116,7 @@ export function SessionPicker({
               return (
                 <div
                   key={session.path}
-                  ref={isSelected ? selectedRef : undefined}
+                  ref={mergeRefs(isSelected ? selectedRef : null, registerVisible(session.path))}
                   className={`picker__session${isSelected ? " picker__session--selected" : ""}${session.is_ongoing ? " picker__session--ongoing" : ""}`}
                   onMouseEnter={() => onSelectIndex?.(idx)}
                   onClick={() => onSelect(session)}
@@ -169,3 +179,5 @@ export function SessionPicker({
     </div>
   );
 }
+
+function noop() {}

--- a/src/hooks/usePicker.test.ts
+++ b/src/hooks/usePicker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { usePicker } from "./usePicker";
 
 const mockInvoke = vi.fn();
@@ -7,9 +7,27 @@ vi.mock("../lib/invoke", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+type Listener = (e: { payload: unknown }) => void;
+const listeners = new Map<string, Set<Listener>>();
 vi.mock("../lib/listen", () => ({
-  listen: () => Promise.resolve(() => {}),
+  listen: (event: string, cb: Listener) => {
+    let set = listeners.get(event);
+    if (!set) {
+      set = new Set();
+      listeners.set(event, set);
+    }
+    set.add(cb);
+    return Promise.resolve(() => {
+      set?.delete(cb);
+    });
+  },
 }));
+
+function emit(event: string, payload: unknown) {
+  const set = listeners.get(event);
+  if (!set) return;
+  for (const cb of set) cb({ payload });
+}
 
 const session = (path: string, ongoing: boolean) => ({
   path,
@@ -73,6 +91,36 @@ describe("usePicker", () => {
 
     // Original session unchanged
     expect(result.current.allSessions[0].is_ongoing).toBe(true);
+  });
+
+  it("picker-refresh signal re-fetches sessions via discover_sessions", async () => {
+    const initial = [session("/a.jsonl", true)];
+    const refreshed = [session("/a.jsonl", true), session("/b.jsonl", false)];
+    let call = 0;
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "discover_sessions") {
+        call += 1;
+        return Promise.resolve(call === 1 ? initial : refreshed);
+      }
+      return Promise.resolve();
+    });
+
+    const { result } = renderHook(() => usePicker());
+
+    await act(async () => {
+      await result.current.discoverSessions(["/projects"]);
+    });
+    expect(result.current.allSessions).toHaveLength(1);
+
+    // Backend now broadcasts an empty signal — the hook must re-fetch
+    // rather than treating the payload as the session list.
+    await act(async () => {
+      emit("picker-refresh", {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.allSessions).toHaveLength(2);
+    });
   });
 
   it("updateSessionOngoing skips update if value unchanged", async () => {

--- a/src/hooks/usePicker.ts
+++ b/src/hooks/usePicker.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "../lib/invoke";
 import type { SessionInfo } from "../types";
 import { useTauriEvent } from "./useTauriEvent";
@@ -16,25 +16,37 @@ export function usePicker(selectedProject: string | null = null) {
     searchQuery: "",
   });
 
-  const discoverSessions = useCallback(async (projectDirs: string[]) => {
-    setState((prev) => ({ ...prev, loading: true }));
-    try {
-      const sessions = await invoke<SessionInfo[]>("discover_sessions", {
-        projectDirs,
-      });
-      setState((prev) => ({ ...prev, sessions, loading: false }));
+  // Track the most recent project dirs so picker-refresh signals can re-fetch
+  // without needing the caller to re-supply them.
+  const projectDirsRef = useRef<string[] | null>(null);
 
-      // Start watching for new sessions
-      try {
-        await invoke<void>("watch_picker", { projectDirs });
-      } catch {
-        // watcher is optional
-      }
-    } catch (err) {
-      console.error("Failed to discover sessions:", err);
-      setState((prev) => ({ ...prev, loading: false }));
-    }
+  const fetchSessions = useCallback(async (projectDirs: string[]) => {
+    const sessions = await invoke<SessionInfo[]>("discover_sessions", {
+      projectDirs,
+    });
+    setState((prev) => ({ ...prev, sessions, loading: false }));
   }, []);
+
+  const discoverSessions = useCallback(
+    async (projectDirs: string[]) => {
+      projectDirsRef.current = projectDirs;
+      setState((prev) => ({ ...prev, loading: true }));
+      try {
+        await fetchSessions(projectDirs);
+
+        // Start watching for new sessions
+        try {
+          await invoke<void>("watch_picker", { projectDirs });
+        } catch {
+          // watcher is optional
+        }
+      } catch (err) {
+        console.error("Failed to discover sessions:", err);
+        setState((prev) => ({ ...prev, loading: false }));
+      }
+    },
+    [fetchSessions],
+  );
 
   const setSearchQuery = useCallback((query: string) => {
     setState((prev) => ({ ...prev, searchQuery: query }));
@@ -51,12 +63,14 @@ export function usePicker(selectedProject: string | null = null) {
     });
   }, []);
 
-  // Listen for picker-refresh events (backend already applies staleness)
-  useTauriEvent<{ sessions: SessionInfo[] }>("picker-refresh", (payload) => {
-    setState((prev) => ({
-      ...prev,
-      sessions: payload.sessions,
-    }));
+  // The backend emits a lightweight signal (no payload). Re-fetch via
+  // discover_sessions, which is coalesced by a short-lived server-side cache.
+  useTauriEvent<unknown>("picker-refresh", () => {
+    const dirs = projectDirsRef.current;
+    if (!dirs) return;
+    fetchSessions(dirs).catch((err) => {
+      console.error("Failed to refresh sessions:", err);
+    });
   });
 
   // Cleanup on unmount

--- a/src/hooks/usePicker.ts
+++ b/src/hooks/usePicker.ts
@@ -48,6 +48,20 @@ export function usePicker(selectedProject: string | null = null) {
     [fetchSessions],
   );
 
+  /**
+   * Re-fetch the session list using the most recently supplied project dirs.
+   * Used by the viewport-aware picker to refresh visible cards eagerly,
+   * independent of file-system events. Cheap: coalesced by the backend's
+   * sessions cache.
+   */
+  const refresh = useCallback(() => {
+    const dirs = projectDirsRef.current;
+    if (!dirs) return;
+    fetchSessions(dirs).catch((err) => {
+      console.error("Failed to refresh sessions:", err);
+    });
+  }, [fetchSessions]);
+
   const setSearchQuery = useCallback((query: string) => {
     setState((prev) => ({ ...prev, searchQuery: query }));
   }, []);
@@ -104,6 +118,7 @@ export function usePicker(selectedProject: string | null = null) {
     searchQuery: state.searchQuery,
     setSearchQuery,
     discoverSessions,
+    refresh,
     updateSessionOngoing,
   };
 }

--- a/src/hooks/useVisibleSessions.test.ts
+++ b/src/hooks/useVisibleSessions.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useVisibleSessions } from "./useVisibleSessions";
+
+type Callback = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => void;
+
+class FakeIO {
+  static last: FakeIO | null = null;
+  cb: Callback;
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = vi.fn(() => [] as IntersectionObserverEntry[]);
+  root = null;
+  rootMargin = "";
+  thresholds: number[] = [];
+
+  constructor(cb: Callback) {
+    this.cb = cb;
+    FakeIO.last = this;
+  }
+
+  /** Simulate the browser delivering visibility changes. */
+  trigger(updates: { el: Element; isIntersecting: boolean }[]) {
+    const entries = updates.map(
+      (u) =>
+        ({
+          target: u.el,
+          isIntersecting: u.isIntersecting,
+          intersectionRatio: u.isIntersecting ? 1 : 0,
+          boundingClientRect: new DOMRect(),
+          intersectionRect: new DOMRect(),
+          rootBounds: new DOMRect(),
+          time: 0,
+        }) as unknown as IntersectionObserverEntry,
+    );
+    this.cb(entries, this as unknown as IntersectionObserver);
+  }
+}
+
+beforeEach(() => {
+  FakeIO.last = null;
+  (globalThis as { IntersectionObserver: unknown }).IntersectionObserver = FakeIO;
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useVisibleSessions", () => {
+  it("creates an IntersectionObserver on mount", () => {
+    renderHook(() => useVisibleSessions(vi.fn()));
+    expect(FakeIO.last).not.toBeNull();
+  });
+
+  it("registers an element via observer.observe and tags it with data-path", () => {
+    const { result } = renderHook(() => useVisibleSessions(vi.fn()));
+    const el = document.createElement("div");
+    act(() => {
+      result.current("/a/b.jsonl")(el);
+    });
+    expect(FakeIO.last!.observe).toHaveBeenCalledWith(el);
+    expect(el.dataset.path).toBe("/a/b.jsonl");
+  });
+
+  it("fires onChange (debounced) when a card becomes visible", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useVisibleSessions(onChange, { debounceMs: 100 }));
+    const el = document.createElement("div");
+    act(() => {
+      result.current("/a/b.jsonl")(el);
+    });
+
+    act(() => {
+      FakeIO.last!.trigger([{ el, isIntersecting: true }]);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(["/a/b.jsonl"]);
+  });
+
+  it("drops a path from the visible set when it leaves the viewport", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useVisibleSessions(onChange, { debounceMs: 100 }));
+    const el = document.createElement("div");
+    act(() => {
+      result.current("/a/b.jsonl")(el);
+    });
+
+    act(() => {
+      FakeIO.last!.trigger([{ el, isIntersecting: true }]);
+      vi.advanceTimersByTime(100);
+    });
+    onChange.mockClear();
+
+    act(() => {
+      FakeIO.last!.trigger([{ el, isIntersecting: false }]);
+      vi.advanceTimersByTime(100);
+    });
+    expect(onChange).toHaveBeenCalledExactlyOnceWith([]);
+  });
+
+  it("coalesces rapid visibility changes within the debounce window", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useVisibleSessions(onChange, { debounceMs: 100 }));
+    const el1 = document.createElement("div");
+    const el2 = document.createElement("div");
+    act(() => {
+      result.current("/a.jsonl")(el1);
+      result.current("/b.jsonl")(el2);
+    });
+
+    act(() => {
+      FakeIO.last!.trigger([{ el: el1, isIntersecting: true }]);
+      vi.advanceTimersByTime(50);
+      FakeIO.last!.trigger([{ el: el2, isIntersecting: true }]);
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(
+      expect.arrayContaining(["/a.jsonl", "/b.jsonl"]),
+    );
+  });
+
+  it("re-emits visible paths on the heartbeat interval", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useVisibleSessions(onChange, { debounceMs: 50, heartbeatMs: 1000 }),
+    );
+    const el = document.createElement("div");
+    act(() => {
+      result.current("/a.jsonl")(el);
+      FakeIO.last!.trigger([{ el, isIntersecting: true }]);
+      vi.advanceTimersByTime(50);
+    });
+    onChange.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onChange).toHaveBeenCalledExactlyOnceWith(["/a.jsonl"]);
+  });
+
+  it("skips the heartbeat when no cards are visible", () => {
+    const onChange = vi.fn();
+    renderHook(() => useVisibleSessions(onChange, { heartbeatMs: 1000 }));
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const { unmount } = renderHook(() => useVisibleSessions(vi.fn()));
+    const observer = FakeIO.last!;
+    unmount();
+    expect(observer.disconnect).toHaveBeenCalled();
+  });
+
+  it("unobserves the previous element when a path's ref changes", () => {
+    const { result } = renderHook(() => useVisibleSessions(vi.fn()));
+    const el1 = document.createElement("div");
+    const el2 = document.createElement("div");
+    const reg = result.current("/a.jsonl");
+
+    act(() => {
+      reg(el1);
+      reg(el2);
+    });
+
+    expect(FakeIO.last!.unobserve).toHaveBeenCalledWith(el1);
+    expect(FakeIO.last!.observe).toHaveBeenCalledWith(el2);
+  });
+});

--- a/src/hooks/useVisibleSessions.ts
+++ b/src/hooks/useVisibleSessions.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Options {
+  /** Time to wait after a visibility change before firing `onChange` (ms). */
+  debounceMs?: number;
+  /** Periodic re-emit interval while visible set is non-empty (ms). 0 disables. */
+  heartbeatMs?: number;
+}
+
+/**
+ * Track which session cards are visible in the picker viewport via
+ * IntersectionObserver. Returns a `register(path)` factory that produces a
+ * callback ref to attach to each card.
+ *
+ * `onChange` fires (debounced) when the visible set changes, and again on a
+ * periodic heartbeat while any cards remain visible — that's the cue the
+ * caller uses to re-fetch fresh session info for what the user is looking at.
+ *
+ * Implementation note: the observer is created lazily in a `useState`
+ * initializer so it exists during the commit phase when card refs are first
+ * attached, not later in a `useEffect`. Otherwise the very first batch of
+ * cards never gets observed.
+ */
+export function useVisibleSessions(
+  onChange: (paths: string[]) => void,
+  { debounceMs = 150, heartbeatMs = 2000 }: Options = {},
+) {
+  const visibleRef = useRef<Set<string>>(new Set());
+  const elsRef = useRef<Map<string, Element>>(new Map());
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handlerRef = useRef(onChange);
+  handlerRef.current = onChange;
+  const debounceMsRef = useRef(debounceMs);
+  debounceMsRef.current = debounceMs;
+
+  const [observer] = useState<IntersectionObserver | null>(() => {
+    if (typeof IntersectionObserver === "undefined") return null;
+    return new IntersectionObserver((entries) => {
+      let changed = false;
+      for (const entry of entries) {
+        const path = (entry.target as HTMLElement).dataset.path;
+        if (!path) continue;
+        if (entry.isIntersecting) {
+          if (!visibleRef.current.has(path)) {
+            visibleRef.current.add(path);
+            changed = true;
+          }
+        } else if (visibleRef.current.has(path)) {
+          visibleRef.current.delete(path);
+          changed = true;
+        }
+      }
+      if (!changed) return;
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = setTimeout(() => {
+        handlerRef.current(Array.from(visibleRef.current));
+      }, debounceMsRef.current);
+    });
+  });
+
+  // Cleanup on unmount. Refs go out of scope with the hook, no need to clear them.
+  useEffect(() => {
+    const timerRef = debounceTimerRef;
+    return () => {
+      observer?.disconnect();
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [observer]);
+
+  // Heartbeat: re-emit visible set periodically so callers can refresh stats.
+  useEffect(() => {
+    if (heartbeatMs <= 0) return;
+    const id = setInterval(() => {
+      if (visibleRef.current.size > 0) {
+        handlerRef.current(Array.from(visibleRef.current));
+      }
+    }, heartbeatMs);
+    return () => clearInterval(id);
+  }, [heartbeatMs]);
+
+  /** Returns a callback ref for a given session path. */
+  const register = useCallback(
+    (path: string) => {
+      return (el: HTMLElement | null) => {
+        if (!observer) return;
+        const prev = elsRef.current.get(path);
+        if (prev && prev !== el) {
+          observer.unobserve(prev);
+          visibleRef.current.delete(path);
+          elsRef.current.delete(path);
+        }
+        if (el) {
+          el.dataset.path = path;
+          observer.observe(el);
+          elsRef.current.set(path, el);
+        }
+      };
+    },
+    [observer],
+  );
+
+  return register;
+}

--- a/src/lib/mergeRefs.test.ts
+++ b/src/lib/mergeRefs.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { createRef } from "react";
+import { mergeRefs } from "./mergeRefs";
+
+describe("mergeRefs", () => {
+  it("writes to a ref object and calls a callback ref with the same element", () => {
+    const objectRef = createRef<HTMLDivElement>();
+    const callbackRef = vi.fn();
+    const el = document.createElement("div");
+
+    mergeRefs(objectRef, callbackRef)(el);
+
+    expect(objectRef.current).toBe(el);
+    expect(callbackRef).toHaveBeenCalledWith(el);
+  });
+
+  it("passes null through to both refs on unmount", () => {
+    const objectRef = createRef<HTMLDivElement>();
+    const callbackRef = vi.fn();
+
+    const merged = mergeRefs(objectRef, callbackRef);
+    merged(document.createElement("div"));
+    merged(null);
+
+    expect(objectRef.current).toBeNull();
+    expect(callbackRef).toHaveBeenLastCalledWith(null);
+  });
+
+  it("ignores nullish refs in the list", () => {
+    const callbackRef = vi.fn();
+    const el = document.createElement("div");
+
+    mergeRefs(null, undefined, callbackRef)(el);
+
+    expect(callbackRef).toHaveBeenCalledWith(el);
+  });
+});

--- a/src/lib/mergeRefs.ts
+++ b/src/lib/mergeRefs.ts
@@ -1,0 +1,15 @@
+import type { Ref, MutableRefObject } from "react";
+
+/** Combine multiple refs into a single callback ref. */
+export function mergeRefs<T>(...refs: (Ref<T> | null | undefined)[]): (el: T | null) => void {
+  return (el) => {
+    for (const ref of refs) {
+      if (!ref) continue;
+      if (typeof ref === "function") {
+        ref(el);
+      } else {
+        (ref as MutableRefObject<T | null>).current = el;
+      }
+    }
+  };
+}

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-trace-tui",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Terminal UI for Claude Code Trace",
   "bin": {
     "cctrace-tui": "./dist/tui/src/cli.js"

--- a/tui/src/App.tsx
+++ b/tui/src/App.tsx
@@ -48,6 +48,7 @@ export function App() {
   const [sidebarFocused, setSidebarFocused] = useState(false);
   const [sidebarHighlight, setSidebarHighlight] = useState(0);
   const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
+  const projectDirsRef = useRef<string[] | null>(null);
 
   const toggleCollapse = useCallback((key: string) => {
     setCollapsedKeys((prev) => {
@@ -80,6 +81,7 @@ export function App() {
         if (cancelled) return;
         setAllSessions(list);
         setPickerLoading(false);
+        projectDirsRef.current = d;
         await api.watchPicker(d);
       } catch (e) {
         if (cancelled) return;
@@ -98,10 +100,17 @@ export function App() {
     };
   }, []);
 
-  useSSE<{ sessions: SessionInfo[] }>(
-    "picker-update",
-    useCallback((payload) => {
-      if (payload.sessions) setAllSessions(payload.sessions);
+  // The backend emits "picker-refresh" with an empty payload; re-fetch the
+  // session list using the dirs we discovered earlier.
+  useSSE<unknown>(
+    "picker-refresh",
+    useCallback(() => {
+      const dirs = projectDirsRef.current;
+      if (!dirs) return;
+      api
+        .discoverSessions(dirs)
+        .then((list) => setAllSessions(list))
+        .catch(() => {});
     }, []),
   );
 


### PR DESCRIPTION
The TUI subscribed to 'picker-update' and destructured payload.sessions,
but the backend emits 'picker-refresh' with an empty payload (watcher.rs:340).
The handler never fired and the TUI picker never auto-updated.

Switch to 'picker-refresh' and re-fetch via api.discoverSessions(dirs) — same
pattern the web frontend uses in src/hooks/usePicker.ts.