### PR TITLE
feat(parser): capture background_tasks and session_crons from v2.1.145+ Stop/SubagentStop hooks

### DIFF
--- a/specs/01-parser-pipeline.md
+++ b/specs/01-parser-pipeline.md
@@ -67,19 +67,21 @@ Each JSONL line is decoded into an `Entry` struct that mirrors the raw Claude Co
 
 ### Key Fields
 
-| Field              | Description                                                     |
-| ------------------ | --------------------------------------------------------------- |
-| `uuid`             | Unique message identifier                                       |
-| `entry_type`       | Discriminant: `user`, `assistant`, `system`, `hook_event`, etc. |
-| `role`             | Same as `entry_type` for most messages                          |
-| `content`          | Message body (string or content-block array)                    |
-| `model`            | Model string (assistant messages only)                          |
-| `subtype`          | Hook subtype: `PreToolUse`, `PostToolUse`, `Stop`, …            |
-| `hookEvent`        | Hook event name                                                 |
-| `isCompactSummary` | Compaction boundary marker                                      |
-| `away_summary`     | Session-recap text                                              |
-| `forkedFrom`       | Pre-v2.1.118 fork reference                                     |
-| `tool_use_result`  | JSON object for tool results                                    |
+| Field              | Description                                                              |
+| ------------------ | ------------------------------------------------------------------------ |
+| `uuid`             | Unique message identifier                                                |
+| `entry_type`       | Discriminant: `user`, `assistant`, `system`, `hook_event`, etc.          |
+| `role`             | Same as `entry_type` for most messages                                   |
+| `content`          | Message body (string or content-block array)                             |
+| `model`            | Model string (assistant messages only)                                   |
+| `subtype`          | Hook subtype: `PreToolUse`, `PostToolUse`, `Stop`, …                     |
+| `hookEvent`        | Hook event name                                                          |
+| `isCompactSummary` | Compaction boundary marker                                               |
+| `away_summary`     | Session-recap text                                                       |
+| `forkedFrom`       | Pre-v2.1.118 fork reference                                              |
+| `tool_use_result`  | JSON object for tool results                                             |
+| `background_tasks` | v2.1.145+: running background task descriptors (Stop/SubagentStop hooks) |
+| `session_crons`    | v2.1.145+: registered session cron jobs (Stop/SubagentStop hooks)        |
 
 ```mermaid
 classDiagram

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -111,6 +111,13 @@ pub struct Entry {
     // notifications, window titles, or bells without a controlling terminal.
     #[serde(default, rename = "terminalSequence")]
     pub terminal_sequence: Option<String>,
+    // Present in Stop and SubagentStop hook input payloads (v2.1.145+). Claude Code includes
+    // currently-running background task descriptors and session-scoped cron jobs so hooks can
+    // inspect or block on them before the session exits.
+    #[serde(default, rename = "background_tasks")]
+    pub background_tasks: Option<Value>,
+    #[serde(default, rename = "session_crons")]
+    pub session_crons: Option<Value>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -619,6 +626,96 @@ mod tests {
             entry.terminal_sequence.is_none(),
             "terminalSequence must be None when absent"
         );
+    }
+
+    // --- Issue #106: v2.1.145+ Stop/SubagentStop gain background_tasks and session_crons ---
+
+    #[test]
+    fn parse_entry_captures_background_tasks_and_session_crons_v2_1_145() {
+        // v2.1.145+: Stop and SubagentStop hook input payloads include background_tasks
+        // (array of running task descriptors) and session_crons (array of registered cron jobs).
+        // Both must be captured as Value so callers can inspect them.
+        let line = json!({
+            "type": "system",
+            "subtype": "hook_progress",
+            "uuid": "stop-hook-uuid-145",
+            "timestamp": "2026-05-19T10:00:00Z",
+            "hookEvent": "Stop",
+            "hookName": "on-stop",
+            "background_tasks": [{"id": "task-1", "description": "running bg job"}],
+            "session_crons": [{"id": "cron-1", "schedule": "*/5 * * * *"}]
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry =
+            parse_entry(&bytes).expect("must parse Stop hook entry with new v2.1.145 fields");
+
+        let tasks = entry
+            .background_tasks
+            .expect("background_tasks must be captured");
+        assert!(tasks.is_array(), "background_tasks must be an array");
+        assert_eq!(tasks.as_array().unwrap().len(), 1);
+        assert_eq!(tasks[0].get("id").and_then(|v| v.as_str()), Some("task-1"));
+
+        let crons = entry.session_crons.expect("session_crons must be captured");
+        assert!(crons.is_array(), "session_crons must be an array");
+        assert_eq!(crons.as_array().unwrap().len(), 1);
+        assert_eq!(
+            crons[0].get("schedule").and_then(|v| v.as_str()),
+            Some("*/5 * * * *")
+        );
+    }
+
+    #[test]
+    fn parse_entry_background_tasks_and_session_crons_default_to_none_when_absent() {
+        // Stop/SubagentStop hook entries from before v2.1.145 have no background_tasks or
+        // session_crons fields — both must default to None.
+        let line = json!({
+            "type": "system",
+            "subtype": "hook_progress",
+            "uuid": "stop-hook-uuid-old",
+            "timestamp": "2026-05-01T10:00:00Z",
+            "hookEvent": "Stop",
+            "hookName": "on-stop"
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse old Stop hook entry");
+        assert!(
+            entry.background_tasks.is_none(),
+            "background_tasks must be None when absent"
+        );
+        assert!(
+            entry.session_crons.is_none(),
+            "session_crons must be None when absent"
+        );
+    }
+
+    #[test]
+    fn parse_entry_subagent_stop_with_background_tasks_and_session_crons() {
+        // SubagentStop hook input also gains these fields in v2.1.145+.
+        let line = json!({
+            "type": "system",
+            "subtype": "hook_progress",
+            "uuid": "subagent-stop-uuid-145",
+            "timestamp": "2026-05-19T11:00:00Z",
+            "hookEvent": "SubagentStop",
+            "hookName": "on-subagent-stop",
+            "background_tasks": [],
+            "session_crons": [{"id": "c1"}, {"id": "c2"}]
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry =
+            parse_entry(&bytes).expect("must parse SubagentStop hook entry with new fields");
+
+        let tasks = entry
+            .background_tasks
+            .expect("background_tasks must be captured");
+        assert!(
+            tasks.as_array().unwrap().is_empty(),
+            "empty array must be preserved"
+        );
+
+        let crons = entry.session_crons.expect("session_crons must be captured");
+        assert_eq!(crons.as_array().unwrap().len(), 2);
     }
 
     // --- Issue #85: lone UTF-16 surrogate sanitization ---


### PR DESCRIPTION
## Summary

Adds `background_tasks` and `session_crons` as optional fields on the `Entry` struct to handle the new Stop/SubagentStop hook payload fields introduced in Claude Code v2.1.145.

## Problem

Claude Code v2.1.145 (May 19, 2026) added two new fields to `Stop` and `SubagentStop` hook input payloads:

- `background_tasks` — array of currently-running background task descriptors
- `session_crons` — array of cron jobs registered for the session

Without explicit struct fields, serde silently skips these arrays on deserialization. While this does not cause parser crashes (no `deny_unknown_fields` is in use), the data is lost and future code cannot access it. Declaring the fields explicitly captures the payloads and makes the compat intent clear.

## Changes

- **`src-tauri/src/parser/entry.rs`**: Added `background_tasks: Option<Value>` and `session_crons: Option<Value>` to `Entry`, both with `#[serde(default)]` so pre-v2.1.145 entries (where the fields are absent) default to `None` without error. Added 3 tests covering: Stop hook with both fields populated, pre-v2.1.145 Stop hook with neither field present, and SubagentStop hook with an empty `background_tasks` array and a multi-item `session_crons` array.
- **`specs/01-parser-pipeline.md`**: Added the two new fields to the Key Fields table.

## Testing

All 400 Rust tests pass (`cargo test`). All 349 frontend tests pass (`vitest run`). `cargo clippy -- -D warnings` reports no issues.

Fixes #106
