### PR TITLE
[#125]: Compat: capture hookSpecificOutput.additionalContext for Stop/SubagentStop hooks (v2.1.163)

### DIFF
--- a/specs/01-parser-pipeline.md
+++ b/specs/01-parser-pipeline.md
@@ -67,25 +67,26 @@ Each JSONL line is decoded into an `Entry` struct that mirrors the raw Claude Co
 
 ### Key Fields
 
-| Field              | Description                                                              |
-| ------------------ | ------------------------------------------------------------------------ |
-| `uuid`             | Unique message identifier                                                |
-| `entry_type`       | Discriminant: `user`, `assistant`, `system`, `hook_event`, etc.          |
-| `role`             | Same as `entry_type` for most messages                                   |
-| `content`          | Message body (string or content-block array)                             |
-| `model`            | Model string (assistant messages only)                                   |
-| `subtype`          | Hook subtype: `PreToolUse`, `PostToolUse`, `Stop`, …                     |
-| `hookEvent`        | Hook event name                                                          |
-| `isCompactSummary` | Compaction boundary marker                                               |
-| `away_summary`     | Session-recap text                                                       |
-| `forkedFrom`       | Pre-v2.1.118 fork reference                                              |
-| `tool_use_result`  | JSON object for tool results                                             |
-| `background_tasks` | v2.1.145+: running background task descriptors (Stop/SubagentStop hooks) |
-| `session_crons`    | v2.1.145+: registered session cron jobs (Stop/SubagentStop hooks)        |
-| `workflowId`       | v2.1.154+: workflow identifier on lifecycle entries                      |
-| `workflowName`     | v2.1.154+: workflow name on lifecycle entries                            |
-| `workflowRunUrl`   | v2.1.154+: workflow run URL on lifecycle entries                         |
-| `workflowStatus`   | v2.1.154+: workflow run status on lifecycle entries                      |
+| Field                | Description                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `uuid`               | Unique message identifier                                                                                          |
+| `entry_type`         | Discriminant: `user`, `assistant`, `system`, `hook_event`, etc.                                                    |
+| `role`               | Same as `entry_type` for most messages                                                                             |
+| `content`            | Message body (string or content-block array)                                                                       |
+| `model`              | Model string (assistant messages only)                                                                             |
+| `subtype`            | Hook subtype: `PreToolUse`, `PostToolUse`, `Stop`, …                                                               |
+| `hookEvent`          | Hook event name                                                                                                    |
+| `isCompactSummary`   | Compaction boundary marker                                                                                         |
+| `away_summary`       | Session-recap text                                                                                                 |
+| `forkedFrom`         | Pre-v2.1.118 fork reference                                                                                        |
+| `tool_use_result`    | JSON object for tool results                                                                                       |
+| `background_tasks`   | v2.1.145+: running background task descriptors (Stop/SubagentStop hooks)                                           |
+| `session_crons`      | v2.1.145+: registered session cron jobs (Stop/SubagentStop hooks)                                                  |
+| `hookSpecificOutput` | v2.1.163+: hook result payload; `additionalContext` sub-field carries feedback text injected back into the session |
+| `workflowId`         | v2.1.154+: workflow identifier on lifecycle entries                                                                |
+| `workflowName`       | v2.1.154+: workflow name on lifecycle entries                                                                      |
+| `workflowRunUrl`     | v2.1.154+: workflow run URL on lifecycle entries                                                                   |
+| `workflowStatus`     | v2.1.154+: workflow run status on lifecycle entries                                                                |
 
 ```mermaid
 classDiagram

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -187,12 +187,14 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     .get("command")
                     .map(resolve_hook_output)
                     .unwrap_or_default();
+                // v2.1.163+: hookSpecificOutput may be nested inside data for progress entries.
+                let metadata = data.get("hookSpecificOutput").cloned();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event,
                     hook_name,
                     command,
-                    metadata: None,
+                    metadata,
                 }));
             }
         }
@@ -224,32 +226,38 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
+                // v2.1.163+: hookSpecificOutput carries additionalContext from the hook result.
+                let metadata = e.hook_specific_output.clone();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event: "Stop".to_string(),
                     hook_name,
                     command: String::new(),
-                    metadata: None,
+                    metadata,
                 }));
             }
             // hook_progress: written in verbose/stream-json mode for mid-session hooks.
             "hook_progress" => {
+                // v2.1.163+: hookSpecificOutput carries additionalContext from the hook result.
+                let metadata = e.hook_specific_output.clone();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event: e.hook_event.clone(),
                     hook_name: e.hook_name.clone(),
                     command: String::new(),
-                    metadata: None,
+                    metadata,
                 }));
             }
             // hookEvent present on any system entry (forward-compat for future hook types).
             _ if !e.hook_event.is_empty() => {
+                // v2.1.163+: hookSpecificOutput carries additionalContext from the hook result.
+                let metadata = e.hook_specific_output.clone();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event: e.hook_event.clone(),
                     hook_name: e.hook_name.clone(),
                     command: String::new(),
-                    metadata: None,
+                    metadata,
                 }));
             }
             _ => {}
@@ -1918,6 +1926,166 @@ mod tests {
             classify(e).is_none(),
             "workflow-start with data fields must still be dropped"
         );
+    }
+
+    // --- Issue #125: v2.1.163+ hookSpecificOutput.additionalContext is surfaced in metadata ---
+
+    #[test]
+    fn classify_stop_hook_summary_with_hook_specific_output_sets_metadata() {
+        // v2.1.163+: stop_hook_summary entries carrying hookSpecificOutput must expose it as
+        // HookMsg.metadata so the frontend can render additionalContext in the hook details panel.
+        let e = Entry {
+            entry_type: "system".to_string(),
+            uuid: "uuid-stop-with-context".to_string(),
+            timestamp: "2026-06-04T10:00:00Z".to_string(),
+            subtype: "stop_hook_summary".to_string(),
+            hook_count: 1,
+            hook_infos: Some(json!([{"command": "~/.claude/hooks/stop.sh", "durationMs": 42}])),
+            hook_specific_output: Some(json!({"additionalContext": "All checks passed."})),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "Stop");
+                let meta = h
+                    .metadata
+                    .expect("hookSpecificOutput must be set as metadata");
+                assert_eq!(
+                    meta.get("additionalContext").and_then(|v| v.as_str()),
+                    Some("All checks passed."),
+                    "additionalContext must be accessible from metadata"
+                );
+            }
+            other => panic!(
+                "Expected Hook for stop_hook_summary with hookSpecificOutput, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_stop_hook_summary_without_hook_specific_output_has_none_metadata() {
+        // Pre-v2.1.163 stop_hook_summary entries without hookSpecificOutput must still produce
+        // HookMsg with metadata: None — no regression from the old behaviour.
+        let e = Entry {
+            entry_type: "system".to_string(),
+            uuid: "uuid-stop-no-context".to_string(),
+            timestamp: "2026-06-04T10:00:00Z".to_string(),
+            subtype: "stop_hook_summary".to_string(),
+            hook_count: 1,
+            hook_infos: Some(json!([{"command": "~/.claude/hooks/stop.sh", "durationMs": 10}])),
+            hook_specific_output: None,
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert!(
+                    h.metadata.is_none(),
+                    "metadata must be None when hookSpecificOutput is absent"
+                );
+            }
+            other => panic!("Expected Hook for stop_hook_summary, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_system_hook_progress_with_hook_specific_output_sets_metadata() {
+        // v2.1.163+: system/hook_progress entries for Stop/SubagentStop may carry
+        // hookSpecificOutput — it must flow through to HookMsg.metadata.
+        let e = Entry {
+            entry_type: "system".to_string(),
+            uuid: "uuid-sys-hook-context".to_string(),
+            timestamp: "2026-06-04T11:00:00Z".to_string(),
+            subtype: "hook_progress".to_string(),
+            hook_event: "SubagentStop".to_string(),
+            hook_name: "on-subagent-stop".to_string(),
+            hook_specific_output: Some(
+                json!({"additionalContext": "Subagent completed successfully."}),
+            ),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "SubagentStop");
+                let meta = h
+                    .metadata
+                    .expect("hookSpecificOutput must be set as metadata");
+                assert_eq!(
+                    meta.get("additionalContext").and_then(|v| v.as_str()),
+                    Some("Subagent completed successfully.")
+                );
+            }
+            other => panic!(
+                "Expected Hook for system/hook_progress with hookSpecificOutput, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_progress_hook_entry_with_hook_specific_output_in_data_sets_metadata() {
+        // v2.1.163+: progress-type hook entries may carry hookSpecificOutput nested inside
+        // data rather than at the top level of the entry. It must be extracted and set as
+        // HookMsg.metadata.
+        let e = Entry {
+            entry_type: "progress".to_string(),
+            uuid: "uuid-progress-hook-context".to_string(),
+            timestamp: "2026-06-04T12:00:00Z".to_string(),
+            data: Some(json!({
+                "type": "hook_progress",
+                "hookEvent": "Stop",
+                "hookName": "on-stop",
+                "command": "~/.claude/hooks/stop.sh",
+                "hookSpecificOutput": {
+                    "additionalContext": "Git status is clean."
+                }
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "Stop");
+                assert_eq!(h.hook_name, "on-stop");
+                let meta = h
+                    .metadata
+                    .expect("hookSpecificOutput in data must be set as metadata");
+                assert_eq!(
+                    meta.get("additionalContext").and_then(|v| v.as_str()),
+                    Some("Git status is clean.")
+                );
+            }
+            other => panic!(
+                "Expected Hook for progress/hook_progress with hookSpecificOutput in data, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_progress_hook_entry_without_hook_specific_output_has_none_metadata() {
+        // Pre-v2.1.163 progress hook entries without hookSpecificOutput in data must produce
+        // HookMsg with metadata: None — no regression from old behaviour.
+        let e = Entry {
+            entry_type: "progress".to_string(),
+            uuid: "uuid-progress-hook-old".to_string(),
+            timestamp: "2026-05-01T10:00:00Z".to_string(),
+            data: Some(json!({
+                "type": "hook_progress",
+                "hookEvent": "Stop",
+                "hookName": "on-stop",
+                "command": "~/.claude/hooks/stop.sh"
+            })),
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert!(
+                    h.metadata.is_none(),
+                    "metadata must be None when hookSpecificOutput is absent from data"
+                );
+            }
+            other => panic!("Expected Hook for old progress hook entry, got {:?}", other),
+        }
     }
 
     // --- Issue #37: document content block is recognised as user content ---

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -122,6 +122,12 @@ pub struct Entry {
     pub background_tasks: Option<Value>,
     #[serde(default, rename = "session_crons")]
     pub session_crons: Option<Value>,
+    // Present in Stop and SubagentStop hook result entries (v2.1.163+). When a hook returns
+    // hookSpecificOutput.additionalContext, Claude Code persists the payload at the top level
+    // so the feedback text can be injected back into the session without being labeled a hook
+    // error.
+    #[serde(default, rename = "hookSpecificOutput")]
+    pub hook_specific_output: Option<Value>,
     // Present in workflow lifecycle entries (v2.1.154+). Claude Code's dynamic workflow
     // system writes workflow-start, workflow-progress, workflow-complete, workflow-cancelled,
     // and workflow-error entries carrying these fields.
@@ -788,6 +794,85 @@ mod tests {
         assert!(
             entry.session_crons.is_none(),
             "session_crons must be None when absent"
+        );
+    }
+
+    // --- Issue #125: v2.1.163+ hookSpecificOutput.additionalContext ---
+
+    #[test]
+    fn parse_entry_captures_hook_specific_output_v2_1_163() {
+        // v2.1.163+: Stop and SubagentStop hooks can return hookSpecificOutput.additionalContext
+        // to inject feedback back into the session. The field must be captured as a Value so
+        // callers can inspect additionalContext and any future sub-fields.
+        let line = json!({
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "uuid": "stop-hook-output-uuid",
+            "timestamp": "2026-06-04T10:00:00Z",
+            "hookCount": 1,
+            "hookInfos": [{"command": "~/.claude/hooks/stop.sh", "durationMs": 42}],
+            "hookSpecificOutput": {
+                "additionalContext": "All checks passed. You may continue."
+            }
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes)
+            .expect("must parse stop_hook_summary entry with hookSpecificOutput");
+        assert_eq!(entry.subtype, "stop_hook_summary");
+        let hso = entry
+            .hook_specific_output
+            .expect("hookSpecificOutput must be captured");
+        assert_eq!(
+            hso.get("additionalContext").and_then(|v| v.as_str()),
+            Some("All checks passed. You may continue."),
+            "additionalContext must be accessible from hookSpecificOutput"
+        );
+    }
+
+    #[test]
+    fn parse_entry_hook_specific_output_defaults_to_none_when_absent() {
+        // Entries from before v2.1.163 (or hooks that don't return feedback) have no
+        // hookSpecificOutput field — must default to None.
+        let line = json!({
+            "type": "system",
+            "subtype": "stop_hook_summary",
+            "uuid": "stop-hook-old-uuid",
+            "timestamp": "2026-05-01T10:00:00Z",
+            "hookCount": 1,
+            "hookInfos": [{"command": "~/.claude/hooks/stop.sh", "durationMs": 10}]
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse old stop_hook_summary entry");
+        assert!(
+            entry.hook_specific_output.is_none(),
+            "hookSpecificOutput must be None when absent"
+        );
+    }
+
+    #[test]
+    fn parse_entry_hook_specific_output_on_hook_progress_entry() {
+        // hookSpecificOutput may also appear on system/hook_progress entries for SubagentStop.
+        let line = json!({
+            "type": "system",
+            "subtype": "hook_progress",
+            "uuid": "subagent-stop-output-uuid",
+            "timestamp": "2026-06-04T11:00:00Z",
+            "hookEvent": "SubagentStop",
+            "hookName": "on-subagent-stop",
+            "hookSpecificOutput": {
+                "additionalContext": "Subagent completed successfully."
+            }
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes)
+            .expect("must parse SubagentStop hook_progress with hookSpecificOutput");
+        assert_eq!(entry.hook_event, "SubagentStop");
+        let hso = entry
+            .hook_specific_output
+            .expect("hookSpecificOutput must be captured for SubagentStop hook_progress");
+        assert_eq!(
+            hso.get("additionalContext").and_then(|v| v.as_str()),
+            Some("Subagent completed successfully.")
         );
     }
 


### PR DESCRIPTION
## Summary

Adds compatibility support for the `hookSpecificOutput.additionalContext` field introduced in Claude Code v2.1.163. Stop and SubagentStop hooks can now return this field to inject feedback into the session without being labeled a hook error — previously the text was silently dropped from the transcript view.

## Changes

### `src-tauri/src/parser/entry.rs`
- Added `hook_specific_output: Option<Value>` field to `Entry` struct, deserialized from the `hookSpecificOutput` JSON key
- 3 tests covering: stop_hook_summary entry parsing, absent-field defaulting to None, SubagentStop hook_progress entry parsing

### `src-tauri/src/parser/classify.rs`
- `stop_hook_summary` arm: passes `e.hook_specific_output` as `HookMsg.metadata` (was always `None`)
- `system/hook_progress` arm: same
- Generic `_ if !e.hook_event.is_empty()` arm: same
- `progress` hook entries: extracts `data["hookSpecificOutput"]` as metadata
- 5 tests covering the four entry paths plus no-regression for absent field

### `specs/01-parser-pipeline.md`
- Added `hookSpecificOutput` row to the Entry fields table

## How it surfaces in the UI

`hook_specific_output` flows through `HookMsg.metadata` to `FrontendDisplayItem.hook_metadata` (pretty-printed JSON), rendered by the existing Metadata section in `DetailItem.tsx` — no frontend changes required.

attachment-based hooks (PreToolUse/PostToolUse/etc.) already captured their full attachment object as metadata; this change only affects the three non-attachment hook paths that previously had `metadata: None`.

Fixes #125
