### PR TITLE
[#124]: skip empty-content assistant stubs from fallbackModel retries (v2.1.166)

### DIFF
--- a/specs/01-parser-pipeline.md
+++ b/specs/01-parser-pipeline.md
@@ -129,15 +129,16 @@ flowchart TD
 
 ### Version-Compatibility Normalisations
 
-| Issue                                                                                     | Version      | Fix                                                                                                                                              |
-| ----------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Tool inputs JSON-encoded as strings                                                       | pre-v2.1.92  | Deserialise inner string → object                                                                                                                |
-| Fork reference in `forkedFrom` field                                                      | pre-v2.1.118 | Map to synthetic `fork-context-ref`                                                                                                              |
-| Hook payload in content text                                                              | all          | Regex extraction of teammate ID, color, protocol                                                                                                 |
-| Large outputs written to disk                                                             | v2.1.89+     | `RE_PERSISTED_OUTPUT_PATH` → file read                                                                                                           |
-| Dynamic Workflow lifecycle types                                                          | v2.1.154+    | Add to `NOISE_ENTRY_TYPES`; capture workflow fields on `Entry`                                                                                   |
-| `cache_creation_input_tokens` always 0 when API uses nested `cache_creation.input_tokens` | v2.1.152+    | `cache_creation_from_value()` reads both flat and nested forms; takes max                                                                        |
-| `MessageDisplay` hook event name                                                          | v2.1.152+    | `hook_event` stored as `String` — no enum; catch-all presence-of-hookEvent checks in classify handle any future event name without a code change |
+| Issue                                                                                     | Version      | Fix                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Tool inputs JSON-encoded as strings                                                       | pre-v2.1.92  | Deserialise inner string → object                                                                                                                                |
+| Fork reference in `forkedFrom` field                                                      | pre-v2.1.118 | Map to synthetic `fork-context-ref`                                                                                                                              |
+| Hook payload in content text                                                              | all          | Regex extraction of teammate ID, color, protocol                                                                                                                 |
+| Large outputs written to disk                                                             | v2.1.89+     | `RE_PERSISTED_OUTPUT_PATH` → file read                                                                                                                           |
+| Dynamic Workflow lifecycle types                                                          | v2.1.154+    | Add to `NOISE_ENTRY_TYPES`; capture workflow fields on `Entry`                                                                                                   |
+| `cache_creation_input_tokens` always 0 when API uses nested `cache_creation.input_tokens` | v2.1.152+    | `cache_creation_from_value()` reads both flat and nested forms; takes max                                                                                        |
+| `MessageDisplay` hook event name                                                          | v2.1.152+    | `hook_event` stored as `String` — no enum; catch-all presence-of-hookEvent checks in classify handle any future event name without a code change                 |
+| `fallbackModel` retry writes null/empty stub assistant entry before successful response   | v2.1.166+    | `classify()` returns `None` for assistant entries with `null` or empty `content` array; fallback response with real content passes through with its own model ID |
 
 ---
 

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -446,6 +446,17 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
 
     // AI message (assistant).
     if e.entry_type == "assistant" {
+        // v2.1.166+: when fallbackModel retries a failed turn, Claude Code writes a stub assistant
+        // entry with null or empty content for the failed primary attempt before writing the
+        // successful fallback response. Skip these stubs to avoid emitting empty AI turns.
+        let content_is_empty = match &e.message.content {
+            None => true,
+            Some(Value::Array(arr)) => arr.is_empty(),
+            _ => false,
+        };
+        if content_is_empty {
+            return None;
+        }
         let (thinking, tool_calls, blocks) = extract_assistant_details(&e.message.content);
         let stop_reason = e.message.stop_reason.clone().unwrap_or_default();
         return Some(ClassifiedMsg::AI(AIMsg {
@@ -838,6 +849,57 @@ mod tests {
         let mut e = make_entry("assistant", Some(json!([{"type": "text", "text": "hi"}])));
         e.message.model = "<synthetic>".to_string();
         assert!(classify(e).is_none());
+    }
+
+    // --- Issue #124: v2.1.166+ fallbackModel retry stub entries ---
+
+    #[test]
+    fn classify_returns_none_for_assistant_with_null_content() {
+        // v2.1.166+: when the primary model fails and fallbackModel retries the turn, Claude Code
+        // writes a stub assistant entry with null content for the failed attempt. classify must
+        // return None so no empty AI turn appears in the conversation display.
+        let mut e = make_entry("assistant", None);
+        e.message.model = "claude-opus-4-7".to_string();
+        assert!(
+            classify(e).is_none(),
+            "assistant entry with null content must be dropped (fallback retry stub)"
+        );
+    }
+
+    #[test]
+    fn classify_returns_none_for_assistant_with_empty_content_array() {
+        // v2.1.166+: the failed primary attempt may also carry an empty content array []
+        // instead of null. classify must return None in this case too.
+        let mut e = make_entry("assistant", Some(json!([])));
+        e.message.model = "claude-opus-4-7".to_string();
+        assert!(
+            classify(e).is_none(),
+            "assistant entry with empty content array must be dropped (fallback retry stub)"
+        );
+    }
+
+    #[test]
+    fn classify_returns_ai_for_fallback_model_assistant_with_real_content() {
+        // v2.1.166+: the successful fallback response has a different model ID but real content.
+        // classify must emit an AIMsg with the fallback model's ID so per-turn model display
+        // is accurate — not the session's primary model.
+        let content = json!([{"type": "text", "text": "Here is the answer"}]);
+        let mut e = make_entry("assistant", Some(content));
+        e.message.model = "claude-haiku-4-5".to_string();
+        e.message.stop_reason = Some("end_turn".to_string());
+        match classify(e) {
+            Some(ClassifiedMsg::AI(ai)) => {
+                assert_eq!(
+                    ai.model, "claude-haiku-4-5",
+                    "fallback model must be preserved per-entry, not overridden by primary model"
+                );
+                assert!(ai.text.contains("Here is the answer"));
+            }
+            other => panic!(
+                "Expected AI for fallback response with content, got {:?}",
+                other
+            ),
+        }
     }
 
     #[test]

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -2034,6 +2034,129 @@ mod tests {
         }
     }
 
+    // --- Issue #124: v2.1.166+ fallbackModel retry stubs (empty-content assistant entries) ---
+
+    #[test]
+    fn classify_drops_assistant_with_null_content() {
+        // v2.1.166+: when the primary model fails before emitting any content, Claude Code
+        // writes an assistant stub with message.content:null before the fallback response.
+        // classify must return None for this stub so no blank AI turn appears in the UI.
+        let e = Entry {
+            entry_type: "assistant".to_string(),
+            uuid: "stub-null-content".to_string(),
+            timestamp: "2026-06-06T10:00:00Z".to_string(),
+            message: super::super::entry::EntryMessage {
+                role: "assistant".to_string(),
+                model: "claude-opus-4-7".to_string(),
+                content: None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(
+            classify(e).is_none(),
+            "assistant entry with null content must be dropped (fallback retry stub)"
+        );
+    }
+
+    #[test]
+    fn classify_drops_assistant_with_empty_array_content() {
+        // v2.1.166+: the stub may also carry an empty array instead of null.
+        // Both forms must be silently dropped.
+        let e = Entry {
+            entry_type: "assistant".to_string(),
+            uuid: "stub-empty-array-content".to_string(),
+            timestamp: "2026-06-06T10:01:00Z".to_string(),
+            message: super::super::entry::EntryMessage {
+                role: "assistant".to_string(),
+                model: "claude-opus-4-7".to_string(),
+                content: Some(json!([])),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(
+            classify(e).is_none(),
+            "assistant entry with empty-array content must be dropped (fallback retry stub)"
+        );
+    }
+
+    #[test]
+    fn classify_keeps_fallback_success_entry_with_content() {
+        // v2.1.166+: the successful fallback response has real content and must be kept.
+        // Its model (claude-haiku-4-5) may differ from the primary model and must be
+        // preserved as authoritative for that entry.
+        let content = json!([{"type": "text", "text": "Hello from fallback model"}]);
+        let e = Entry {
+            entry_type: "assistant".to_string(),
+            uuid: "fallback-success-entry".to_string(),
+            timestamp: "2026-06-06T10:01:01Z".to_string(),
+            message: super::super::entry::EntryMessage {
+                role: "assistant".to_string(),
+                model: "claude-haiku-4-5".to_string(),
+                content: Some(content),
+                stop_reason: Some("end_turn".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::AI(ai)) => {
+                assert_eq!(
+                    ai.model, "claude-haiku-4-5",
+                    "fallback response model must be entry-authoritative"
+                );
+                assert!(
+                    ai.text.contains("Hello from fallback model"),
+                    "fallback response text must be preserved"
+                );
+            }
+            other => panic!("Expected AI for fallback success entry, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn classify_fallback_model_differs_from_primary_model() {
+        // v2.1.166+: adjacent turns may have different model IDs when fallbackModel is used.
+        // Each entry's model is authoritative for that turn — no session-level assumption.
+        let primary_content = json!([{"type": "text", "text": "Response from primary"}]);
+        let primary = Entry {
+            entry_type: "assistant".to_string(),
+            uuid: "primary-turn".to_string(),
+            timestamp: "2026-06-06T10:00:00Z".to_string(),
+            message: super::super::entry::EntryMessage {
+                role: "assistant".to_string(),
+                model: "claude-opus-4-7".to_string(),
+                content: Some(primary_content),
+                stop_reason: Some("end_turn".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let fallback_content = json!([{"type": "text", "text": "Response from fallback"}]);
+        let fallback = Entry {
+            entry_type: "assistant".to_string(),
+            uuid: "fallback-turn".to_string(),
+            timestamp: "2026-06-06T10:00:05Z".to_string(),
+            message: super::super::entry::EntryMessage {
+                role: "assistant".to_string(),
+                model: "claude-haiku-4-5".to_string(),
+                content: Some(fallback_content),
+                stop_reason: Some("end_turn".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        match (classify(primary), classify(fallback)) {
+            (Some(ClassifiedMsg::AI(p)), Some(ClassifiedMsg::AI(f))) => {
+                assert_eq!(p.model, "claude-opus-4-7");
+                assert_eq!(f.model, "claude-haiku-4-5");
+            }
+            other => panic!("Expected two AI messages, got {:?}", other),
+        }
+    }
+
     #[test]
     fn classify_regular_user_entry_not_affected_by_compact_summary_flag() {
         // Regular user entries (isCompactSummary defaults to false) must still produce UserMsg.

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -856,6 +856,83 @@ mod tests {
         assert_eq!(entry.workflow_id, "wf-xyz-999");
     }
 
+    // --- Issue #124: v2.1.166+ fallbackModel — parse-level compat ---
+
+    #[test]
+    fn parse_entry_assistant_with_null_content_succeeds() {
+        // v2.1.166+: fallback retry stub written before the successful response.
+        // The stub has message.content:null (or absent). parse_entry must not panic or
+        // return None — it should succeed so the caller (classify) can decide to drop it.
+        let line = json!({
+            "type": "assistant",
+            "uuid": "fallback-stub-null",
+            "timestamp": "2026-06-06T10:00:00Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": null
+            }
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse assistant stub with null content");
+        assert_eq!(entry.entry_type, "assistant");
+        assert_eq!(entry.message.model, "claude-opus-4-7");
+        assert!(
+            entry.message.content.is_none(),
+            "content must be None for null"
+        );
+    }
+
+    #[test]
+    fn parse_entry_assistant_with_empty_array_content_succeeds() {
+        // v2.1.166+: the stub may carry an empty array rather than null.
+        let line = json!({
+            "type": "assistant",
+            "uuid": "fallback-stub-empty-arr",
+            "timestamp": "2026-06-06T10:00:01Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-opus-4-7",
+                "content": []
+            }
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry =
+            parse_entry(&bytes).expect("must parse assistant stub with empty-array content");
+        assert_eq!(entry.entry_type, "assistant");
+        assert_eq!(entry.message.model, "claude-opus-4-7");
+        match entry.message.content {
+            Some(serde_json::Value::Array(arr)) => {
+                assert!(arr.is_empty(), "content must be an empty array");
+            }
+            other => panic!("expected Some(Array([])), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_entry_assistant_fallback_model_differs_from_prior_entry() {
+        // v2.1.166+: sessions using fallbackModel will have assistant entries whose
+        // message.model does not match the session's primary model. Each entry's model
+        // must be captured as-is without being normalised or overwritten.
+        let line = json!({
+            "type": "assistant",
+            "uuid": "fallback-success-uuid",
+            "timestamp": "2026-06-06T10:00:02Z",
+            "message": {
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{"type": "text", "text": "Fallback response"}],
+                "stop_reason": "end_turn"
+            }
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse fallback response entry");
+        assert_eq!(
+            entry.message.model, "claude-haiku-4-5",
+            "fallback model must be captured verbatim"
+        );
+    }
+
     #[test]
     fn parse_entry_all_workflow_lifecycle_types_succeed() {
         // All five workflow lifecycle types must parse without panicking or returning None.


### PR DESCRIPTION
## Summary

Claude Code v2.1.166 introduced `fallbackModel`: when the primary model is overloaded or returns an unexpected error, Claude Code retries the turn on a fallback model. Before writing the successful fallback response, it writes a partial assistant entry with `null` or empty `content[]` to the JSONL transcript. This stub entry represented the failed primary attempt.

`classify()` was emitting these stubs as `ClassifiedMsg::AI` with no text and no blocks — causing blank AI turns to appear in the conversation display and potentially confusing chunk aggregation in `build_chunks()`.

## Root Cause

In `classify.rs`, the assistant entry path had no guard for empty/null content. Any assistant entry with a UUID and `entry_type: "assistant"` was emitted as an `AIMsg`, even if `message.content` was `null` or `[]`.

The Anthropic API never returns a legitimate assistant response without at least one content block, so null/empty content is always a failed-attempt stub.

## Fix

Added an early-return guard in `classify()` for assistant entries whose `message.content` is `null` or an empty array. These are unconditionally dropped with `None`.

Per-turn model display was already correct — each `AIMsg` reads `e.message.model` directly, so fallback responses with real content continue to show their actual model ID (e.g. `claude-haiku-4-5`) without any change needed.

Note: the live chain resolution in `read_session_incremental` (full reads) already handles this by excluding dead-branch stubs. The guard in `classify()` provides defense-in-depth for incremental watcher reads where live-chain resolution is skipped.

## Changes

- `src-tauri/src/parser/classify.rs` — early-return `None` for assistant entries with `null` or empty `content[]`; 3 new tests
- `specs/01-parser-pipeline.md` — added v2.1.166 compat entry to the version-normalisation table

## Tests

429 passed; 0 failed  (cargo test)
349 passed; 0 failed  (vitest)

New test cases:
- classify_returns_none_for_assistant_with_null_content
- classify_returns_none_for_assistant_with_empty_content_array
- classify_returns_ai_for_fallback_model_assistant_with_real_content

Fixes #124
