### PR TITLE
[#137]: strip bracket context suffixes and date components from model IDs

### DIFF
--- a/src-tauri/src/convert.rs
+++ b/src-tauri/src/convert.rs
@@ -120,19 +120,36 @@ fn format_time(ts: &chrono::DateTime<chrono::Utc>) -> String {
     local.format("%Y-%m-%d %H:%M:%S").to_string()
 }
 
-/// Shorten model name: "claude-opus-4-6" -> "opus4.6"
+/// Shorten model name: "claude-opus-4-6" -> "opus4.6".
+/// Strips bracket context suffixes (e.g. "[1m]", "[1M]") and 8-digit date
+/// components so "claude-fable-5-20261001[1m]" becomes "fable5".
 fn short_model(m: &str) -> String {
+    // Strip bracket suffix (e.g., "[1m]", "[1M]") before normalizing.
+    let m = if let Some(bracket_pos) = m.find('[') {
+        &m[..bracket_pos]
+    } else {
+        m
+    };
     let m = m.strip_prefix("claude-").unwrap_or(m);
     let parts: Vec<&str> = m.splitn(2, '-').collect();
     if parts.len() == 2 {
         let family = parts[0];
-        let v_parts: Vec<&str> = parts[1].splitn(3, '-').collect();
-        let version = if v_parts.len() >= 2 {
-            format!("{}-{}", v_parts[0], v_parts[1])
+        // Skip pure 8-digit date components (YYYYMMDD); keep major-minor only.
+        let v_parts: Vec<&str> = parts[1]
+            .split('-')
+            .filter(|p| !(p.len() == 8 && p.chars().all(|c| c.is_ascii_digit())))
+            .collect();
+        let version = v_parts
+            .iter()
+            .take(2)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(".");
+        if version.is_empty() {
+            family.to_string()
         } else {
-            v_parts[0].to_string()
-        };
-        format!("{}{}", family, version.replace('-', "."))
+            format!("{family}{version}")
+        }
     } else {
         m.to_string()
     }
@@ -501,6 +518,21 @@ mod tests {
     #[test]
     fn short_model_empty() {
         assert_eq!(short_model(""), "");
+    }
+
+    #[test]
+    fn short_model_fable5_with_date() {
+        assert_eq!(short_model("claude-fable-5-20261001"), "fable5");
+    }
+
+    #[test]
+    fn short_model_fable5_with_bracket_suffix_lowercase() {
+        assert_eq!(short_model("claude-fable-5-20261001[1m]"), "fable5");
+    }
+
+    #[test]
+    fn short_model_fable5_with_bracket_suffix_uppercase() {
+        assert_eq!(short_model("claude-fable-5-20261001[1M]"), "fable5");
     }
 
     // ---- tool_category_str tests ----

--- a/src/components/MessageList.test.tsx
+++ b/src/components/MessageList.test.tsx
@@ -98,7 +98,7 @@ describe("MessageList", () => {
       makeMessage({ role: "claude", content: "Response", model: "claude-sonnet-4-20250514" }),
     ];
     render(<MessageList {...defaultProps({ messages })} />);
-    const modelEl = screen.getByText("sonnet4.20250514");
+    const modelEl = screen.getByText("sonnet4");
     expect(modelEl).toBeInTheDocument();
     expect(modelEl).toHaveStyle({ color: "#5fafff" }); // modelSonnet color
   });

--- a/src/components/SessionPicker.test.tsx
+++ b/src/components/SessionPicker.test.tsx
@@ -156,7 +156,7 @@ describe("SessionPicker", () => {
         onSearchChange={vi.fn()}
       />,
     );
-    expect(screen.getByText("sonnet4.20250514")).toBeInTheDocument();
+    expect(screen.getByText("sonnet4")).toBeInTheDocument();
     // Tokens appear in both header and session row
     expect(screen.getAllByText(/5\.0k/).length).toBeGreaterThanOrEqual(1);
     // Cost appears in both header and session row

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -52,6 +52,15 @@ describe("shortModel", () => {
   it("handles claude- prefix only", () => {
     expect(shortModel("claude-")).toBe("");
   });
+
+  it("strips bracket context suffix before normalizing", () => {
+    expect(shortModel("claude-fable-5-20261001[1m]")).toBe("fable5");
+    expect(shortModel("claude-fable-5-20261001[1M]")).toBe("fable5");
+  });
+
+  it("handles new single-number family version with date", () => {
+    expect(shortModel("claude-fable-5-20261001")).toBe("fable5");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -7,20 +7,23 @@ export { formatTokens, transformInlineJson } from "../../shared/format";
 
 /**
  * Turns "claude-opus-4-6" into "opus4.6".
+ * Strips bracket context suffixes (e.g. "[1m]", "[1M]") and 8-digit date
+ * components so "claude-fable-5-20261001[1m]" becomes "fable5".
  */
 export function shortModel(m: string): string {
+  // Strip bracket suffix (e.g., "[1m]", "[1M]") before normalizing.
+  const bracketIdx = m.indexOf("[");
+  if (bracketIdx !== -1) m = m.slice(0, bracketIdx);
+
   m = m.replace(/^claude-/, "");
   const dashIdx = m.indexOf("-");
   if (dashIdx === -1) return m;
 
   const family = m.slice(0, dashIdx);
   const rest = m.slice(dashIdx + 1);
-  // Keep major-minor only, drop patch/build metadata
-  const vParts = rest.split("-");
-  let version = vParts[0];
-  if (vParts.length >= 2) {
-    version = vParts[0] + "." + vParts[1];
-  }
+  // Keep major-minor only; skip pure 8-digit date components (YYYYMMDD).
+  const vParts = rest.split("-").filter((p) => !(p.length === 8 && /^\d+$/.test(p)));
+  const version = vParts.slice(0, 2).join(".");
   return family + version;
 }
 


### PR DESCRIPTION
## Summary

Adds support for Claude Fable 5 model strings (`claude-fable-5-*`) introduced in Claude Code v2.1.170, and normalizes the raw bracket context-size suffix (`[1m]`/`[1M]`) that appeared in pre-v2.1.173 session files.

Fixes #137

## Changes

### Root cause

`shortModel` (TypeScript) and `short_model` (Rust) had two gaps:

1. **Bracket suffix not stripped**: model strings like `claude-fable-5-20261001[1m]` passed the bracket through into the display label.
2. **Single-digit version family with date**: the Fable 5 family has only one version component (`5`) before the date, so the date was treated as the minor version (`fable5.20261001`).

### Fix

Both `shortModel` (TypeScript, `src/lib/format.ts`) and `short_model` (Rust, `src-tauri/src/convert.rs`) now:

1. Strip bracket suffixes (`[...]`) from the model string before any parsing.
2. Filter out 8-digit pure-numeric components (YYYYMMDD dates) when collecting version parts.

Result:
- `claude-fable-5-20261001[1m]` → `fable5`
- `claude-fable-5-20261001` → `fable5`
- `claude-haiku-4-5-20251001` → `haiku4.5` (unchanged)
- `claude-opus-4-6` → `opus4.6` (unchanged)

### Tests

- Added 3 TypeScript tests in `src/lib/format.test.ts` covering bracket suffix variants and date-only version.
- Added 3 Rust tests in `src-tauri/src/convert.rs` covering the same cases.
- Updated 2 component tests that previously expected the old (incorrect) date-inclusive label `sonnet4.20250514`; they now expect `sonnet4`.

## Verification

All checks pass: 365 frontend tests, 447 Rust tests, clippy clean, tsc clean, oxlint clean.
