### PR TITLE
fix(projectTree): nest orphan worktree sessions under a synthesized repo node

### DIFF
--- a/shared/projectTree.test.ts
+++ b/shared/projectTree.test.ts
@@ -171,23 +171,21 @@ describe("buildTree — orphan worktree synthesis", () => {
     const nodes = [
       {
         name: "grpc-js-1.14.4",
-        key: "-t-ws-elements-storefront--claude-worktrees-dep-grpc",
+        key: "-t-ws-webapp--claude-worktrees-dep-grpc",
         sessionCount: 1,
         hasOngoing: false,
       },
       {
         name: "vitest",
-        key: "-t-ws-elements-storefront--claude-worktrees-dep-vitest",
+        key: "-t-ws-webapp--claude-worktrees-dep-vitest",
         sessionCount: 1,
         hasOngoing: false,
       },
     ];
     const roots = buildTree(nodes);
     expect(roots).toHaveLength(1);
-    expect(roots[0].node.key).toBe("-t-ws-elements-storefront");
-    // projectDisplayName collapses every "-" to a path separator (lossy — same as how the
-    // tool labels every other node), so "elements-storefront" surfaces as "storefront".
-    expect(roots[0].node.name).toBe("storefront");
+    expect(roots[0].node.key).toBe("-t-ws-webapp");
+    expect(roots[0].node.name).toBe("webapp");
     expect(roots[0].children).toHaveLength(2);
   });
 
@@ -195,13 +193,13 @@ describe("buildTree — orphan worktree synthesis", () => {
     const nodes = [
       {
         name: "grpc-js-1.14.4",
-        key: "-t-ws-elements-storefront--claude-worktrees-dep-grpc",
+        key: "-t-ws-webapp--claude-worktrees-dep-grpc",
         sessionCount: 1,
         hasOngoing: false,
       },
     ];
     const flat = flattenTree(buildTree(nodes));
-    expect(flat.map((i) => i.name)).toContain("storefront");
+    expect(flat.map((i) => i.name)).toContain("webapp");
     const group = flat.find((i) => i.isGroup && i.name === "claude-worktrees");
     expect(group).toBeDefined();
     // The orphan must no longer be its own depth-0 root.

--- a/shared/projectTree.test.ts
+++ b/shared/projectTree.test.ts
@@ -164,6 +164,66 @@ describe("buildTree", () => {
   });
 });
 
+describe("buildTree — orphan worktree synthesis", () => {
+  it("synthesizes a repo-root parent for worktree nodes with no anchor session", () => {
+    // Headless/deterministic orchestrators only ever run agent phases inside per-item
+    // worktrees, so no session exists at the repo root to anchor them.
+    const nodes = [
+      {
+        name: "grpc-js-1.14.4",
+        key: "-t-ws-elements-storefront--claude-worktrees-dep-grpc",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+      {
+        name: "vitest",
+        key: "-t-ws-elements-storefront--claude-worktrees-dep-vitest",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+    ];
+    const roots = buildTree(nodes);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].node.key).toBe("-t-ws-elements-storefront");
+    // projectDisplayName collapses every "-" to a path separator (lossy — same as how the
+    // tool labels every other node), so "elements-storefront" surfaces as "storefront".
+    expect(roots[0].node.name).toBe("storefront");
+    expect(roots[0].children).toHaveLength(2);
+  });
+
+  it("flattens the synthesized repo node into a CLAUDE-WORKTREES group", () => {
+    const nodes = [
+      {
+        name: "grpc-js-1.14.4",
+        key: "-t-ws-elements-storefront--claude-worktrees-dep-grpc",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+    ];
+    const flat = flattenTree(buildTree(nodes));
+    expect(flat.map((i) => i.name)).toContain("storefront");
+    const group = flat.find((i) => i.isGroup && i.name === "claude-worktrees");
+    expect(group).toBeDefined();
+    // The orphan must no longer be its own depth-0 root.
+    expect(flat.filter((i) => i.depth === 0)).toHaveLength(1);
+  });
+
+  it("does not synthesize when a real root-anchor session exists", () => {
+    const nodes = [
+      { name: "ctf", key: "-ws-ctf", sessionCount: 1, hasOngoing: false },
+      {
+        name: "wt",
+        key: "-ws-ctf-repo--claude-worktrees-fix-1",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+    ];
+    const roots = buildTree(nodes);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].node.key).toBe("-ws-ctf");
+  });
+});
+
 describe("detectWorktreeKind", () => {
   it("detects worktrees (old single-dash style)", () => {
     expect(detectWorktreeKind("-Users-me-backend", "-Users-me-backend-worktrees-EC-123")).toBe(

--- a/shared/projectTree.ts
+++ b/shared/projectTree.ts
@@ -46,8 +46,43 @@ export function treeNodeCmp(a: TreeNode, b: TreeNode): number {
   return a.node.name.localeCompare(b.node.name);
 }
 
+/** The repo-portion of a worktree key: everything before the first worktree marker, or null. */
+function worktreeRootKey(key: string): string | null {
+  for (const marker of ["--claude-worktrees-", "--worktrees-"]) {
+    const i = key.indexOf(marker);
+    if (i > 0) return key.slice(0, i);
+  }
+  return null;
+}
+
+/** True when some other key is a prefix-ancestor of `key` (i.e. a real session can anchor it). */
+function hasRealAncestor(key: string, keys: ReadonlySet<string>): boolean {
+  for (const k of keys) if (k !== key && key.startsWith(k + "-")) return true;
+  return false;
+}
+
 export function buildTree(nodes: ProjectNode[]): TreeNode[] {
-  const sorted = [...nodes].toSorted((a, b) => a.key.length - b.key.length);
+  // A worktree session whose orchestrator never opens a session at the repo root (headless
+  // / deterministic runs that only ever execute agent phases inside per-item worktrees) has
+  // no ancestor node to nest under, so it would orphan as a flat root. Synthesize the
+  // repo-root node from the worktree key so it anchors and groups like an anchored run; the
+  // synthesized node flows through the normal parenting/intermediate/flatten logic below.
+  const keys = new Set(nodes.map((n) => n.key));
+  const synthesized = new Map<string, ProjectNode>();
+  for (const node of nodes) {
+    const rootKey = worktreeRootKey(node.key);
+    if (rootKey && !keys.has(rootKey) && !hasRealAncestor(node.key, keys)) {
+      synthesized.set(rootKey, {
+        name: projectDisplayName(rootKey),
+        key: rootKey,
+        sessionCount: 0,
+        hasOngoing: false,
+      });
+    }
+  }
+  const input = synthesized.size ? [...nodes, ...synthesized.values()] : nodes;
+
+  const sorted = [...input].toSorted((a, b) => a.key.length - b.key.length);
   const roots: TreeNode[] = [];
   const all: TreeNode[] = [];
 

--- a/specs/11-project-tree.md
+++ b/specs/11-project-tree.md
@@ -86,6 +86,15 @@ flowchart LR
     CHILD --> LABEL["label: 'feature-branch'"]
 ```
 
+### Orphan worktrees (no anchor session)
+
+The base project may have **no session of its own** — e.g. a headless/deterministic
+orchestrator that only ever runs agent phases inside per-item worktrees and never opens a
+session at the repo root. In that case `buildTree` **synthesizes** the base project node
+(keyed by the prefix before the worktree marker) so the worktree still nests under its repo
+with a `CLAUDE-WORKTREES` group, instead of orphaning as a flat root. A synthesized node is
+created only when no real prefix-ancestor session exists, so anchored runs are unaffected.
+
 ---
 
 ## Ongoing Status Propagation


### PR DESCRIPTION
## Problem

Worktree sessions with **no root-anchor session** rendered as flat top-level nodes in the project sidebar instead of nesting under their repo with a `CLAUDE-WORKTREES` group.

This affects any headless/deterministic orchestrator that only ever runs agent phases **inside** per-item worktrees and never opens a session at the repo root (e.g. a CLI that clones to a temp dir and spawns one worktree phase per work item). Runs whose orchestrator itself runs as a root-cwd session group correctly, which is why the asymmetry is easy to miss.

## Root cause

`buildTree` (`shared/projectTree.ts`) nested only via an **existing** prefix-ancestor node; the worktree-grouping/intermediate logic lives inside `if (parent)`. A worktree node with no ancestor node fell to `else { roots.push(tn) }`, so its `--claude-worktrees-` marker was ignored and it showed flat.

## Fix

`buildTree` now pre-passes the nodes: for any worktree key (`--claude-worktrees-` / `--worktrees-`) with **no real prefix-ancestor** among the sessions, it synthesizes the repo-root `ProjectNode` (keyed by the prefix before the marker) and feeds it through the existing parenting/intermediate/`flattenTree` logic — which then emits the `CLAUDE-WORKTREES` group and leaves for free. When a real anchor exists, nothing is synthesized, so anchored runs are byte-for-byte unchanged.

## Tests

`shared/projectTree.test.ts`: orphan worktrees now synthesize a repo node + `CLAUDE-WORKTREES` group (was: flat roots); regression test asserts no synthesis when a real anchor exists.

## Verification (local)

- `vitest run` — 366 passed (incl. 3 new)
- `cargo test` — 444 passed
- `tsc --noEmit`, `oxlint`, `oxfmt --check` — clean

Spec updated: `specs/11-project-tree.md` (Worktree Nesting Logic → orphan-worktree synthesis).

Fixes #144
