### PR TITLE
fix(specs): align data-types SessionInfo table widths for oxfmt

### DIFF
--- a/specs/07-data-types.md
+++ b/specs/07-data-types.md
@@ -210,11 +210,11 @@ type TaskStatus = "pending" | "in_progress" | "completed" | "cancelled";
 
 ## `SessionInfo` Field Notes
 
-| Field           | Notes                                                                                                                                                                              |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `first_message` | First user turn content (truncated at ~200 chars)                                                                                                                                  |
-| `mod_time`      | ISO-8601 timestamp of last file modification                                                                                                                                       |
-| `session_id`    | UUID of the root session entry                                                                                                                                                     |
+| Field           | Notes                                                                                                                                                                                  |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `first_message` | First user turn content (truncated at ~200 chars)                                                                                                                                      |
+| `mod_time`      | ISO-8601 timestamp of last file modification                                                                                                                                           |
+| `session_id`    | UUID of the root session entry                                                                                                                                                         |
 | `git_branch`    | Git branch from the last JSONL entry (per-entry; tracks `/cd` and v2.1.157+ EnterWorktree switches). Pre-v2.1.176 sessions may show a stale branch after `/cd` — cwd is authoritative. |
 
 ---


### PR DESCRIPTION
## Summary

`npx oxfmt --check` is failing on `main` after #142 merged. During PR #142's conflict resolution I rewrote the `SessionInfo` table in `specs/07-data-types.md` by hand and the column widths ended up 2 chars short of the longest cell (`git_branch` row).

Re-running `npx oxfmt` extends the dashes to match. No content change.

## Test plan

- [x] `npx oxfmt --check` passes locally (all 127 files)

https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL)_