### PR TITLE
[#157]: compat: handle v2.1.183 thinking-only assistant entries and isMeta re-prompt user entries

### DIFF
--- a/specs/01-parser-pipeline.md
+++ b/specs/01-parser-pipeline.md
@@ -143,6 +143,8 @@ flowchart TD
 | `MessageDisplay` hook event name                                                                             | v2.1.152+    | `hook_event` stored as `String` — no enum; catch-all presence-of-hookEvent checks in classify handle any future event name without a code change                                                                     |
 | `fallbackModel` retry writes null/empty stub assistant entry before successful response                      | v2.1.166+    | `classify()` returns `None` for assistant entries with `null` or empty `content` array; fallback response with real content passes through with its own model ID                                                     |
 | Mid-stream connection drop flushes partial assistant entry with `usage:null` or null individual token fields | v2.1.179+    | `EntryMessage.usage` and all four numeric fields of `EntryUsage` use `null_as_default`; null values deserialise to 0 instead of failing. `stop_reason` was already `Option<String>` and handles null/unknown values. |
+| Thinking-only assistant entries (`content` = one `thinking` block, no `text`/`tool_use`)                     | v2.1.183+    | Non-empty content array passes the empty-content guard; classified as `AIMsg` with `thinking_count=1` and empty `text`. Rendered with thinking block, no empty-bubble discard.                                       |
+| Synthetic re-prompt `isMeta: true` user entries after thinking-only turns                                    | v2.1.183+    | `classify()` returns `None` for `user` entries with `is_meta: true` that don't match a known pattern (Stop hook feedback). Prevents spurious meta-AI bubbles.                                                        |
 
 ---
 

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -353,6 +353,10 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                 metadata: None,
             }));
         }
+        // v2.1.183+: synthetic re-prompt user entries are internal Claude Code markers
+        // inserted when a thinking-only assistant turn triggers a re-prompt. They are not
+        // human-typed messages; drop them to avoid spurious meta-AI bubbles in the UI.
+        return None;
     }
 
     // Teammate messages.
@@ -936,6 +940,74 @@ mod tests {
                 assert_eq!(ai.stop_reason, "tool_use");
             }
             other => panic!("Expected AI, got {other:?}"),
+        }
+    }
+
+    // --- Issue #157: v2.1.183+ thinking-only assistant entries and synthetic re-prompt user entries ---
+
+    #[test]
+    fn classify_returns_ai_for_thinking_only_assistant_entry() {
+        // v2.1.183+: assistant turns that re-prompt because the model returned only a thinking
+        // block must not be silently discarded. The content array is non-empty (has one thinking
+        // block) so the empty-content guard must not fire. The entry must classify as an AIMsg
+        // with thinking_count=1 and empty text.
+        let content = json!([{"type": "thinking", "thinking": "I need to reconsider this."}]);
+        let mut e = make_entry("assistant", Some(content));
+        e.message.model = "claude-opus-4-7".to_string();
+        e.message.stop_reason = Some("end_turn".to_string());
+        match classify(e) {
+            Some(ClassifiedMsg::AI(ai)) => {
+                assert_eq!(ai.thinking_count, 1, "thinking block must be counted");
+                assert_eq!(ai.tool_calls.len(), 0);
+                assert_eq!(ai.stop_reason, "end_turn");
+            }
+            other => panic!("Expected AI for thinking-only assistant entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_drops_is_meta_user_re_prompt_entry() {
+        // v2.1.183+: after a thinking-only assistant turn, Claude Code inserts an internal
+        // isMeta user message to re-prompt the model. These entries are not typed by humans
+        // and must be silently dropped rather than surfaced as spurious AI meta turns.
+        let mut e = make_entry(
+            "user",
+            Some(json!([{"type": "text", "text": "Please continue."}])),
+        );
+        e.is_meta = true;
+        assert!(
+            classify(e).is_none(),
+            "isMeta user re-prompt entry must be dropped"
+        );
+    }
+
+    #[test]
+    fn classify_drops_is_meta_user_entry_with_empty_content() {
+        // isMeta user entries with no content (another possible re-prompt shape) must also drop.
+        let mut e = make_entry("user", Some(json!([])));
+        e.is_meta = true;
+        assert!(
+            classify(e).is_none(),
+            "isMeta user entry with empty content must be dropped"
+        );
+    }
+
+    #[test]
+    fn classify_still_rescues_stop_hook_feedback_is_meta_user() {
+        // The isMeta drop must not fire for Stop hook feedback entries — they must still
+        // be classified as HookMsg so hook errors appear in the transcript.
+        let mut e = make_entry(
+            "user",
+            Some(json!(
+                "Stop hook feedback:\n[~/.claude/hook.sh]: non-zero exit"
+            )),
+        );
+        e.is_meta = true;
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "Stop");
+            }
+            other => panic!("Expected Hook for Stop hook feedback isMeta entry, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

Compatibility fix for Claude Code v2.1.183, which introduced two new JSONL entry patterns when the model returns an assistant turn containing only a `thinking` block (no `text` or `tool_use` output):

1. **Thinking-only assistant entries** — `content` array with a single `{"type": "thinking", ...}` block and `stop_reason: "end_turn"`. The existing empty-content guard already passed these through correctly — no code change required. Tests added to document and lock this behaviour.

2. **Synthetic re-prompt user entries** — immediately after a thinking-only turn, Claude Code inserts an internal `isMeta: true` user entry to re-prompt the model. Previously these fell through to the AI-meta fallback in `classify()` and surfaced as spurious meta-AI bubbles in the conversation display. Fixed by returning `None` for any `isMeta` user entry that does not match a known pattern (Stop hook feedback is still rescued as `HookMsg` before the new guard fires).

## Changes

- `src-tauri/src/parser/classify.rs` — add `return None` after the Stop hook feedback block to drop all remaining `isMeta` user entries; add 4 new tests.
- `specs/01-parser-pipeline.md` — add two rows to the Version-Compatibility Normalisations table documenting both patterns.

## Tests

Four new Rust unit tests in `parser::classify::tests`:

| Test | Verifies |
|------|----------|
| `classify_returns_ai_for_thinking_only_assistant_entry` | Thinking-only assistant entry classified as AIMsg with thinking_count=1 |
| `classify_drops_is_meta_user_re_prompt_entry` | isMeta re-prompt user entry returns None |
| `classify_drops_is_meta_user_entry_with_empty_content` | isMeta user entry with empty content returns None |
| `classify_still_rescues_stop_hook_feedback_is_meta_user` | Stop hook feedback isMeta still surfaces as HookMsg |

All 466 Rust tests pass. All 368 frontend tests pass. Clippy clean under -D warnings.

Fixes #157
