### PR TITLE
feat(wsl): discover Claude Code sessions inside WSL distributions

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod git;
 pub mod picker;
 pub mod session;
 pub mod settings;
+pub mod wsl;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -87,28 +87,19 @@ pub async fn watch_session(
     Ok(())
 }
 
-/// Return all project directories under the Claude projects base directory.
-/// Each subdirectory corresponds to an encoded project path.
+/// Return all project directories to scan for sessions: every subdirectory of
+/// the Claude projects base directory plus the projects of each configured WSL
+/// distro. Each entry corresponds to an encoded project path.
 #[tauri::command]
 pub async fn get_project_dirs(state: State<'_, Arc<AppState>>) -> Result<Vec<String>, String> {
-    let configured = state
-        .settings
-        .lock()
-        .map_err(|e| e.to_string())?
-        .projects_dir
-        .clone();
-    let projects_dir = crate::parser::session::claude_projects_dir(configured.as_deref())?;
-    if !projects_dir.exists() {
-        return Ok(Vec::new());
-    }
-    let mut dirs = Vec::new();
-    let entries = std::fs::read_dir(&projects_dir).map_err(|e| e.to_string())?;
-    for entry in entries.flatten() {
-        if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            dirs.push(entry.path().to_string_lossy().to_string());
-        }
-    }
-    Ok(dirs)
+    let (configured, wsl_distros) = {
+        let guard = state.settings.lock().map_err(|e| e.to_string())?;
+        (guard.projects_dir.clone(), guard.wsl_distros.clone())
+    };
+    Ok(crate::wsl::collect_project_dirs(
+        configured.as_deref(),
+        &wsl_distros,
+    ))
 }
 
 /// Stop watching the current session.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -16,6 +16,8 @@ pub struct SettingsResponse {
     pub effective_dir: String,
     /// Whether the effective directory actually exists on disk.
     pub effective_dir_exists: bool,
+    /// WSL distributions whose projects are also discovered.
+    pub wsl_distros: Vec<String>,
 }
 
 pub fn platform_default_dir() -> String {
@@ -38,6 +40,7 @@ pub fn build_response_pub(settings: &crate::settings::Settings) -> SettingsRespo
         default_dir: platform_default_dir(),
         effective_dir: effective.to_string_lossy().to_string(),
         effective_dir_exists,
+        wsl_distros: settings.wsl_distros.clone(),
     }
 }
 

--- a/src-tauri/src/commands/wsl.rs
+++ b/src-tauri/src/commands/wsl.rs
@@ -1,0 +1,62 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use tauri::State;
+
+use crate::commands::settings::{build_response_pub, SettingsResponse};
+use crate::state::AppState;
+
+/// Trim, drop empty entries, and de-duplicate distro names while preserving order.
+pub fn sanitize_distros(distros: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    distros
+        .into_iter()
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty() && seen.insert(d.clone()))
+        .collect()
+}
+
+/// List installed WSL distributions. Empty on non-Windows hosts or when WSL is
+/// not installed.
+#[tauri::command]
+pub async fn list_wsl_distros() -> Result<Vec<String>, String> {
+    Ok(crate::wsl::list_distros())
+}
+
+/// Persist the set of WSL distros whose projects should be discovered.
+#[tauri::command]
+pub async fn set_wsl_distros(
+    distros: Vec<String>,
+    state: State<'_, Arc<AppState>>,
+) -> Result<SettingsResponse, String> {
+    let mut guard = state.settings.lock().map_err(|e| e.to_string())?;
+    guard.wsl_distros = sanitize_distros(distros);
+    crate::settings::save_settings(&guard)?;
+    Ok(build_response_pub(&guard))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_trims_and_drops_empty() {
+        let out = sanitize_distros(vec![
+            "  Ubuntu  ".to_string(),
+            "".to_string(),
+            "   ".to_string(),
+            "Debian".to_string(),
+        ]);
+        assert_eq!(out, vec!["Ubuntu", "Debian"]);
+    }
+
+    #[test]
+    fn sanitize_dedupes_preserving_order() {
+        let out = sanitize_distros(vec![
+            "Ubuntu".to_string(),
+            "Debian".to_string(),
+            "Ubuntu".to_string(),
+        ]);
+        assert_eq!(out, vec!["Ubuntu", "Debian"]);
+    }
+}

--- a/src-tauri/src/http_api.rs
+++ b/src-tauri/src/http_api.rs
@@ -91,6 +91,10 @@ async fn run_server(state: Arc<HttpState>) {
     let mut router = Router::new()
         .route("/api/settings", get(api_get_settings))
         .route("/api/settings/dir", post(api_set_projects_dir))
+        .route(
+            "/api/wsl/distros",
+            get(api_list_wsl_distros).post(api_set_wsl_distros),
+        )
         .route("/api/project-dirs", get(api_get_project_dirs))
         .route("/api/sessions", post(api_discover_sessions))
         .route("/api/session", get(api_get_session_by_id))
@@ -205,31 +209,45 @@ async fn api_set_projects_dir(
 
 async fn api_get_project_dirs(State(state): State<Arc<HttpState>>) -> Response {
     let app_state = app_state(&state);
-    let configured = match app_state.settings.lock() {
-        Ok(g) => g.projects_dir.clone(),
+    let (configured, wsl_distros) = match app_state.settings.lock() {
+        Ok(g) => (g.projects_dir.clone(), g.wsl_distros.clone()),
         Err(e) => {
             return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
         }
     };
-    let projects_dir = match crate::parser::session::claude_projects_dir(configured.as_deref()) {
-        Ok(d) => d,
-        Err(e) => return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e),
-    };
-    if !projects_dir.exists() {
-        return ok_json(&Vec::<String>::new());
-    }
-    let entries = match std::fs::read_dir(&projects_dir) {
-        Ok(e) => e,
-        Err(e) => {
-            return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
-        }
-    };
-    let dirs: Vec<String> = entries
-        .flatten()
-        .filter(|e| e.file_type().map(|t| t.is_dir()).unwrap_or(false))
-        .map(|e| e.path().to_string_lossy().to_string())
-        .collect();
+    let dirs = crate::wsl::collect_project_dirs(configured.as_deref(), &wsl_distros);
     ok_json(&dirs)
+}
+
+// ---------------------------------------------------------------------------
+// WSL distros
+// ---------------------------------------------------------------------------
+
+async fn api_list_wsl_distros() -> Response {
+    ok_json(&crate::wsl::list_distros())
+}
+
+#[derive(Deserialize)]
+struct SetWslBody {
+    distros: Vec<String>,
+}
+
+async fn api_set_wsl_distros(
+    State(state): State<Arc<HttpState>>,
+    Json(body): Json<SetWslBody>,
+) -> Response {
+    let app_state = app_state(&state);
+    let mut guard = match app_state.settings.lock() {
+        Ok(g) => g,
+        Err(e) => {
+            return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+        }
+    };
+    guard.wsl_distros = crate::commands::wsl::sanitize_distros(body.distros);
+    if let Err(e) = crate::settings::save_settings(&guard) {
+        return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e);
+    }
+    ok_json(&crate::commands::settings::build_response_pub(&guard))
 }
 
 // ---------------------------------------------------------------------------
@@ -338,31 +356,23 @@ async fn api_get_session_by_id(
     }
 
     let app_state = app_state(&state);
-    let configured = match app_state.settings.lock() {
-        Ok(g) => g.projects_dir.clone(),
+    let (configured, wsl_distros) = match app_state.settings.lock() {
+        Ok(g) => (g.projects_dir.clone(), g.wsl_distros.clone()),
         Err(e) => {
             return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
         }
     };
-    let projects_dir = match crate::parser::session::claude_projects_dir(configured.as_deref()) {
-        Ok(d) => d,
-        Err(e) => return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e),
-    };
 
-    // Search all project subdirs for <id>.jsonl
+    // Search every project dir (host + WSL distros) for <id>.jsonl
+    let project_dirs = crate::wsl::collect_project_dirs(configured.as_deref(), &wsl_distros);
     let filename = format!("{}.jsonl", q.id);
-    let found_path = std::fs::read_dir(&projects_dir).ok().and_then(|entries| {
-        entries.flatten().find_map(|entry| {
-            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                return None;
-            }
-            let candidate = entry.path().join(&filename);
-            if candidate.exists() {
-                Some(candidate.to_string_lossy().to_string())
-            } else {
-                None
-            }
-        })
+    let found_path = project_dirs.iter().find_map(|dir| {
+        let candidate = std::path::Path::new(dir).join(&filename);
+        if candidate.exists() {
+            Some(candidate.to_string_lossy().to_string())
+        } else {
+            None
+        }
     });
 
     let path = match found_path {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod parser;
 mod settings;
 mod state;
 mod watcher;
+mod wsl;
 
 use std::sync::Arc;
 
@@ -68,6 +69,8 @@ pub fn run() {
             commands::debug::get_debug_log,
             commands::settings::get_settings,
             commands::settings::set_projects_dir,
+            commands::wsl::list_wsl_distros,
+            commands::wsl::set_wsl_distros,
             switch_to_browser,
         ])
         .setup(move |app| {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -6,6 +6,10 @@ use std::path::PathBuf;
 pub struct Settings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub projects_dir: Option<String>,
+    /// Names of WSL distributions whose `~/.claude/projects` should also be
+    /// scanned for sessions (Windows host discovering sessions inside WSL).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub wsl_distros: Vec<String>,
 }
 
 fn settings_path() -> Result<PathBuf, String> {
@@ -49,6 +53,7 @@ mod tests {
 
         let settings = Settings {
             projects_dir: Some("/custom/path".to_string()),
+            ..Default::default()
         };
         let json = serde_json::to_string_pretty(&settings).unwrap();
         fs::write(&path, &json).unwrap();
@@ -63,5 +68,24 @@ mod tests {
     fn deserialize_empty_json_gives_defaults() {
         let settings: Settings = serde_json::from_str("{}").unwrap();
         assert!(settings.projects_dir.is_none());
+        assert!(settings.wsl_distros.is_empty());
+    }
+
+    #[test]
+    fn wsl_distros_roundtrip() {
+        let settings = Settings {
+            projects_dir: None,
+            wsl_distros: vec!["Ubuntu".to_string(), "Debian".to_string()],
+        };
+        let json = serde_json::to_string_pretty(&settings).unwrap();
+        let loaded: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(loaded.wsl_distros, vec!["Ubuntu", "Debian"]);
+    }
+
+    #[test]
+    fn empty_wsl_distros_omitted_from_json() {
+        let settings = Settings::default();
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(!json.contains("wsl_distros"));
     }
 }

--- a/src-tauri/src/wsl.rs
+++ b/src-tauri/src/wsl.rs
@@ -1,0 +1,275 @@
+//! WSL (Windows Subsystem for Linux) integration.
+//!
+//! Lets the desktop app discover Claude Code sessions that live *inside* WSL
+//! distributions. Claude Code running in a distro stores its projects under the
+//! Linux home directory (`~/.claude/projects`); from Windows those are reachable
+//! through the `\\wsl.localhost\<distro>\...` UNC share. This module enumerates
+//! installed distros, resolves each one's projects directory, and aggregates the
+//! per-project subdirectories alongside the host's own projects directory.
+//!
+//! All `wsl.exe` invocation is gated to Windows. On other platforms the spawn
+//! helpers are no-ops, so configured distros simply contribute nothing — the
+//! pure parsing/path helpers remain testable everywhere.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+/// Decode raw bytes emitted by `wsl.exe`. `wsl.exe --list` writes UTF-16LE on
+/// Windows, whereas stdout piped from a command run *inside* a distro is UTF-8.
+/// Detect UTF-16 by the presence of NUL bytes and decode accordingly.
+fn decode_wsl_bytes(bytes: &[u8]) -> String {
+    if bytes.contains(&0) {
+        let u16s: Vec<u16> = bytes
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        String::from_utf16_lossy(&u16s)
+    } else {
+        String::from_utf8_lossy(bytes).into_owned()
+    }
+}
+
+/// Parse the output of `wsl --list --quiet` into distro names. Strips BOMs, NULs,
+/// and carriage returns, drops blank lines, and ignores lines containing interior
+/// whitespace (e.g. the "no installed distributions" message WSL prints when none
+/// exist — distro names are always single tokens).
+fn parse_distro_list(raw: &str) -> Vec<String> {
+    raw.lines()
+        .map(|l| l.trim_matches(|c: char| c.is_whitespace() || c == '\u{feff}' || c == '\0'))
+        .filter(|l| !l.is_empty() && !l.contains(char::is_whitespace))
+        .map(str::to_string)
+        .collect()
+}
+
+/// Build the Windows UNC path to a distro's Claude projects directory from a
+/// POSIX home directory.
+/// e.g. `("Ubuntu", "/home/nat")` -> `\\wsl.localhost\Ubuntu\home\nat\.claude\projects`.
+fn unc_projects_path(distro: &str, posix_home: &str) -> String {
+    let home = posix_home
+        .trim()
+        .trim_end_matches('/')
+        .trim_start_matches('/')
+        .replace('/', "\\");
+    if home.is_empty() {
+        format!(r"\\wsl.localhost\{distro}\.claude\projects")
+    } else {
+        format!(r"\\wsl.localhost\{distro}\{home}\.claude\projects")
+    }
+}
+
+/// Run `wsl.exe` with the given args and return stdout on success.
+#[cfg(target_os = "windows")]
+fn run_wsl(args: &[&str]) -> Option<Vec<u8>> {
+    use std::os::windows::process::CommandExt;
+    // CREATE_NO_WINDOW — keep wsl.exe from flashing a console window.
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let output = std::process::Command::new("wsl.exe")
+        .args(args)
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .ok()?;
+    if output.status.success() {
+        Some(output.stdout)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn run_wsl(_args: &[&str]) -> Option<Vec<u8>> {
+    None
+}
+
+/// List installed WSL distributions. Returns an empty list on non-Windows
+/// platforms or when WSL is not installed / has no distros.
+pub fn list_distros() -> Vec<String> {
+    match run_wsl(&["--list", "--quiet"]) {
+        Some(bytes) => parse_distro_list(&decode_wsl_bytes(&bytes)),
+        None => Vec::new(),
+    }
+}
+
+/// Process-wide cache of successfully resolved distro projects directories.
+/// A distro's home directory is effectively immutable for the app's lifetime, so
+/// caching avoids re-spawning `wsl.exe` on every filesystem-triggered rescan.
+/// Only successful resolutions are cached — an unreachable distro keeps retrying.
+fn resolve_cache() -> &'static Mutex<HashMap<String, String>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Resolve the Windows-accessible Claude projects directory for a WSL distro,
+/// or `None` if the distro can't be reached or reports no home directory.
+pub fn resolve_distro_projects_dir(distro: &str) -> Option<String> {
+    if let Ok(cache) = resolve_cache().lock() {
+        if let Some(dir) = cache.get(distro) {
+            return Some(dir.clone());
+        }
+    }
+    let resolved = resolve_distro_projects_dir_uncached(distro)?;
+    if let Ok(mut cache) = resolve_cache().lock() {
+        cache.insert(distro.to_string(), resolved.clone());
+    }
+    Some(resolved)
+}
+
+fn resolve_distro_projects_dir_uncached(distro: &str) -> Option<String> {
+    let bytes = run_wsl(&["-d", distro, "--", "sh", "-c", "echo $HOME"])?;
+    let home = decode_wsl_bytes(&bytes);
+    let home = home.trim();
+    if !home.starts_with('/') {
+        return None;
+    }
+    Some(unc_projects_path(distro, home))
+}
+
+/// List the immediate subdirectories of `dir` as path strings.
+fn list_subdirs(dir: &Path) -> Vec<String> {
+    let mut dirs = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                dirs.push(entry.path().to_string_lossy().to_string());
+            }
+        }
+    }
+    dirs
+}
+
+/// Collect every project directory to scan for sessions: the host's configured
+/// (or default) projects directory plus each configured WSL distro's projects
+/// directory. Each returned entry is an encoded-path project subdirectory.
+pub fn collect_project_dirs(configured: Option<&str>, wsl_distros: &[String]) -> Vec<String> {
+    let mut dirs = Vec::new();
+
+    if let Ok(base) = crate::parser::session::claude_projects_dir(configured) {
+        if base.exists() {
+            dirs.extend(list_subdirs(&base));
+        }
+    }
+
+    for distro in wsl_distros {
+        if let Some(projects) = resolve_distro_projects_dir(distro) {
+            let p = Path::new(&projects);
+            if p.exists() {
+                dirs.extend(list_subdirs(p));
+            }
+        }
+    }
+
+    dirs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- decode_wsl_bytes ---
+
+    #[test]
+    fn decode_utf8_passthrough() {
+        assert_eq!(decode_wsl_bytes(b"/home/nat\n"), "/home/nat\n");
+    }
+
+    #[test]
+    fn decode_utf16le_with_nuls() {
+        // "Ub" encoded UTF-16LE: 0x55 0x00 0x62 0x00
+        let bytes = [0x55u8, 0x00, 0x62, 0x00];
+        assert_eq!(decode_wsl_bytes(&bytes), "Ub");
+    }
+
+    // --- parse_distro_list ---
+
+    #[test]
+    fn parse_distro_list_basic() {
+        let raw = "Ubuntu\r\nDebian\r\nkali-linux\r\n";
+        assert_eq!(
+            parse_distro_list(raw),
+            vec!["Ubuntu", "Debian", "kali-linux"]
+        );
+    }
+
+    #[test]
+    fn parse_distro_list_strips_bom_and_blanks() {
+        let raw = "\u{feff}Ubuntu\n\n  Debian  \n";
+        assert_eq!(parse_distro_list(raw), vec!["Ubuntu", "Debian"]);
+    }
+
+    #[test]
+    fn parse_distro_list_ignores_sentence_lines() {
+        // The message WSL prints when there are no distros has interior spaces.
+        let raw = "Windows Subsystem for Linux has no installed distributions.\n";
+        assert!(parse_distro_list(raw).is_empty());
+    }
+
+    // --- unc_projects_path ---
+
+    #[test]
+    fn unc_path_for_standard_home() {
+        assert_eq!(
+            unc_projects_path("Ubuntu", "/home/nat"),
+            r"\\wsl.localhost\Ubuntu\home\nat\.claude\projects"
+        );
+    }
+
+    #[test]
+    fn unc_path_trims_trailing_slash_and_newline() {
+        assert_eq!(
+            unc_projects_path("Debian", "/root/\n"),
+            r"\\wsl.localhost\Debian\root\.claude\projects"
+        );
+    }
+
+    #[test]
+    fn unc_path_handles_root_home() {
+        assert_eq!(
+            unc_projects_path("Alpine", "/"),
+            r"\\wsl.localhost\Alpine\.claude\projects"
+        );
+    }
+
+    // --- resolve_distro_projects_dir (non-Windows: run_wsl is a no-op) ---
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn resolve_returns_none_off_windows() {
+        assert_eq!(resolve_distro_projects_dir("Ubuntu"), None);
+    }
+
+    // --- list_distros (non-Windows) ---
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn list_distros_empty_off_windows() {
+        assert!(list_distros().is_empty());
+    }
+
+    // --- collect_project_dirs ---
+
+    #[test]
+    fn collect_lists_base_subdirs_no_distros() {
+        let tmp = std::env::temp_dir().join("cctrace-wsl-collect-test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("-home-me-proj-a")).unwrap();
+        std::fs::create_dir_all(tmp.join("-home-me-proj-b")).unwrap();
+        // A stray file should be ignored.
+        std::fs::write(tmp.join("not-a-dir.txt"), "x").unwrap();
+
+        let dirs = collect_project_dirs(Some(tmp.to_str().unwrap()), &[]);
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs.iter().any(|d| d.ends_with("-home-me-proj-a")));
+        assert!(dirs.iter().any(|d| d.ends_with("-home-me-proj-b")));
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn collect_skips_missing_base_dir() {
+        // A non-existent configured path falls back to the default
+        // ~/.claude/projects, which may or may not exist on the test machine.
+        // Either way it must not panic and must never yield empty path strings.
+        let dirs = collect_project_dirs(Some("/no/such/path/at/all/xyz"), &[]);
+        assert!(dirs.iter().all(|d| !d.is_empty()));
+    }
+}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -9,11 +9,16 @@ vi.mock("../lib/invoke", () => ({
 
 const DEFAULT_DIR = "/Users/x/.claude/projects";
 
-const makeSettings = (projects_dir: string | null, effective_dir_exists = true) => ({
+const makeSettings = (
+  projects_dir: string | null,
+  effective_dir_exists = true,
+  wsl_distros: string[] = [],
+) => ({
   projects_dir,
   default_dir: DEFAULT_DIR,
   effective_dir: projects_dir ?? DEFAULT_DIR,
   effective_dir_exists,
+  wsl_distros,
 });
 
 describe("SettingsModal", () => {
@@ -25,6 +30,8 @@ describe("SettingsModal", () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === "get_settings") return Promise.resolve(makeSettings(null));
       if (cmd === "set_projects_dir") return Promise.resolve(makeSettings(null));
+      if (cmd === "set_wsl_distros") return Promise.resolve(makeSettings(null));
+      if (cmd === "list_wsl_distros") return Promise.resolve([]);
       return Promise.resolve();
     });
   });
@@ -96,6 +103,50 @@ describe("SettingsModal", () => {
 
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith("set_projects_dir", { path: null });
+    });
+    expect(onSaved).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows no-distros hint when WSL reports none", async () => {
+    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No WSL distributions detected/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders detected WSL distros with configured ones checked", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_settings") return Promise.resolve(makeSettings(null, true, ["Ubuntu"]));
+      if (cmd === "list_wsl_distros") return Promise.resolve(["Ubuntu", "Debian"]);
+      return Promise.resolve();
+    });
+    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+
+    await waitFor(() => expect(screen.getByLabelText("Ubuntu")).toBeInTheDocument());
+    expect((screen.getByLabelText("Ubuntu") as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByLabelText("Debian") as HTMLInputElement).checked).toBe(false);
+  });
+
+  it("persists toggled WSL distros on save", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_settings") return Promise.resolve(makeSettings(null, true, ["Ubuntu"]));
+      if (cmd === "list_wsl_distros") return Promise.resolve(["Ubuntu", "Debian"]);
+      if (cmd === "set_projects_dir") return Promise.resolve(makeSettings(null, true, ["Ubuntu"]));
+      if (cmd === "set_wsl_distros")
+        return Promise.resolve(makeSettings(null, true, ["Ubuntu", "Debian"]));
+      return Promise.resolve();
+    });
+    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+
+    await waitFor(() => expect(screen.getByLabelText("Debian")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText("Debian"));
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("set_wsl_distros", {
+        distros: ["Ubuntu", "Debian"],
+      });
     });
     expect(onSaved).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ interface SettingsResponse {
   default_dir: string;
   effective_dir: string;
   effective_dir_exists: boolean;
+  wsl_distros: string[];
 }
 
 interface SettingsModalProps {
@@ -14,11 +15,20 @@ interface SettingsModalProps {
   onSaved: () => void;
 }
 
+/** Merge detected distros with already-configured ones so configured-but-offline
+ * distros still appear (and stay toggleable) even when WSL isn't reporting them. */
+function mergeDistros(available: string[], configured: string[]): string[] {
+  const seen = new Set(available);
+  return [...available, ...configured.filter((d) => !seen.has(d))];
+}
+
 export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
   const [projectsDir, setProjectsDir] = useState("");
   const [defaultDir, setDefaultDir] = useState("");
   const [effectiveDir, setEffectiveDir] = useState("");
   const [effectiveDirExists, setEffectiveDirExists] = useState(true);
+  const [availableDistros, setAvailableDistros] = useState<string[]>([]);
+  const [selectedDistros, setSelectedDistros] = useState<Set<string>>(new Set());
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
 
@@ -27,6 +37,7 @@ export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
     setProjectsDir(res.projects_dir ?? "");
     setEffectiveDir(res.effective_dir);
     setEffectiveDirExists(res.effective_dir_exists);
+    setSelectedDistros(new Set(res.wsl_distros ?? []));
   }, []);
 
   useEffect(() => {
@@ -37,18 +48,36 @@ export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
       } catch (err) {
         console.error("Failed to load settings:", err);
       }
+      try {
+        const distros = await invoke<string[]>("list_wsl_distros");
+        setAvailableDistros(distros ?? []);
+      } catch (err) {
+        console.error("Failed to list WSL distros:", err);
+      }
     };
     void load();
   }, [applyResponse]);
+
+  const toggleDistro = useCallback((name: string) => {
+    setSelectedDistros((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
 
   const handleSave = useCallback(async () => {
     setSaving(true);
     setError("");
     try {
-      const res = await invoke<SettingsResponse>("set_projects_dir", {
+      const dirRes = await invoke<SettingsResponse>("set_projects_dir", {
         path: projectsDir.trim() || null,
       });
-      applyResponse(res);
+      const wslRes = await invoke<SettingsResponse>("set_wsl_distros", {
+        distros: [...selectedDistros],
+      });
+      applyResponse(wslRes ?? dirRes);
       onSaved();
       onClose();
     } catch (err) {
@@ -56,7 +85,7 @@ export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
     } finally {
       setSaving(false);
     }
-  }, [projectsDir, applyResponse, onSaved, onClose]);
+  }, [projectsDir, selectedDistros, applyResponse, onSaved, onClose]);
 
   const handleReset = useCallback(async () => {
     setSaving(true);
@@ -83,12 +112,14 @@ export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
     [handleSave],
   );
 
+  const distros = mergeDistros(availableDistros, [...selectedDistros]);
+
   return (
     <PopoutModal
       onClose={onClose}
       header={<span className="settings-modal__title">Settings</span>}
       initialWidth={520}
-      initialHeight={260}
+      initialHeight={400}
     >
       <div className="settings-modal">
         <label className="settings-modal__label" htmlFor="projects-dir">
@@ -120,6 +151,33 @@ export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
             {effectiveDirExists ? "✓ Active:" : "✗ Not found:"} {effectiveDir}
           </p>
         )}
+
+        <label className="settings-modal__label settings-modal__label--section">WSL Distros</label>
+        {distros.length === 0 ? (
+          <p className="settings-modal__hint">
+            No WSL distributions detected. Sessions created inside WSL appear here once a distro is
+            installed.
+          </p>
+        ) : (
+          <>
+            <p className="settings-modal__hint">
+              Include projects from Claude Code running inside these distributions.
+            </p>
+            <div className="settings-modal__wsl">
+              {distros.map((name) => (
+                <label key={name} className="settings-modal__wsl-item">
+                  <input
+                    type="checkbox"
+                    checked={selectedDistros.has(name)}
+                    onChange={() => toggleDistro(name)}
+                  />
+                  <span>{name}</span>
+                </label>
+              ))}
+            </div>
+          </>
+        )}
+
         {error && <p className="settings-modal__error">{error}</p>}
         <div className="settings-modal__actions">
           <button

--- a/src/lib/invoke.test.ts
+++ b/src/lib/invoke.test.ts
@@ -60,6 +60,29 @@ describe("invoke (web/HTTP mode)", () => {
     expect(res).toEqual(dirs);
   });
 
+  it("list_wsl_distros calls GET /api/wsl/distros", async () => {
+    const distros = ["Ubuntu", "Debian"];
+    mockFetch(distros);
+    const { invoke } = await import("./invoke");
+
+    const res = await invoke<string[]>("list_wsl_distros");
+    expect(res).toEqual(distros);
+  });
+
+  it("set_wsl_distros calls POST /api/wsl/distros with distros body", async () => {
+    const fetchFn = mockFetch({ wsl_distros: ["Ubuntu"] });
+    const { invoke } = await import("./invoke");
+
+    await invoke("set_wsl_distros", { distros: ["Ubuntu"] });
+    expect(fetchFn).toHaveBeenCalledWith(
+      `${API_BASE}/api/wsl/distros`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ distros: ["Ubuntu"] }),
+      }),
+    );
+  });
+
   it("discover_sessions calls POST /api/sessions with dirs body", async () => {
     const fetchFn = mockFetch([]);
     const { invoke } = await import("./invoke");

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -26,6 +26,12 @@ const routes: Record<string, Route> = {
     path: "/api/settings/dir",
     body: (a) => ({ path: a.path ?? null }),
   },
+  list_wsl_distros: { path: "/api/wsl/distros" },
+  set_wsl_distros: {
+    method: "POST",
+    path: "/api/wsl/distros",
+    body: (a) => ({ distros: (a.distros as string[]) ?? [] }),
+  },
   get_project_dirs: { path: "/api/project-dirs" },
   discover_sessions: {
     method: "POST",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2443,6 +2443,34 @@ body {
   letter-spacing: 0.5px;
 }
 
+.settings-modal__label--section {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+
+.settings-modal__wsl {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 120px;
+  overflow-y: auto;
+}
+
+.settings-modal__wsl-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.settings-modal__wsl-item input {
+  cursor: pointer;
+  accent-color: var(--accent);
+}
+
 .settings-modal__input {
   width: 100%;
   padding: 6px 8px;


### PR DESCRIPTION
## What

On Windows, Claude Code running inside a WSL distribution stores its projects under the Linux home (`~/.claude/projects`), reachable from the host through the `\wsl.localhost\<distro>\...` UNC share. This PR adds **opt-in discovery** of those sessions so they appear alongside the host's own projects.

## How

- **`wsl` module** (`src-tauri/src/wsl.rs`): enumerates installed distros via `wsl --list --quiet` (decoding its UTF-16LE output), resolves each distro's `~/.claude/projects` to a `\wsl.localhost` UNC path (cached per distro for the process lifetime), and aggregates the per-project subdirectories. All `wsl.exe` invocation is gated to `#[cfg(target_os = "windows")]` with `CREATE_NO_WINDOW`; the parsing and path helpers are pure and unit-tested on every platform, so non-Windows hosts simply contribute nothing.
- **Settings**: new persisted `wsl_distros: Vec<String>` field.
- **Commands / HTTP API**: `list_wsl_distros` and `set_wsl_distros` Tauri commands, mirrored as `GET`/`POST /api/wsl/distros` for the web transport. `get_project_dirs` now folds the configured distros' projects into the scan set.
- **UI**: the Settings modal lists detected distros as checkboxes, with an empty-state hint when none are found.

## Testing

- Rust: `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` (495 passed) — incl. new tests for distro-list parsing, UNC path building, `collect_project_dirs`, distro sanitize/dedupe, and settings round-trip.
- Frontend: `tsc --noEmit`, `oxlint`, `oxfmt --check` clean; new unit tests for the `invoke` route table and the SettingsModal rendering (run in CI).
- Verified end-to-end on Windows 11 with two installed distros: enabling a distro grew the discovered project set with the in-WSL projects (including nested worktrees).

## Notes / possible follow-up

Discovery over the `\wsl.localhost` 9P share is noticeably slower than local disk (~1–2s per full scan in my testing) and currently runs as blocking I/O inside the async handlers, with the picker watcher recursively watching the share. It's functionally correct and only active when a distro is enabled; moving the WSL scans off the async runtime (`spawn_blocking`) and using a non-recursive watch would be a reasonable hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)