### PR TITLE
fix(install): skip TUI build when tui directory is missing

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -47,11 +47,15 @@ else
   cargo install --path src-tauri
 fi
 
-echo "==> Building TUI..."
-cd tui
-npm install
-npm run build
-cd ..
+if [[ -d tui ]]; then
+  echo "==> Building TUI..."
+  cd tui
+  npm install
+  npm run build
+  cd ..
+else
+  echo "==> Skipping TUI build (tui directory not found)."
+fi
 
 echo "==> Linking cctrace CLI..."
 npm link


### PR DESCRIPTION
## What

Add a guard in `script/install.sh` to check whether the `tui` directory exists before building it.

## Why

The script ran `cd tui` unconditionally. In environments without a `tui` directory, `set -euo pipefail` caused the script to abort at that point, so it never reached the final `npm link` step (the `cctrace` CLI link) and the installation never completed.

## How

Build the TUI only when the `tui` directory exists; otherwise pnue with the remaining install steps.