### PR TITLE
fix(wsl): grant ACL permissions for WSL distro commands

### DIFF
--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -13,6 +13,8 @@ permissions = [
   "allow-get-project-dirs",
   "allow-get-settings",
   "allow-set-projects-dir",
+  "allow-list-wsl-distros",
+  "allow-set-wsl-distros",
   "allow-switch-to-browser",
 ]
 
@@ -75,6 +77,16 @@ commands.allow = ["get_settings"]
 identifier = "allow-set-projects-dir"
 description = "Allow setting the projects directory"
 commands.allow = ["set_projects_dir"]
+
+[[permission]]
+identifier = "allow-list-wsl-distros"
+description = "Allow listing installed WSL distributions"
+commands.allow = ["list_wsl_distros"]
+
+[[permission]]
+identifier = "allow-set-wsl-distros"
+description = "Allow setting the WSL distributions to discover"
+commands.allow = ["set_wsl_distros"]
 
 [[permission]]
 identifier = "allow-switch-to-browser"

--- a/src-tauri/tests/acl_consistency.rs
+++ b/src-tauri/tests/acl_consistency.rs
@@ -1,0 +1,119 @@
+//! Regression guard for the Tauri ACL.
+//!
+//! Every IPC command registered in `tauri::generate_handler![ ... ]` must also be
+//! granted by the `[default]` permission set in `permissions/default.toml`.
+//! Otherwise the desktop build rejects the call at runtime with
+//! `Command <name> not allowed by ACL` — the bug that hit `set_wsl_distros` when
+//! the WSL feature added the handler but forgot the matching `commands.allow`
+//! entry. The check runs in both directions so a stale ACL grant is caught too.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+const LIB_RS: &str = include_str!("../src/lib.rs");
+const DEFAULT_TOML: &str = include_str!("../permissions/default.toml");
+
+/// Contents of every double-quoted string in `s`.
+fn quoted_strings(s: &str) -> BTreeSet<String> {
+    s.split('"')
+        .enumerate()
+        .filter(|(i, _)| i % 2 == 1)
+        .map(|(_, part)| part.to_string())
+        .collect()
+}
+
+/// Command names registered in `tauri::generate_handler![ ... ]` (last path segment).
+fn handler_commands() -> BTreeSet<String> {
+    let start = LIB_RS
+        .find("generate_handler![")
+        .expect("generate_handler! macro present in lib.rs");
+    let rest = &LIB_RS[start..];
+    let open = rest.find('[').expect("opening [ for generate_handler!");
+    let close = rest.find(']').expect("closing ] for generate_handler!");
+    rest[open + 1..close]
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(|t| t.rsplit("::").next().unwrap().trim().to_string())
+        .collect()
+}
+
+/// Identifiers referenced by the `[default]` permission set.
+fn default_permission_set() -> BTreeSet<String> {
+    let key = "permissions = [";
+    let start = DEFAULT_TOML
+        .find(key)
+        .expect("[default] permissions array present");
+    let after = &DEFAULT_TOML[start + key.len()..];
+    let end = after.find(']').expect("closing ] for default permissions");
+    quoted_strings(&after[..end])
+}
+
+/// Map of each `[[permission]]` identifier to the commands it allows.
+fn permission_blocks() -> BTreeMap<String, BTreeSet<String>> {
+    let mut map = BTreeMap::new();
+    for chunk in DEFAULT_TOML.split("[[permission]]").skip(1) {
+        let Some(id_line) = chunk
+            .lines()
+            .find(|l| l.trim_start().starts_with("identifier"))
+        else {
+            continue;
+        };
+        let Some(id) = quoted_strings(id_line).into_iter().next() else {
+            continue;
+        };
+        let key = "commands.allow = [";
+        let cmds = match chunk.find(key) {
+            Some(s) => {
+                let after = &chunk[s + key.len()..];
+                let end = after.find(']').unwrap_or(after.len());
+                quoted_strings(&after[..end])
+            }
+            None => BTreeSet::new(),
+        };
+        map.insert(id, cmds);
+    }
+    map
+}
+
+/// Commands granted by the `[default]` permission set.
+fn acl_granted_commands() -> BTreeSet<String> {
+    let referenced = default_permission_set();
+    let blocks = permission_blocks();
+    referenced
+        .iter()
+        .filter_map(|id| blocks.get(id))
+        .flat_map(|cmds| cmds.iter().cloned())
+        .collect()
+}
+
+#[test]
+fn handler_and_acl_grant_the_same_commands() {
+    let handler = handler_commands();
+    let granted = acl_granted_commands();
+
+    let missing_from_acl: Vec<_> = handler.difference(&granted).collect();
+    assert!(
+        missing_from_acl.is_empty(),
+        "commands registered in generate_handler! but missing an ACL `commands.allow` entry \
+         (these fail at runtime with `Command <name> not allowed by ACL`): {missing_from_acl:?}"
+    );
+
+    let extra_in_acl: Vec<_> = granted.difference(&handler).collect();
+    assert!(
+        extra_in_acl.is_empty(),
+        "ACL grants commands that are not registered in generate_handler!: {extra_in_acl:?}"
+    );
+}
+
+#[test]
+fn wsl_commands_are_acl_granted() {
+    let granted = acl_granted_commands();
+    assert!(
+        granted.contains("list_wsl_distros"),
+        "list_wsl_distros must be ACL-granted"
+    );
+    assert!(
+        granted.contains("set_wsl_distros"),
+        "set_wsl_distros must be ACL-granted"
+    );
+}


### PR DESCRIPTION
## Problem

Disabling a WSL distro and saving the Settings modal fails on the **desktop build** with:

> Command set_wsl_distros not allowed by ACL

The WSL discovery feature (#164) registered `list_wsl_distros` and `set_wsl_distros` in the Tauri invoke handler ([`src-tauri/src/lib.rs`](https://github.com/delexw/claude-code-trace/blob/main/src-tauri/src/lib.rs)) but never added the matching ACL `commands.allow` entries to `src-tauri/permissions/default.toml`. In Tauri v2, the desktop IPC layer rejects any command that isn't granted by a capability, so:

- `set_wsl_distros` (called on **Save**) surfaced the visible error to the user.
- `list_wsl_distros` (called when the modal opens) was also blocked, but the error was swallowed by a `try/catch` that only logs to the console.

This only affects the desktop (Tauri IPC) build. Browser/web mode goes through the HTTP API, which doesn't use the ACL — which is why the existing tests and web flow didn't catch it.

## Fix

Add `allow-list-wsl-distros` and `allow-set-wsl-distros` to the default permission set in `permissions/default.toml`.

## Regression test

Added `src-tauri/tests/acl_consistency.rs`, which cross-checks — in both directions — that every command registered in `tauri::generate_handler!` is granted by the ACL `[default]` permission set. This catches the exact class of bug that occurred (a command wired into the handler but missing its ACL grant) at test time instead of at runtime. Verified the test **fails** without the fix (reporting the missing `list_wsl_distros`/`set_wsl_distros` grants) and **passes** with it.

Note: the generated `src-tauri/gen/schemas/*` artifacts are left to regenerate on build (Tauri embeds the ACL from `permissions/*.toml` at compile time), to keep the diff to the source-of-truth change.

## Verification

- `cargo build` / `cargo test` / `cargo clippy --all-targets` / `cargo fmt --check` — pass
- `tsc --noEmit`, `oxlint` — clean
- New ACL consistency test passes (and fails when the grants are removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
