### PR TITLE
fix(compat): handle v2.1.186 background subagent permission prompt attribution fields

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -60,6 +60,10 @@ export interface DisplayItem {
   /** Tool result as pretty-printed JSON when the content is an object or array. */
   tool_result_json: string;
   is_orphan: boolean;
+  /** v2.1.186+: name of the background subagent that triggered a cross-session permission prompt. */
+  hook_source_agent_name: string;
+  /** v2.1.186+: session UUID of the background subagent requesting permission. */
+  hook_requesting_agent_uuid: string;
 }
 
 export interface LastOutput {

--- a/specs/01-parser-pipeline.md
+++ b/specs/01-parser-pipeline.md
@@ -67,35 +67,39 @@ Each JSONL line is decoded into an `Entry` struct that mirrors the raw Claude Co
 
 ### Key Fields
 
-| Field                | Description                                                                                                                                     |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `uuid`               | Unique message identifier                                                                                                                       |
-| `entry_type`         | Discriminant: `user`, `assistant`, `system`, `hook_event`, etc.                                                                                 |
-| `role`               | Same as `entry_type` for most messages                                                                                                          |
-| `content`            | Message body (string or content-block array)                                                                                                    |
-| `model`              | Model string (assistant messages only)                                                                                                          |
-| `subtype`            | Hook subtype: `PreToolUse`, `PostToolUse`, `Stop`, …                                                                                            |
-| `hookEvent`          | Hook event name                                                                                                                                 |
-| `isCompactSummary`   | Compaction boundary marker                                                                                                                      |
-| `away_summary`       | Session-recap text                                                                                                                              |
-| `forkedFrom`         | Pre-v2.1.118 fork reference                                                                                                                     |
-| `tool_use_result`    | JSON object for tool results                                                                                                                    |
-| `background_tasks`   | v2.1.145+: running background task descriptors (Stop/SubagentStop hooks)                                                                        |
-| `session_crons`      | v2.1.145+: registered session cron jobs (Stop/SubagentStop hooks)                                                                               |
-| `hookSpecificOutput` | v2.1.163+: hook result payload; `additionalContext` sub-field carries feedback text injected back into the session                              |
-| `workflowId`         | v2.1.154+: workflow identifier on lifecycle entries                                                                                             |
-| `workflowName`       | v2.1.154+: workflow name on lifecycle entries                                                                                                   |
-| `workflowRunUrl`     | v2.1.154+: workflow run URL on lifecycle entries                                                                                                |
-| `workflowStatus`     | v2.1.154+: workflow run status on lifecycle entries                                                                                             |
-| `agentDepth`         | v2.1.172+: 1-indexed nesting depth for sidechain entries from deeply nested sub-agents (up to 5 levels)                                         |
-| `parentAgentName`    | v2.1.172+: name of the spawning agent for deeply nested sidechain attribution                                                                   |
-| `version`            | v2.1.141+: Claude Code version string (e.g. `"2.1.195"`) on all entries from SDK/background-agent sessions; acts as schema-version discriminant |
-| `entrypoint`         | v2.1.141+: how Claude Code was invoked (`"sdk-ts"`, `"cli"`, …); present on all background-agent session entries                                |
-| `sessionId`          | v2.1.141+: owning session UUID; on all background-agent entries and on `last-prompt`/`queue-operation` metadata                                 |
-| `agentId`            | v2.1.141+: opaque background-agent instance ID (distinct from the human-readable `agentName`)                                                   |
-| `userType`           | v2.1.141+: actor classification (`"external"` for SDK/background agents, `"human"` for interactive CLI)                                         |
-| `attributionSkill`   | v2.1.141+: skill name that spawned this background-agent session; absent for directly-launched agents                                           |
-| `lastPrompt`         | v2.1.195+: prompt text in `type:"last-prompt"` checkpoint entries; used by Claude Code for background-agent resume                              |
+| Field                 | Description                                                                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `uuid`                | Unique message identifier                                                                                                                       |
+| `entry_type`          | Discriminant: `user`, `assistant`, `system`, `hook_event`, etc.                                                                                 |
+| `role`                | Same as `entry_type` for most messages                                                                                                          |
+| `content`             | Message body (string or content-block array)                                                                                                    |
+| `model`               | Model string (assistant messages only)                                                                                                          |
+| `subtype`             | Hook subtype: `PreToolUse`, `PostToolUse`, `Stop`, …                                                                                            |
+| `hookEvent`           | Hook event name                                                                                                                                 |
+| `isCompactSummary`    | Compaction boundary marker                                                                                                                      |
+| `away_summary`        | Session-recap text                                                                                                                              |
+| `forkedFrom`          | Pre-v2.1.118 fork reference                                                                                                                     |
+| `tool_use_result`     | JSON object for tool results                                                                                                                    |
+| `background_tasks`    | v2.1.145+: running background task descriptors (Stop/SubagentStop hooks)                                                                        |
+| `session_crons`       | v2.1.145+: registered session cron jobs (Stop/SubagentStop hooks)                                                                               |
+| `hookSpecificOutput`  | v2.1.163+: hook result payload; `additionalContext` sub-field carries feedback text injected back into the session                              |
+| `workflowId`          | v2.1.154+: workflow identifier on lifecycle entries                                                                                             |
+| `workflowName`        | v2.1.154+: workflow name on lifecycle entries                                                                                                   |
+| `workflowRunUrl`      | v2.1.154+: workflow run URL on lifecycle entries                                                                                                |
+| `workflowStatus`      | v2.1.154+: workflow run status on lifecycle entries                                                                                             |
+| `agentDepth`          | v2.1.172+: 1-indexed nesting depth for sidechain entries from deeply nested sub-agents (up to 5 levels)                                         |
+| `parentAgentName`     | v2.1.172+: name of the spawning agent for deeply nested sidechain attribution                                                                   |
+| `version`             | v2.1.141+: Claude Code version string (e.g. `"2.1.195"`) on all entries from SDK/background-agent sessions; acts as schema-version discriminant |
+| `entrypoint`          | v2.1.141+: how Claude Code was invoked (`"sdk-ts"`, `"cli"`, …); present on all background-agent session entries                                |
+| `sessionId`           | v2.1.141+: owning session UUID; on all background-agent entries and on `last-prompt`/`queue-operation` metadata                                 |
+| `agentId`             | v2.1.141+: opaque background-agent instance ID (distinct from the human-readable `agentName`)                                                   |
+| `userType`            | v2.1.141+: actor classification (`"external"` for SDK/background agents, `"human"` for interactive CLI)                                         |
+| `attributionSkill`    | v2.1.141+: skill name that spawned this background-agent session; absent for directly-launched agents                                           |
+| `lastPrompt`          | v2.1.195+: prompt text in `type:"last-prompt"` checkpoint entries; used by Claude Code for background-agent resume                              |
+| `sourceAgentName`     | v2.1.186+: display name of the background subagent requesting a cross-session permission prompt                                                 |
+| `requestingAgentUuid` | v2.1.186+: session UUID of the background subagent requesting a cross-session permission prompt                                                 |
+| `reason`              | v2.1.193+: human-readable denial explanation in `auto-mode-denial` / `permission-denial` entries                                                |
+| `toolName`            | v2.1.193+: name of the blocked tool in `auto-mode-denial` entries                                                                               |
 
 ```mermaid
 classDiagram
@@ -153,7 +157,9 @@ flowchart TD
 | Thinking-only assistant entries (`content` = one `thinking` block, no `text`/`tool_use`)                                               | v2.1.183+    | Non-empty content array passes the empty-content guard; classified as `AIMsg` with `thinking_count=1` and empty `text`. Rendered with thinking block, no empty-bubble discard.                                                                                                                                                         |
 | Synthetic re-prompt `isMeta: true` user entries after thinking-only turns                                                              | v2.1.183+    | `classify()` returns `None` for `user` entries with `is_meta: true` that don't match a known pattern (Stop hook feedback). Prevents spurious meta-AI bubbles.                                                                                                                                                                          |
 | Background-agent sessions carry new top-level fields (`version`, `entrypoint`, `sessionId`, `agentId`, `userType`, `attributionSkill`) | v2.1.141+    | Added to `Entry` struct; silently ignored for display but captured for future use / forward-compat reasoning.                                                                                                                                                                                                                          |
+| Background subagent permission prompts appear in main session with `sourceAgentName` / `requestingAgentUuid`                           | v2.1.186+    | Both fields added to `Entry` with `#[serde(default)]`; propagated through `classify()` → `HookMsg` → `chunk.rs` → `FrontendDisplayItem`; `DetailItem` renders a "Requesting Agent" section when non-empty.                                                                                                                             |
 | `/rewind` support — new `rewind-pointer` entry type; `rewindable` + `checkpointUuid` fields on summary/compact_boundary                | v2.1.191+    | `rewind-pointer` added to `NOISE_ENTRY_TYPES`; `rewind_to_uuid`, `rewindable`, `checkpoint_uuid` captured on `Entry`. Chain resolver unchanged — `leafUuid` always points to the live tip; post-rewind entries have `parentUuid` pointing to the pre-clear anchor, so the backward walk naturally bypasses the dead post-clear branch. |
+| Auto-mode denial entries (`type:"auto-mode-denial"` / `"permission-denial"`) with `reason` and `toolName`                              | v2.1.193+    | Both fields added to `Entry` with `#[serde(default)]`; captured for display and future denial-history rendering.                                                                                                                                                                                                                       |
 | `type:"last-prompt"` checkpoint entry (background-agent resume state)                                                                  | v2.1.195+    | Added `"last-prompt"` to `NOISE_ENTRY_TYPES`; `lastPrompt` field added to `Entry`. Entry passes `parse_entry` (has `leafUuid`) but is explicitly discarded by classify before reaching conversation display.                                                                                                                           |
 
 ---

--- a/src-tauri/src/convert.rs
+++ b/src-tauri/src/convert.rs
@@ -46,6 +46,9 @@ pub struct FrontendDisplayItem {
     pub is_orphan: bool,
     pub subagent_prompt: String,
     pub is_deferred: bool,
+    // v2.1.186+: agent attribution for cross-session permission prompts from background subagents.
+    pub hook_source_agent_name: String,
+    pub hook_requesting_agent_uuid: String,
 }
 
 /// Frontend last output.
@@ -273,6 +276,8 @@ fn convert_display_items(
                 is_orphan: it.is_orphan,
                 subagent_prompt: String::new(),
                 is_deferred: it.is_deferred,
+                hook_source_agent_name: it.hook_source_agent_name.clone(),
+                hook_requesting_agent_uuid: it.hook_requesting_agent_uuid.clone(),
             };
 
             // Link subagent process if available (Subagent items and ToolCall items like Skill).

--- a/src-tauri/src/parser/chunk.rs
+++ b/src-tauri/src/parser/chunk.rs
@@ -50,6 +50,9 @@ pub struct DisplayItem {
     /// True when the session was suspended via a "defer" PreToolUse permission decision
     /// before a tool_result arrived for this tool_use block.
     pub is_deferred: bool,
+    // v2.1.186+: agent attribution for cross-session permission prompts from background subagents.
+    pub hook_source_agent_name: String,
+    pub hook_requesting_agent_uuid: String,
 }
 
 impl Default for DisplayItem {
@@ -78,6 +81,8 @@ impl Default for DisplayItem {
             tool_result_json: None,
             is_orphan: false,
             is_deferred: false,
+            hook_source_agent_name: String::new(),
+            hook_requesting_agent_uuid: String::new(),
         }
     }
 }
@@ -214,6 +219,8 @@ pub fn build_chunks(msgs: &[ClassifiedMsg]) -> Vec<Chunk> {
                         tool_name: m.hook_name.clone(),
                         tool_id: m.hook_event.clone(),
                         hook_metadata: m.metadata.clone(),
+                        hook_source_agent_name: m.source_agent_name.clone(),
+                        hook_requesting_agent_uuid: m.requesting_agent_uuid.clone(),
                         ..Default::default()
                     }],
                     usage: Usage::default(),
@@ -370,6 +377,8 @@ fn merge_ai_buffer(buf: &[AIMsg], orphan_pending: bool) -> Chunk {
                             hook_name: b.tool_name.clone(),
                             hook_command: b.text.clone(),
                             hook_metadata: b.hook_metadata.clone(),
+                            hook_source_agent_name: b.hook_source_agent_name.clone(),
+                            hook_requesting_agent_uuid: b.hook_requesting_agent_uuid.clone(),
                             ..Default::default()
                         });
                     }

--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -44,6 +44,9 @@ pub struct ContentBlock {
     pub hook_metadata: Option<Value>,
     /// For tool_result blocks: raw content value before stringification.
     pub content_json: Option<Value>,
+    /// For hook_event blocks (v2.1.186+): attribution for cross-session permission prompts.
+    pub hook_source_agent_name: String,
+    pub hook_requesting_agent_uuid: String,
 }
 
 /// Classified message types.
@@ -109,6 +112,10 @@ pub struct HookMsg {
     /// All key-value pairs from the hook attachment JSON (stdout, stderr, command,
     /// exitCode, durationMs, additionalContext, decision, reason, …).
     pub metadata: Option<Value>,
+    // v2.1.186+: when a background subagent surfaces a permission prompt in the main session,
+    // these fields identify the requesting agent. Empty on all non-cross-session hook entries.
+    pub source_agent_name: String,
+    pub requesting_agent_uuid: String,
 }
 
 pub const SYSTEM_OUTPUT_TAGS: &[&str] = &[
@@ -148,6 +155,17 @@ const NOISE_ENTRY_TYPES: &[&str] = &[
     "last-prompt",
 ];
 
+// v2.1.193+: auto-mode denial reasons written to transcript. The entry may use one of these
+// top-level type values, or appear as a progress entry with data.type set to one of them.
+const AUTO_MODE_DENIAL_ENTRY_TYPES: &[&str] = &["auto-mode-denial", "permission-denial"];
+// data.type values used when the denial is embedded inside a progress entry.
+const AUTO_MODE_DENIAL_DATA_TYPES: &[&str] = &[
+    "auto_mode_denial",
+    "auto-mode-denial",
+    "permission_denial",
+    "permission-denial",
+];
+
 const HARD_NOISE_TAGS: &[&str] = &["<local-command-caveat>", "<system-reminder>"];
 
 const EMPTY_STDOUT: &str = "<local-command-stdout></local-command-stdout>";
@@ -179,8 +197,8 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
     // are also rescued without needing to enumerate data.type values.
     if e.entry_type == "progress" {
         if let Some(ref data) = e.data {
-            let is_hook = data.get("type").and_then(|v| v.as_str()) == Some("hook_progress")
-                || data.get("hookEvent").is_some();
+            let data_type = data.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let is_hook = data_type == "hook_progress" || data.get("hookEvent").is_some();
             if is_hook {
                 let hook_event = data
                     .get("hookEvent")
@@ -198,12 +216,36 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     .unwrap_or_default();
                 // v2.1.163+: hookSpecificOutput may be nested inside data for progress entries.
                 let metadata = data.get("hookSpecificOutput").cloned();
+                // v2.1.186+: attribution fields surface on the entry itself (not inside data).
+                let source_agent_name = e.source_agent_name.clone();
+                let requesting_agent_uuid = e.requesting_agent_uuid.clone();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event,
                     hook_name,
                     command,
                     metadata,
+                    source_agent_name,
+                    requesting_agent_uuid,
+                }));
+            }
+            // v2.1.193+: auto-mode denial reasons may be embedded inside a progress entry.
+            if AUTO_MODE_DENIAL_DATA_TYPES.contains(&data_type) {
+                let reason = data
+                    .get("reason")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let tool_name = data
+                    .get("toolName")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let output = format_denial_output(&tool_name, &reason);
+                return Some(ClassifiedMsg::System(SystemMsg {
+                    timestamp: ts,
+                    output,
+                    is_error: false,
                 }));
             }
         }
@@ -243,6 +285,8 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     hook_name,
                     command: String::new(),
                     metadata,
+                    source_agent_name: String::new(),
+                    requesting_agent_uuid: String::new(),
                 }));
             }
             // hook_progress: written in verbose/stream-json mode for mid-session hooks.
@@ -255,6 +299,8 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     hook_name: e.hook_name.clone(),
                     command: String::new(),
                     metadata,
+                    source_agent_name: e.source_agent_name.clone(),
+                    requesting_agent_uuid: e.requesting_agent_uuid.clone(),
                 }));
             }
             // hookEvent present on any system entry (forward-compat for future hook types).
@@ -267,6 +313,8 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     hook_name: e.hook_name.clone(),
                     command: String::new(),
                     metadata,
+                    source_agent_name: e.source_agent_name.clone(),
+                    requesting_agent_uuid: e.requesting_agent_uuid.clone(),
                 }));
             }
             _ => {}
@@ -310,12 +358,26 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                 // additionalContext (when stdout is parsed JSON), decision, reason, etc.
                 // Any nested JSON strings (e.g. stdout) are left for the frontend to expand.
                 let metadata = Some(att.clone());
+                // v2.1.186+: attribution fields may also appear on attachment entries when a
+                // background subagent surfaces its permission prompt in the main session.
+                let source_agent_name = att
+                    .get("sourceAgentName")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let requesting_agent_uuid = att
+                    .get("requestingAgentUuid")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
                 return Some(ClassifiedMsg::Hook(HookMsg {
                     timestamp: ts,
                     hook_event: hook_event.to_string(),
                     hook_name,
                     command,
                     metadata,
+                    source_agent_name,
+                    requesting_agent_uuid,
                 }));
             }
         }
@@ -360,6 +422,8 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                 hook_name,
                 command,
                 metadata: None,
+                source_agent_name: String::new(),
+                requesting_agent_uuid: String::new(),
             }));
         }
         // v2.1.183+: synthetic re-prompt user entries are internal Claude Code markers
@@ -498,6 +562,17 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
         }));
     }
 
+    // v2.1.193+: top-level auto-mode denial entries carry reason and toolName at the top level.
+    // Rescue them before the empty-role drop so they appear as system notices in the UI.
+    if AUTO_MODE_DENIAL_ENTRY_TYPES.contains(&e.entry_type.as_str()) {
+        let output = format_denial_output(&e.tool_name, &e.reason);
+        return Some(ClassifiedMsg::System(SystemMsg {
+            timestamp: ts,
+            output,
+            is_error: false,
+        }));
+    }
+
     // Unknown entry types with no message role (e.g. rate_limit_event, CwdChanged,
     // FileChanged, --channels injected entries) are structural metadata — drop them.
     if e.message.role.is_empty() {
@@ -541,6 +616,16 @@ fn extract_teammate_content(s: &str) -> String {
         .and_then(|c| c.get(1))
         .map(|m| m.as_str().trim().to_string())
         .unwrap_or_else(|| s.to_string())
+}
+
+/// Format a denial reason for display. Combines tool name and reason into a single notice string.
+fn format_denial_output(tool_name: &str, reason: &str) -> String {
+    match (tool_name.is_empty(), reason.is_empty()) {
+        (false, false) => format!("Auto-mode denied {tool_name}: {reason}"),
+        (false, true) => format!("Auto-mode denied {tool_name}"),
+        (true, false) => format!("Auto-mode denial: {reason}"),
+        (true, true) => "Auto-mode denial".to_string(),
+    }
 }
 
 /// Parse a "Stop hook feedback:\n[command]: output\n" string into (hook_name, command).
@@ -2449,6 +2534,137 @@ mod tests {
         );
     }
 
+    // --- Issue #168: v2.1.193+ auto-mode denial entries surface as SystemMsg ---
+
+    #[test]
+    fn classify_auto_mode_denial_top_level_type_produces_system_msg() {
+        // v2.1.193+: a new type:"auto-mode-denial" entry must be rescued from the
+        // unknown-type discard path and rendered as a SystemMsg so it appears in the UI.
+        let mut e = make_entry("user", None);
+        e.entry_type = "auto-mode-denial".to_string();
+        e.message.role = String::new();
+        e.reason = "Bash is not allowed in auto mode".to_string();
+        e.tool_name = "Bash".to_string();
+        match classify(e) {
+            Some(ClassifiedMsg::System(s)) => {
+                assert!(
+                    s.output.contains("Bash"),
+                    "output must mention the denied tool"
+                );
+                assert!(
+                    s.output.contains("not allowed in auto mode"),
+                    "output must include the denial reason"
+                );
+                assert!(!s.is_error, "denial is informational, not an error");
+            }
+            other => panic!("Expected System for auto-mode-denial entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_permission_denial_top_level_type_produces_system_msg() {
+        // v2.1.193+: alternative type:"permission-denial" must also produce SystemMsg.
+        let mut e = make_entry("user", None);
+        e.entry_type = "permission-denial".to_string();
+        e.message.role = String::new();
+        e.reason = "Write access denied by permission policy".to_string();
+        match classify(e) {
+            Some(ClassifiedMsg::System(s)) => {
+                assert!(
+                    s.output.contains("Write access denied"),
+                    "output must include the denial reason"
+                );
+                assert!(!s.is_error);
+            }
+            other => panic!("Expected System for permission-denial entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_auto_mode_denial_in_progress_entry_produces_system_msg() {
+        // v2.1.193+: denial reason embedded inside a progress entry (data.type="auto_mode_denial")
+        // must be rescued before the progress noise filter drops it.
+        let mut e = make_entry("user", None);
+        e.entry_type = "progress".to_string();
+        e.message.role = String::new();
+        e.data = Some(json!({
+            "type": "auto_mode_denial",
+            "reason": "Bash is not allowed in auto mode",
+            "toolName": "Bash"
+        }));
+        match classify(e) {
+            Some(ClassifiedMsg::System(s)) => {
+                assert!(
+                    s.output.contains("Bash"),
+                    "output must mention the denied tool"
+                );
+                assert!(
+                    s.output.contains("not allowed in auto mode"),
+                    "output must include the denial reason"
+                );
+                assert!(!s.is_error);
+            }
+            other => panic!("Expected System for progress auto_mode_denial entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_auto_mode_denial_progress_with_kebab_data_type_produces_system_msg() {
+        // The data.type value may also use kebab-case ("auto-mode-denial").
+        let mut e = make_entry("user", None);
+        e.entry_type = "progress".to_string();
+        e.message.role = String::new();
+        e.data = Some(json!({
+            "type": "auto-mode-denial",
+            "reason": "Tool not permitted",
+            "toolName": "Write"
+        }));
+        match classify(e) {
+            Some(ClassifiedMsg::System(s)) => {
+                assert!(s.output.contains("Write"), "output must mention the tool");
+                assert!(
+                    s.output.contains("Tool not permitted"),
+                    "output must include reason"
+                );
+            }
+            other => {
+                panic!("Expected System for kebab progress auto-mode-denial entry, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn classify_auto_mode_denial_without_reason_produces_fallback_system_msg() {
+        // When neither reason nor toolName is present, a generic notice must still be emitted.
+        let mut e = make_entry("user", None);
+        e.entry_type = "auto-mode-denial".to_string();
+        e.message.role = String::new();
+        match classify(e) {
+            Some(ClassifiedMsg::System(s)) => {
+                assert!(
+                    !s.output.is_empty(),
+                    "a non-empty fallback notice must be emitted"
+                );
+                assert!(!s.is_error);
+            }
+            other => panic!("Expected System for bare auto-mode-denial entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_auto_mode_denial_sidechain_is_dropped() {
+        // Sidechain entries are always dropped regardless of type — denial entries in
+        // sidechain sessions must not leak into the main conversation view.
+        let mut e = make_entry("user", None);
+        e.entry_type = "auto-mode-denial".to_string();
+        e.is_sidechain = true;
+        e.reason = "should be dropped".to_string();
+        assert!(
+            classify(e).is_none(),
+            "sidechain auto-mode-denial must be dropped"
+        );
+    }
+
     #[test]
     fn classify_background_agent_user_entry_produces_user_msg() {
         // v2.1.195+: background-agent user entries carry new top-level fields (version,
@@ -2467,6 +2683,138 @@ mod tests {
                 assert_eq!(u.text, "run the background task");
             }
             other => panic!("Expected User for background-agent user entry, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_progress_hook_entry_still_produces_hook_msg_after_denial_rescue() {
+        // Regression: adding the denial rescue inside the progress block must not
+        // break hook_progress entries that were already classified correctly.
+        let mut e = make_entry("user", None);
+        e.entry_type = "progress".to_string();
+        e.message.role = String::new();
+        e.data = Some(json!({
+            "type": "hook_progress",
+            "hookEvent": "PreToolUse",
+            "hookName": "my-hook",
+            "command": "~/.claude/hooks/guard.sh"
+        }));
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.hook_event, "PreToolUse");
+                assert_eq!(h.hook_name, "my-hook");
+            }
+            other => panic!(
+                "hook_progress must still produce HookMsg after denial rescue, got {other:?}"
+            ),
+        }
+    }
+
+    // --- Issue #171: v2.1.186+ background subagent permission prompt attribution ---
+
+    #[test]
+    fn classify_hook_progress_carries_source_agent_attribution_v2_1_186() {
+        // v2.1.186+: when a background subagent surfaces a permission prompt via a
+        // hook_progress system entry, sourceAgentName / requestingAgentUuid on the entry
+        // must propagate into HookMsg so the UI can attribute the request.
+        let mut e2 = Entry {
+            entry_type: "system".to_string(),
+            subtype: "hook_progress".to_string(),
+            hook_event: "PreToolUse".to_string(),
+            hook_name: "permission_check".to_string(),
+            source_agent_name: "background-explore-agent".to_string(),
+            requesting_agent_uuid: "session-uuid-bg-001".to_string(),
+            ..make_entry("user", None)
+        };
+        e2.message.role = String::new();
+        match classify(e2) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(
+                    h.source_agent_name, "background-explore-agent",
+                    "source_agent_name must propagate from entry to HookMsg"
+                );
+                assert_eq!(
+                    h.requesting_agent_uuid, "session-uuid-bg-001",
+                    "requesting_agent_uuid must propagate from entry to HookMsg"
+                );
+            }
+            other => panic!("Expected Hook for hook_progress with attribution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_progress_hook_carries_source_agent_attribution_from_entry_v2_1_186() {
+        // v2.1.186+: progress entries with hook data may also carry top-level attribution.
+        // The source_agent_name / requesting_agent_uuid on the Entry must propagate.
+        let mut e = make_entry("user", None);
+        e.entry_type = "progress".to_string();
+        e.message.role = String::new();
+        e.source_agent_name = "bg-task-agent".to_string();
+        e.requesting_agent_uuid = "agent-uuid-002".to_string();
+        e.data = Some(json!({
+            "type": "hook_progress",
+            "hookEvent": "PreToolUse",
+            "hookName": "perm-check",
+            "command": ""
+        }));
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.source_agent_name, "bg-task-agent");
+                assert_eq!(h.requesting_agent_uuid, "agent-uuid-002");
+            }
+            other => panic!("Expected Hook for progress hook with attribution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_hook_attachment_carries_source_agent_attribution_from_attachment_v2_1_186() {
+        // v2.1.186+: attachment entries may embed sourceAgentName / requestingAgentUuid
+        // inside the attachment object for cross-session permission prompts.
+        let e = Entry {
+            entry_type: "attachment".to_string(),
+            attachment: Some(json!({
+                "type": "hook_success",
+                "hookEvent": "PreToolUse",
+                "hookName": "permission_check",
+                "sourceAgentName": "bg-explore",
+                "requestingAgentUuid": "uuid-attach-003"
+            })),
+            ..make_entry("user", None)
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert_eq!(h.source_agent_name, "bg-explore");
+                assert_eq!(h.requesting_agent_uuid, "uuid-attach-003");
+            }
+            other => panic!("Expected Hook for attachment with attribution fields, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_regular_hook_has_empty_attribution_fields() {
+        // Non-cross-session hooks must have empty attribution so the UI does not show
+        // a phantom "Requesting Agent" section.
+        let e = Entry {
+            entry_type: "attachment".to_string(),
+            attachment: Some(json!({
+                "type": "hook_success",
+                "hookEvent": "PostToolUse",
+                "hookName": "my-hook"
+            })),
+            ..make_entry("user", None)
+        };
+        match classify(e) {
+            Some(ClassifiedMsg::Hook(h)) => {
+                assert!(
+                    h.source_agent_name.is_empty(),
+                    "source_agent_name must be empty for a regular hook"
+                );
+                assert!(
+                    h.requesting_agent_uuid.is_empty(),
+                    "requesting_agent_uuid must be empty for a regular hook"
+                );
+            }
+            other => panic!("Expected Hook for regular attachment, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/parser/debuglog.rs
+++ b/src-tauri/src/parser/debuglog.rs
@@ -251,6 +251,8 @@ pub fn extract_hook_msgs(session_path: &str) -> Vec<super::classify::ClassifiedM
                     hook_name,
                     command,
                     metadata: None,
+                    source_agent_name: String::new(),
+                    requesting_agent_uuid: String::new(),
                 },
             ))
         })
@@ -336,6 +338,8 @@ prompt captured\n\
                     hook_name,
                     command: e.extra.clone(),
                     metadata: None,
+                    source_agent_name: String::new(),
+                    requesting_agent_uuid: String::new(),
                 }))
             })
             .collect();

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -205,6 +205,22 @@ pub struct Entry {
     // the checkpoint was written.
     #[serde(default, rename = "lastPrompt")]
     pub last_prompt: String,
+    // Present in auto-mode denial entries (v2.1.193+). When Claude Code's auto-mode denies a
+    // tool call, it writes a denial entry to the transcript for replay and /permissions recent
+    // denials display. `reason` holds the human-readable denial explanation; `tool_name` names
+    // the tool that was blocked (may also appear in progress data for the same event).
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default, rename = "toolName")]
+    pub tool_name: String,
+    // Present in background subagent permission prompt entries (v2.1.186+). When a background
+    // subagent surfaces a permission prompt in the main session JSONL instead of being
+    // auto-denied, `source_agent_name` is the requesting subagent's display name and
+    // `requesting_agent_uuid` is its session UUID, allowing the UI to attribute the prompt.
+    #[serde(default, rename = "sourceAgentName")]
+    pub source_agent_name: String,
+    #[serde(default, rename = "requestingAgentUuid")]
+    pub requesting_agent_uuid: String,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -1550,6 +1566,60 @@ mod tests {
         assert_eq!(entry.message.stop_reason.as_deref(), Some("end_turn"));
     }
 
+    // --- Issue #168: v2.1.193+ auto-mode denial entries — reason and toolName fields ---
+
+    #[test]
+    fn parse_entry_captures_reason_and_tool_name_for_auto_mode_denial() {
+        // v2.1.193+: a new type:"auto-mode-denial" entry carries a top-level `reason` and
+        // `toolName` explaining why the tool call was blocked. Both must be captured.
+        let line = json!({
+            "type": "auto-mode-denial",
+            "uuid": "denial-uuid-001",
+            "timestamp": "2026-06-25T10:00:00Z",
+            "reason": "Bash is not allowed in auto mode",
+            "toolName": "Bash"
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse auto-mode-denial entry");
+        assert_eq!(entry.entry_type, "auto-mode-denial");
+        assert_eq!(entry.reason, "Bash is not allowed in auto mode");
+        assert_eq!(entry.tool_name, "Bash");
+    }
+
+    #[test]
+    fn parse_entry_captures_reason_for_permission_denial_type() {
+        // v2.1.193+: alternative type name "permission-denial" with only a reason (no toolName).
+        let line = json!({
+            "type": "permission-denial",
+            "uuid": "denial-uuid-002",
+            "timestamp": "2026-06-25T10:01:00Z",
+            "reason": "Write access denied by permission policy"
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse permission-denial entry");
+        assert_eq!(entry.entry_type, "permission-denial");
+        assert_eq!(entry.reason, "Write access denied by permission policy");
+        assert_eq!(
+            entry.tool_name, "",
+            "absent toolName must default to empty string"
+        );
+    }
+
+    #[test]
+    fn parse_entry_reason_and_tool_name_default_to_empty_when_absent() {
+        // Regular entries have no reason or toolName — both must default to "".
+        let line = json!({
+            "type": "user",
+            "uuid": "regular-uuid-no-denial",
+            "timestamp": "2026-06-25T10:00:00Z",
+            "message": {"role": "user", "content": "Hello"}
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse regular entry");
+        assert_eq!(entry.reason, "", "reason must be empty when absent");
+        assert_eq!(entry.tool_name, "", "toolName must be empty when absent");
+    }
+
     #[test]
     fn parse_entry_sidechain_with_all_depth_fields_succeeds() {
         // Full payload as Claude Code v2.1.172+ might write for a depth-3 sidechain entry.
@@ -1884,5 +1954,55 @@ mod tests {
         assert_eq!(entry.message.model, "claude-opus-4-7");
         assert_eq!(entry.message.usage.input_tokens, 100);
         assert_eq!(entry.message.usage.output_tokens, 20);
+    }
+
+    // --- Issue #171: v2.1.186+ background subagent permission prompt attribution fields ---
+
+    #[test]
+    fn parse_entry_captures_source_agent_name_and_requesting_agent_uuid_v2_1_186() {
+        // v2.1.186+: background subagent permission prompts surfaced in the main session JSONL
+        // carry sourceAgentName and requestingAgentUuid so the UI can attribute the request.
+        let line = json!({
+            "type": "progress",
+            "uuid": "perm-prompt-uuid-001",
+            "timestamp": "2026-06-28T08:00:00Z",
+            "sourceAgentName": "background-explore-agent",
+            "requestingAgentUuid": "session-uuid-bg-001",
+            "data": {
+                "type": "hook_progress",
+                "hookEvent": "PreToolUse",
+                "hookName": "permission_check",
+                "command": ""
+            }
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse progress entry with attribution");
+        assert_eq!(entry.source_agent_name, "background-explore-agent");
+        assert_eq!(entry.requesting_agent_uuid, "session-uuid-bg-001");
+    }
+
+    #[test]
+    fn parse_entry_source_agent_name_defaults_to_empty_when_absent() {
+        // Regular hook entries produced by the main agent have no attribution fields.
+        let line = json!({
+            "type": "attachment",
+            "uuid": "regular-hook-uuid",
+            "timestamp": "2026-06-28T08:01:00Z",
+            "attachment": {
+                "hookEvent": "PostToolUse",
+                "hookName": "format",
+                "type": "hook_success"
+            }
+        });
+        let bytes = serde_json::to_vec(&line).unwrap();
+        let entry = parse_entry(&bytes).expect("must parse attachment entry without attribution");
+        assert_eq!(
+            entry.source_agent_name, "",
+            "sourceAgentName must default to empty when absent"
+        );
+        assert_eq!(
+            entry.requesting_agent_uuid, "",
+            "requestingAgentUuid must default to empty when absent"
+        );
     }
 }

--- a/src/components/DetailItem.test.tsx
+++ b/src/components/DetailItem.test.tsx
@@ -31,6 +31,8 @@ function makeItem(overrides: Partial<DisplayItem> = {}): DisplayItem {
     hook_metadata: "",
     tool_result_json: "",
     is_orphan: false,
+    hook_source_agent_name: "",
+    hook_requesting_agent_uuid: "",
     ...overrides,
   };
 }
@@ -479,5 +481,49 @@ describe("DetailItem", () => {
     expect(screen.getByText("Hook")).toBeInTheDocument();
     expect(screen.getByText("Command")).toBeInTheDocument();
     expect(screen.getByText("prettier --write .")).toBeInTheDocument();
+  });
+
+  it("shows Requesting Agent section when hook_source_agent_name is set (v2.1.186+)", () => {
+    render(
+      <DetailItem
+        item={makeItem({
+          item_type: "HookEvent",
+          hook_event: "PreToolUse",
+          hook_name: "permission_check",
+          hook_source_agent_name: "background-explore-agent",
+          hook_requesting_agent_uuid: "session-uuid-bg-001",
+        })}
+        index={0}
+        isSelected={false}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        onToggleExpand={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Requesting Agent")).toBeInTheDocument();
+    expect(screen.getByText("background-explore-agent")).toBeInTheDocument();
+    expect(screen.getByText(/session-uuid-bg-001/)).toBeInTheDocument();
+  });
+
+  it("omits Requesting Agent section when hook_source_agent_name is empty", () => {
+    render(
+      <DetailItem
+        item={makeItem({
+          item_type: "HookEvent",
+          hook_event: "PostToolUse",
+          hook_name: "my-hook",
+          hook_source_agent_name: "",
+          hook_requesting_agent_uuid: "",
+        })}
+        index={0}
+        isSelected={false}
+        isExpanded={true}
+        onToggle={vi.fn()}
+        onToggleExpand={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Requesting Agent")).not.toBeInTheDocument();
   });
 });

--- a/src/components/DetailItem.tsx
+++ b/src/components/DetailItem.tsx
@@ -365,6 +365,17 @@ function DetailItemBody({ item }: { item: DisplayItem }) {
               </div>
             </div>
           )}
+          {item.hook_source_agent_name && (
+            <div className="detail-item__section">
+              <div className="detail-item__section-title">Requesting Agent</div>
+              <div className="detail-item__text detail-item__text--mono">
+                {item.hook_source_agent_name}
+                {item.hook_requesting_agent_uuid && (
+                  <span className="detail-item__muted"> ({item.hook_requesting_agent_uuid})</span>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       );
     default:

--- a/src/components/MessageDetail.test.tsx
+++ b/src/components/MessageDetail.test.tsx
@@ -40,6 +40,8 @@ function makeItem(overrides: Partial<DisplayItem> = {}): DisplayItem {
     hook_metadata: "",
     tool_result_json: "",
     is_orphan: false,
+    hook_source_agent_name: "",
+    hook_requesting_agent_uuid: "",
     ...overrides,
   };
 }

--- a/src/components/MessageList.test.tsx
+++ b/src/components/MessageList.test.tsx
@@ -194,6 +194,8 @@ describe("MessageList", () => {
             hook_metadata: "",
             tool_result_json: "",
             is_orphan: false,
+            hook_source_agent_name: "",
+            hook_requesting_agent_uuid: "",
           },
         ],
       }),

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1661,6 +1661,11 @@ body {
   opacity: 0.8;
 }
 
+.detail-item__muted {
+  color: var(--text-muted);
+  opacity: 0.7;
+}
+
 .detail-item__json {
   background: var(--bg-elevated);
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

Fixes #171 — [Compat] Claude Code v2.1.186: Background subagent permission prompts surfaced in main session JSONL with agent attribution field.

Claude Code v2.1.186 changed background subagents to surface permission prompts in the main session instead of auto-denying. Each prompt now carries sourceAgentName and requestingAgentUuid identifying the requesting subagent. Without this fix, those fields were silently dropped and the attribution label never appeared in the conversation UI.

## Changes

### src-tauri/src/parser/entry.rs
Added two new fields to the Entry struct:
- source_agent_name (sourceAgentName) — display name of the background subagent that triggered the cross-session permission prompt
- requesting_agent_uuid (requestingAgentUuid) — session UUID of the requesting subagent

Both use #[serde(default)] so sessions predating v2.1.186 are unaffected. Added 2 parse tests.

### src-tauri/src/parser/classify.rs
Added source_agent_name and requesting_agent_uuid to HookMsg and propagated them from all classify() paths that produce hook-related messages (hook_progress system entries, progress entries, attachment entries, and the debug-log path). Added 4 classify tests.

### src-tauri/src/parser/chunk.rs
Thread hook_source_agent_name and hook_requesting_agent_uuid through DisplayItem assembly so they reach the frontend.

### src-tauri/src/parser/debuglog.rs
Zero-initialise the two new fields in debug-log derived HookMsg structs.

### src-tauri/src/convert.rs
Expose hook_source_agent_name and hook_requesting_agent_uuid on FrontendDisplayItem.

### shared/types.ts
Add hook_source_agent_name and hook_requesting_agent_uuid to the DisplayItem TypeScript interface.

### src/components/DetailItem.tsx + src/styles/global.css
Render a "Requesting Agent" section when hook_source_agent_name is non-empty. Added .detail-item__muted CSS class.

### specs/01-parser-pipeline.md
Added sourceAgentName, requestingAgentUuid, reason, and toolName to the Key Fields table; added version-compat rows for v2.1.186 and v2.1.193.

## Test results

All 513 Rust tests pass; 8 new tests added across entry.rs and classify.rs. All 398 frontend tests pass; 2 new UI tests added in DetailItem.test.tsx. Clippy -D warnings clean.

## Backward compatibility

All new Entry fields use #[serde(default)], so JSONL files produced by older Claude Code versions continue to parse identically.
