### PR TITLE
fix(parser): dedupe denial symbols and Entry fields after #174 rebase

### DIFF
--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -155,17 +155,6 @@ const NOISE_ENTRY_TYPES: &[&str] = &[
     "last-prompt",
 ];
 
-// v2.1.193+: auto-mode denial reasons written to transcript. The entry may use one of these
-// top-level type values, or appear as a progress entry with data.type set to one of them.
-const AUTO_MODE_DENIAL_ENTRY_TYPES: &[&str] = &["auto-mode-denial", "permission-denial"];
-// data.type values used when the denial is embedded inside a progress entry.
-const AUTO_MODE_DENIAL_DATA_TYPES: &[&str] = &[
-    "auto_mode_denial",
-    "auto-mode-denial",
-    "permission_denial",
-    "permission-denial",
-];
-
 // v2.1.193+: auto-mode denial top-level entry types. Claude Code may use any of these;
 // guard all known variants so minor naming changes (kebab vs. underscore) are handled.
 const AUTO_MODE_DENIAL_ENTRY_TYPES: &[&str] = &[
@@ -269,25 +258,6 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
                     metadata,
                     source_agent_name,
                     requesting_agent_uuid,
-                }));
-            }
-            // v2.1.193+: auto-mode denial reasons may be embedded inside a progress entry.
-            if AUTO_MODE_DENIAL_DATA_TYPES.contains(&data_type) {
-                let reason = data
-                    .get("reason")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let tool_name = data
-                    .get("toolName")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let output = format_denial_output(&tool_name, &reason);
-                return Some(ClassifiedMsg::System(SystemMsg {
-                    timestamp: ts,
-                    output,
-                    is_error: false,
                 }));
             }
         }
@@ -657,16 +627,6 @@ fn extract_teammate_content(s: &str) -> String {
         .and_then(|c| c.get(1))
         .map(|m| m.as_str().trim().to_string())
         .unwrap_or_else(|| s.to_string())
-}
-
-/// Format a denial reason for display. Combines tool name and reason into a single notice string.
-fn format_denial_output(tool_name: &str, reason: &str) -> String {
-    match (tool_name.is_empty(), reason.is_empty()) {
-        (false, false) => format!("Auto-mode denied {tool_name}: {reason}"),
-        (false, true) => format!("Auto-mode denied {tool_name}"),
-        (true, false) => format!("Auto-mode denial: {reason}"),
-        (true, true) => "Auto-mode denial".to_string(),
-    }
 }
 
 /// Parse a "Stop hook feedback:\n[command]: output\n" string into (hook_name, command).

--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -221,13 +221,6 @@ pub struct Entry {
     pub source_agent_name: String,
     #[serde(default, rename = "requestingAgentUuid")]
     pub requesting_agent_uuid: String,
-    // Present in auto-mode denial entries (v2.1.193+). Claude Code writes the denial reason
-    // (e.g. "Tool not allowed in auto mode") and the denied tool name to the transcript so that
-    // /permissions recent denials and session replay can display them.
-    #[serde(default)]
-    pub reason: String,
-    #[serde(default, rename = "toolName")]
-    pub tool_name: String,
 }
 
 #[derive(Debug, Deserialize, Default)]


### PR DESCRIPTION
## Summary

`cargo clippy -- -D warnings` is failing on `main` with `E0428` (duplicate const/fn) and `E0124` (duplicate struct field) — the build can't compile.

## What broke

During the multi-PR merge train (#172/#173/#174/#175), the conflict resolutions for #175 (hook attribution) ended up keeping early-draft copies of the v2.1.193 denial symbols that originally belonged to #174's first commit. Then #174's rebase skipped that first commit (assuming it was a duplicate of #175's hook-attribution content) and applied only the "actually implement denial" follow-up — which re-added the same symbols on top of the ones #175 had already brought in.

The result: two `AUTO_MODE_DENIAL_ENTRY_TYPES`, two `AUTO_MODE_DENIAL_DATA_TYPES`, two `format_denial_output` (with mismatched arg orders), two `Entry::reason`, two `Entry::tool_name`.

## Fix

- `classify.rs`: drop the narrower `AUTO_MODE_DENIAL_*` const pair; keep the comprehensive copy that covers kebab + underscore + `automode-*` spellings.
- `classify.rs`: drop the second `format_denial_output(tool_name, reason)`; keep the first `(reason, tool_name)` signature that matches the existing test fixtures, and fix the one inline call site that was passing args in the dropped order.
- `classify.rs`: drop the dead second denial-rescue block inside the progress branch (unreachable — the same `data_type` is checked before the hook branch already).
- `entry.rs`: drop the duplicate `reason` + `tool_name` fields.

Net change: `-47` lines, no behavioral change beyond removing dead/conflicting definitions.

## Test plan

- [x] `npx oxfmt --check` passes locally
- [x] Inspected all `format_denial_output` call sites — arg order now uniform
- [ ] CI: `cargo clippy -- -D warnings` + `cargo test`

https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL)_