### PR TITLE
fix(parser): dedupe denial test fn + drop unused build_chunks import

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -1986,21 +1986,4 @@ mod tests {
         );
     }
 
-    #[test]
-    fn parse_entry_reason_and_tool_name_default_to_empty_when_absent() {
-        // Entries from before v2.1.193 (or non-denial entries) have no reason/toolName fields.
-        let line = json!({
-            "type": "system",
-            "subtype": "init",
-            "uuid": "regular-system-uuid",
-            "timestamp": "2026-06-01T10:00:00Z"
-        });
-        let bytes = serde_json::to_vec(&line).unwrap();
-        let entry = parse_entry(&bytes).expect("must parse entry without denial fields");
-        assert_eq!(entry.reason, "", "reason must default to empty when absent");
-        assert_eq!(
-            entry.tool_name, "",
-            "toolName must default to empty when absent"
-        );
-    }
 }

--- a/src-tauri/src/parser/subagent.rs
+++ b/src-tauri/src/parser/subagent.rs
@@ -1841,7 +1841,7 @@ mod tests {
 
     #[test]
     fn extract_team_specs_includes_implicit_team_agents() {
-        use crate::parser::chunk::{build_chunks, Chunk, ChunkType, DisplayItem, DisplayItemType};
+        use crate::parser::chunk::{Chunk, ChunkType, DisplayItem, DisplayItemType};
 
         let item = DisplayItem {
             item_type: DisplayItemType::Subagent,


### PR DESCRIPTION
## Summary

CI on cec0bcb (PR #176) failed `cargo test` with E0428 (duplicate test fn) plus a clippy warning that becomes an error under `-D warnings`.

## Errors

```
error[E0428]: the name `parse_entry_reason_and_tool_name_default_to_empty_when_absent` is defined multiple times
   --> src/parser/entry.rs:1990:5

warning: unused import: `build_chunks`
   --> src/parser/subagent.rs:1844:36
```

## Fix

- `entry.rs`: two test functions named `parse_entry_reason_and_tool_name_default_to_empty_when_absent` ended up in the same `mod tests` after the #174 rebase. Keep the first (L1609); drop the second (L1990) — they cover the same behaviour with slightly different fixtures.
- `subagent.rs`: drop the unused `build_chunks` from the local `use` inside `extract_team_specs_includes_implicit_team_agents`. Production paths reach `build_chunks` via the full module path; the local re-import is unused.

## Test plan

- [x] `npx oxfmt --check` passes
- [x] Grep confirms only one definition of the duplicated test fn remains
- [x] `build_chunks` is still referenced via full path elsewhere in the file
- [ ] CI: `cargo test --manifest-path src-tauri/Cargo.toml`

https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL)_