### PR TITLE
fix(parser): drop trailing blank line in entry.rs mod tests

### DIFF
--- a/src-tauri/src/parser/entry.rs
+++ b/src-tauri/src/parser/entry.rs
@@ -1985,5 +1985,4 @@ mod tests {
             "requestingAgentUuid must default to empty when absent"
         );
     }
-
 }


### PR DESCRIPTION
## Summary

`cargo fmt --check` on main (commit 7296af3) failed with a single trailing blank line between the last test function and the closing `}` of `mod tests` in `src-tauri/src/parser/entry.rs:1985` — leftover from my dedupe edit in #177.

`cargo fmt` removes it. One-line diff.

https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL)_