### PR TITLE
Show session /rename names as titles in the picker

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -85,6 +85,9 @@ export interface SessionInfo {
   session_id: string;
   mod_time: string;
   first_message: string;
+  /** User-assigned session name (Claude Code `/rename`), joined from the live
+   *  session registry. `null` when never named or no longer running. */
+  name?: string | null;
   turn_count: number;
   is_ongoing: boolean;
   total_tokens: number;

--- a/src-tauri/src/parser/dategroup.rs
+++ b/src-tauri/src/parser/dategroup.rs
@@ -81,6 +81,7 @@ mod tests {
             session_id: format!("session-{}", mod_time.timestamp()),
             path: "/tmp/test.jsonl".to_string(),
             first_message: "test".to_string(),
+            name: None,
             mod_time,
             turn_count: 1,
             model: "claude-sonnet-4-20250514".to_string(),

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -18,6 +18,14 @@ pub struct SessionInfo {
     pub session_id: String,
     pub mod_time: DateTime<Utc>,
     pub first_message: String,
+    /// User-assigned session name (Claude Code `/rename`), joined from the
+    /// `~/.claude/sessions/*.json` registry. `None` when the session was never
+    /// named or has no entry in the registry. The registry is pid-keyed and
+    /// written by running sessions; an entry normally disappears when a session
+    /// ends. A stale file (process exited uncleanly) keeps a name visible until
+    /// it is removed, which is harmless because the match uses the unique
+    /// `sessionId`.
+    pub name: Option<String>,
     pub turn_count: i32,
     pub is_ongoing: bool,
     pub total_tokens: i64,
@@ -361,6 +369,7 @@ pub fn discover_project_sessions(project_dir: &str) -> Result<Vec<SessionInfo>, 
             session_id,
             mod_time,
             first_message: meta.first_msg,
+            name: None,
             turn_count: meta.turn_count,
             is_ongoing,
             total_tokens: meta.total_tokens,
@@ -393,6 +402,66 @@ pub fn discover_all_project_sessions(project_dirs: &[String]) -> Result<Vec<Sess
     Ok(all)
 }
 
+/// Read the live session-name registry (`~/.claude/sessions/*.json`) and return a
+/// `session_id -> name` map for every running session that has a `/rename` name.
+///
+/// The name is not stored in the transcript JSONL; it lives only in this
+/// pid-keyed, live registry. The map joins on the `sessionId` field inside each
+/// file (not the pid filename), so a recycled pid cannot attach the wrong name.
+/// Entries without a non-empty `name` are skipped. The registry always lives
+/// under the real `~/.claude/sessions`, regardless of any `CLAUDE_PROJECTS_DIR`
+/// override.
+pub fn live_session_names() -> HashMap<String, String> {
+    match dirs::home_dir() {
+        Some(home) => session_names_from_dir(&home.join(".claude").join("sessions")),
+        None => HashMap::new(),
+    }
+}
+
+/// Build the `session_id -> name` map from a session registry directory. Split
+/// out from [`live_session_names`] so it can be unit-tested against a fixture dir.
+pub(crate) fn session_names_from_dir(dir: &std::path::Path) -> HashMap<String, String> {
+    let mut map = HashMap::new();
+    let entries = match fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return map,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let value: Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let session_id = value.get("sessionId").and_then(|v| v.as_str());
+        let name = value
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        if let (Some(session_id), Some(name)) = (session_id, name) {
+            map.insert(session_id.to_string(), name.to_string());
+        }
+    }
+    map
+}
+
+/// Fill in `SessionInfo::name` from a `session_id -> name` map. Sessions absent
+/// from the map keep `name: None` (never named, or no longer running).
+pub fn apply_session_names(sessions: &mut [SessionInfo], names: &HashMap<String, String>) {
+    for session in sessions.iter_mut() {
+        if let Some(name) = names.get(&session.session_id) {
+            session.name = Some(name.clone());
+        }
+    }
+}
+
 /// Convert scanned metadata into a SessionInfo struct.
 /// Public for use by SessionCache.
 pub fn session_info_from_metadata(
@@ -416,6 +485,7 @@ pub fn session_info_from_metadata(
         session_id,
         mod_time: mod_time_chrono,
         first_message: meta.first_msg,
+        name: None,
         turn_count: meta.turn_count,
         is_ongoing,
         total_tokens: meta.total_tokens,
@@ -1327,6 +1397,80 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
             .lock()
             .unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn make_info(session_id: &str) -> SessionInfo {
+        SessionInfo {
+            path: format!("/p/{session_id}.jsonl"),
+            session_id: session_id.to_string(),
+            mod_time: Utc::now(),
+            first_message: "first".to_string(),
+            name: None,
+            turn_count: 0,
+            is_ongoing: false,
+            total_tokens: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            cost_usd: 0.0,
+            duration_ms: 0,
+            model: String::new(),
+            cwd: String::new(),
+            git_branch: String::new(),
+            permission_mode: String::new(),
+        }
+    }
+
+    #[test]
+    fn session_names_from_dir_joins_on_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        // Named session. The pid filename differs from the session id on purpose:
+        // the match uses the sessionId field inside the file, never the filename.
+        fs::write(
+            dir.path().join("41090.json"),
+            r#"{"pid":41090,"sessionId":"sid-a","name":"my-cache"}"#,
+        )
+        .unwrap();
+        // Unnamed session: present but no name -> excluded.
+        fs::write(
+            dir.path().join("41091.json"),
+            r#"{"pid":41091,"sessionId":"sid-b","status":"idle"}"#,
+        )
+        .unwrap();
+        // Empty/whitespace name -> excluded.
+        fs::write(
+            dir.path().join("41092.json"),
+            r#"{"pid":41092,"sessionId":"sid-c","name":"   "}"#,
+        )
+        .unwrap();
+        // Non-JSON and non-.json files -> skipped, no panic.
+        fs::write(dir.path().join("garbage.json"), "not json").unwrap();
+        fs::write(dir.path().join("notes.txt"), "ignored").unwrap();
+
+        let map = session_names_from_dir(dir.path());
+        assert_eq!(map.get("sid-a").map(String::as_str), Some("my-cache"));
+        assert_eq!(map.get("sid-b"), None);
+        assert_eq!(map.get("sid-c"), None);
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn session_names_from_dir_missing_dir_is_empty() {
+        let map = session_names_from_dir(std::path::Path::new("/no/such/sessions/dir"));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn apply_session_names_fills_only_matches() {
+        let mut sessions = vec![make_info("sid-a"), make_info("sid-b")];
+        let mut names = HashMap::new();
+        names.insert("sid-a".to_string(), "my-cache".to_string());
+
+        apply_session_names(&mut sessions, &names);
+
+        assert_eq!(sessions[0].name.as_deref(), Some("my-cache"));
+        assert_eq!(sessions[1].name, None);
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -125,18 +125,32 @@ impl AppState {
         project_dirs: &[String],
     ) -> Result<Vec<SessionInfo>, String> {
         let mut cache = self.sessions_cache.lock().map_err(|e| e.to_string())?;
-        if let Some(ref c) = *cache {
-            if c.dirs == project_dirs && c.cached_at.elapsed() < SESSIONS_CACHE_TTL {
-                return Ok(c.sessions.clone());
-            }
-        }
-        let session_cache = self.session_cache.lock().map_err(|e| e.to_string())?;
-        let sessions = session_cache.discover_all_project_sessions(project_dirs)?;
-        *cache = Some(SessionsCache {
-            dirs: project_dirs.to_vec(),
-            cached_at: Instant::now(),
-            sessions: sessions.clone(),
-        });
+        let fresh = cache
+            .as_ref()
+            .is_some_and(|c| c.dirs == project_dirs && c.cached_at.elapsed() < SESSIONS_CACHE_TTL);
+        let mut sessions = if fresh {
+            cache.as_ref().unwrap().sessions.clone()
+        } else {
+            let session_cache = self.session_cache.lock().map_err(|e| e.to_string())?;
+            let sessions = session_cache.discover_all_project_sessions(project_dirs)?;
+            *cache = Some(SessionsCache {
+                dirs: project_dirs.to_vec(),
+                cached_at: Instant::now(),
+                sessions: sessions.clone(),
+            });
+            sessions
+        };
+        // Release the cache lock before the filesystem work below, so concurrent
+        // callers don't serialize behind it.
+        drop(cache);
+        // Join the live `/rename` names on every call. Names live in the pid-keyed
+        // `~/.claude/sessions/*.json` registry, which the transcript-file cache does
+        // not track (a rename never touches the JSONL), so the join runs after the
+        // cache rather than being baked into the cached `SessionInfo`.
+        crate::parser::session::apply_session_names(
+            &mut sessions,
+            &crate::parser::session::live_session_names(),
+        );
         Ok(sessions)
     }
 

--- a/src/components/SessionPicker.test.tsx
+++ b/src/components/SessionPicker.test.tsx
@@ -122,6 +122,41 @@ describe("SessionPicker", () => {
     expect(screen.getByText(/Hello world/)).toBeInTheDocument();
   });
 
+  it("prefers the session name as title, with first_message as subtitle", () => {
+    const sessions = [makeSession({ name: "valkey-admin-contribution" })];
+    render(
+      <SessionPicker
+        sessions={sessions}
+        loading={false}
+        searchQuery=""
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onSearchChange={vi.fn()}
+      />,
+    );
+    // Name is the primary title; first_message survives as the subtitle.
+    const title = screen.getByText("valkey-admin-contribution");
+    expect(title).toBeInTheDocument();
+    // Named sessions get the accent-highlight modifier class.
+    expect(title).toHaveClass("picker__session-preview--named");
+    expect(screen.getByText(/Hello world/)).toBeInTheDocument();
+  });
+
+  it("falls back to first_message when no name is set", () => {
+    const sessions = [makeSession({ name: null })];
+    render(
+      <SessionPicker
+        sessions={sessions}
+        loading={false}
+        searchQuery=""
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onSearchChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Hello world/)).toBeInTheDocument();
+  });
+
   it("shows active badge for ongoing sessions", () => {
     const sessions = [makeSession({ is_ongoing: true })];
     render(

--- a/src/components/SessionPicker.tsx
+++ b/src/components/SessionPicker.tsx
@@ -125,8 +125,10 @@ export function SessionPicker({
                     <span className="picker__session-icon">
                       <BsClaude />
                     </span>
-                    <span className="picker__session-preview">
-                      {truncate(session.first_message || session.session_id, 80)}
+                    <span
+                      className={`picker__session-preview${session.name ? " picker__session-preview--named" : ""}`}
+                    >
+                      {truncate(session.name || session.first_message || session.session_id, 80)}
                     </span>
                     {session.is_ongoing && (
                       <span className="picker__session-ongoing">
@@ -144,6 +146,11 @@ export function SessionPicker({
                       Detail <ForwardIcon />
                     </button>
                   </div>
+                  {session.name && session.first_message && (
+                    <div className="picker__session-subtitle">
+                      {truncate(session.first_message, 80)}
+                    </div>
+                  )}
                   <div className="picker__session-meta">
                     <span className="picker__session-model" style={{ color: modelClr }}>
                       {model}

--- a/src/hooks/usePicker.ts
+++ b/src/hooks/usePicker.ts
@@ -102,6 +102,7 @@ export function usePicker(selectedProject: string | null = null) {
   let filteredSessions = state.searchQuery
     ? state.sessions.filter(
         (s) =>
+          (s.name?.toLowerCase().includes(state.searchQuery.toLowerCase()) ?? false) ||
           s.first_message.toLowerCase().includes(state.searchQuery.toLowerCase()) ||
           s.session_id.toLowerCase().includes(state.searchQuery.toLowerCase()) ||
           s.model.toLowerCase().includes(state.searchQuery.toLowerCase()),

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1002,6 +1002,22 @@ body {
   text-overflow: ellipsis;
 }
 
+/* A user-assigned /rename name uses the accent color and a heavier weight to
+   distinguish it from a title taken from the first message. */
+.picker__session-preview--named {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.picker__session-subtitle {
+  margin-top: 2px;
+  color: var(--text-dim);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .picker__session-ongoing {
   display: inline-flex;
   align-items: center;

--- a/tui-py/data_types.py
+++ b/tui-py/data_types.py
@@ -115,6 +115,7 @@ class SessionInfo:
     session_id: str = ""
     mod_time: str = ""
     first_message: str = ""
+    name: str = ""
     turn_count: int = 0
     is_ongoing: bool = False
     total_tokens: int = 0
@@ -311,6 +312,7 @@ def session_info_from_dict(d: dict) -> SessionInfo:
         session_id=d.get("session_id", ""),
         mod_time=d.get("mod_time", ""),
         first_message=d.get("first_message", ""),
+        name=d.get("name") or "",
         turn_count=int(d.get("turn_count", 0)),
         is_ongoing=bool(d.get("is_ongoing", False)),
         total_tokens=int(d.get("total_tokens", 0)),

--- a/tui-py/tests/test_data_types_name.py
+++ b/tui-py/tests/test_data_types_name.py
@@ -1,0 +1,21 @@
+"""Tests for SessionInfo.name mapping, mirroring the Rust registry-join tests."""
+
+from __future__ import annotations
+
+from data_types import session_info_from_dict
+
+
+def test_session_info_maps_name():
+    info = session_info_from_dict({"session_id": "a", "name": "my-cache"})
+    assert info.name == "my-cache"
+
+
+def test_session_info_name_defaults_to_empty_when_absent():
+    info = session_info_from_dict({"session_id": "a"})
+    assert info.name == ""
+
+
+def test_session_info_name_null_becomes_empty():
+    # The API serializes an unnamed session's name as JSON null.
+    info = session_info_from_dict({"session_id": "a", "name": None})
+    assert info.name == ""

--- a/tui-py/widgets/session_picker.py
+++ b/tui-py/widgets/session_picker.py
@@ -61,11 +61,13 @@ def _render_session(s: SessionInfo, anim_frame: int = 0) -> object:
     """Render a session as a Rich Group with full-width separator."""
     model_str = short_model(s.model) if s.model else ""
     model_clr = get_model_color(s.model) if s.model else theme.TEXT_DIM
-    msg_text = s.first_message or s.session_id
 
-    # Line 1: message preview — full text, no truncation, wraps naturally
+    # Line 1: title. Prefer the user-assigned /rename name (accent-highlighted);
+    # otherwise use the first message. When a name is shown, the first message is
+    # kept as the subtitle.
+    title = s.name or s.first_message or s.session_id
     line1 = Text()
-    line1.append(msg_text, style=theme.TEXT_PRIMARY)
+    line1.append(title, style=theme.ACCENT if s.name else theme.TEXT_PRIMARY)
     if s.is_ongoing:
         line1.append(f"  {theme.SPIN[anim_frame]}", style=theme.ONGOING)
 
@@ -84,7 +86,11 @@ def _render_session(s: SessionInfo, anim_frame: int = 0) -> object:
     line2.append(f" {ICON_SESSION} {s.session_id[:8]}", style=theme.TEXT_DIM)
     line2.append(f" {ICON_CLOCK} {time_ago(s.mod_time)}", style=theme.TEXT_DIM)
 
-    content = Text.assemble(line1, "\n", line2)
+    if s.name and s.first_message:
+        subtitle = Text(s.first_message, style=theme.TEXT_DIM)
+        content = Text.assemble(line1, "\n", subtitle, "\n", line2)
+    else:
+        content = Text.assemble(line1, "\n", line2)
     sep = Rule(style=theme.TEXT_MUTED, characters="─")
     return Group(content, sep)
 


### PR DESCRIPTION
## What

The session picker now titles a session by its user-assigned name (Claude Code `/rename`) instead of its first message. When a name exists it becomes the title (in the accent color), the first message moves to a subtitle, and search matches the name. Sessions without a name are unchanged.

## Why

The `/rename` name is not written to the transcript JSONL the viewer parses. It lives only in the live, pid-keyed registry `~/.claude/sessions/<pid>.json`, where each file holds a `sessionId` and a `name`. Without reading that registry, the picker fell back to the first message, which is often noise (an agent-sync probe block, a long prompt).

The change joins `session_id` to `name` from the registry and adds `SessionInfo.name`. Three points worth noting:

- The join runs in `discover_sessions_cached` after the session cache, on every call. The cache keys on the transcript file (path, mtime, size), and a `/rename` never touches that file, so a name baked into the cache would stay stale until the next turn.
- The match uses the `sessionId` field inside each registry file, not the pid filename, so a recycled pid cannot attach the wrong name.
- Scope is the live registry only. There is no durable name store for ended sessions (history.jsonl carries `sessionId` but only typed `display` text), so a session shows its name while a registry entry exists and otherwise falls back to the first message. A durable cache can follow if names should persist after a session ends.

## Compatibility

Additive and fail-safe. `SessionInfo` gains one optional field (`name`, `null` when absent; TS `name?: string | null`). Every failure path falls back to current behavior: a missing directory, an unreadable file, or a nameless file is skipped, with no panics. All new title, subtitle, highlight, and search logic is gated on a name being present, so unnamed sessions are byte-for-byte unchanged. The change reads only; it writes nothing.

## Verification

- `npm run check` (tsc, oxlint, oxfmt, cargo fmt, clippy `-D warnings`, vitest, cargo test) and the Python TUI gate (ruff, pytest) pass.
- New tests: 3 Rust unit tests for the registry join (present, absent, empty, malformed file, missing directory) and 2 vitest tests (title prefers the name with the highlight class; falls back to the first message).

One bounded cost: the registry is read on each `/api/sessions` call (a few small files, sub-millisecond). If stale registry files accumulate, a short cache can be added later.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
