### PR TITLE
perf: virtualize message list and fix session-view memory growth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-icons": "^5.6.0",
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^16.1.1",
+        "react-virtuoso": "^4.18.10",
         "remark-gfm": "^4.0.1"
       },
       "bin": {
@@ -4388,6 +4389,16 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
+      }
+    },
+    "node_modules/react-virtuoso": {
+      "version": "4.18.10",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.18.10.tgz",
+      "integrity": "sha512-P6GIZ7kWAPOYB2H16yRQNgy+VF9pJOuTFw1EUc1EAtCj5WxVSAF1Sql3x3fbLwaLeBFsiPnu+3U9o6sIOyTdFw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
       }
     },
     "node_modules/redent": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
+    "react-virtuoso": "^4.18.10",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -142,11 +142,20 @@ export interface SessionTotals {
 }
 
 export interface LoadResult {
+  /** Messages for the requested window (may be a slice of the whole session). */
   messages: DisplayMessage[];
   teams: TeamSnapshot[];
   ongoing: boolean;
   meta: SessionMeta;
   session_totals: SessionTotals;
+  /** Total number of messages in the session (not just the returned window). */
+  count: number;
+  /** Index of the first returned message within the full session. */
+  start: number;
+  /** Role of every message in the full session (length === count). */
+  roles: string[];
+  /** Latest Claude context-window fill (tokens); 0 if none. */
+  context_tokens: number;
 }
 
 export interface GitInfo {

--- a/specs/03-state-management.md
+++ b/specs/03-state-management.md
@@ -1,6 +1,6 @@
 # Spec: State Management
 
-**Locations**: `src-tauri/src/state.rs`, `src-tauri/src/parser/cache.rs`, `src-tauri/src/settings.rs`
+**Locations**: `src-tauri/src/state.rs`, `src-tauri/src/session_load.rs`, `src-tauri/src/parser/cache.rs`, `src-tauri/src/settings.rs`
 
 `AppState` is the central in-memory store for the Rust backend. It is shared across all Tauri
 commands and HTTP handlers via `Arc<AppState>`, protected by per-field `Mutex`es.
@@ -14,24 +14,38 @@ classDiagram
     class AppState {
         +session_watcher: Mutex~Option~WatcherHandle~~
         +picker_watcher: Mutex~Option~WatcherHandle~~
-        +session_cache: SessionCache
-        +settings: RwLock~Settings~
-        +watched_session_ongoing: Mutex~Option~bool~~
-        +event_tx: broadcast::Sender~SSEMessage~
+        +session_cache: Mutex~SessionCache~
+        +settings: Mutex~Settings~
+        +watched_session_ongoing: Mutex~Option~(String, bool)~~
+        +event_tx: broadcast::Sender~SseEvent~
         +sessions_cache: Mutex~Option~SessionsCache~~
+        +session_names_cache: Mutex~SessionNamesCache~
+        +session_light_cache: Mutex~Option~CachedLight~~
     }
 
     class SessionCache {
-        -map: HashMap~CacheKey, CachedSession~
-        +get(path, mtime, size) Option~&CachedSession~
-        +insert(path, mtime, size, session)
+        -file_cache: HashMap~String, CachedFile~
+        +get_or_scan(path, mtime, size) Option~SessionInfo~
+        +discover_all_project_sessions(dirs) Vec~SessionInfo~
     }
 
     class SessionsCache {
+        -dirs: Vec~String~
+        -cached_at: Instant
         -sessions: Vec~SessionInfo~
-        -fetched_at: Instant
         -ttl: 2 s
-        +is_fresh() bool
+    }
+
+    class SessionNamesCache {
+        -entry: Option~(Instant, HashMap~String, String~)~
+        -ttl: 1 s
+        +get_or_load(dir, ttl) HashMap~String, String~
+    }
+
+    class CachedLight {
+        -path: String
+        -size: u64
+        -light: LightBuild
     }
 
     class Settings {
@@ -40,14 +54,89 @@ classDiagram
 
     AppState --> SessionCache
     AppState --> SessionsCache
+    AppState --> SessionNamesCache
+    AppState --> CachedLight
     AppState --> Settings
+```
+
+`session_cache`, `sessions_cache`, and `session_names_cache` all support the **session picker** —
+they cache lightweight `SessionInfo` metadata (and the separate name registry), never parsed
+message bodies. `session_light_cache` is unrelated: it supports the **active session's list
+view** and holds a lightened message build. See below for how list-view caching and detail-view
+loading differ.
+
+---
+
+## Two Caching Behaviors for a Loaded Session
+
+Once a session is open, two different code paths read it, and they deliberately do not share a
+cache:
+
+| Path                              | Serves                                   | Caches?                                 | Keyed by       | Holds                                                  |
+| --------------------------------- | ---------------------------------------- | --------------------------------------- | -------------- | ------------------------------------------------------ |
+| `AppState::load_session_windowed` | List view (windowed/virtualized fetches) | Yes — one slot in `session_light_cache` | `(path, size)` | `LightBuild`: messages with heavy tool bodies stripped |
+| `AppState::full_message_at`       | Detail view (single message)             | Never                                   | n/a            | nothing persisted — full build dropped on return       |
+
+### List view: `session_light_cache` (`state.rs`)
+
+`load_session_windowed` backs the virtualized list. On a cache miss (different `path` or a
+changed `size`; no `mtime` in the key) it calls `session_load::build_light_session`, which runs
+the full parse pipeline and then `lighten_messages` to strip heavy per-item fields (`tool_input`,
+`tool_result`, `tool_result_json`, `last_output`) recursively, including nested subagent
+transcripts. The result (`LightBuild`) is stored in the single `session_light_cache` slot and
+reused by every subsequent scroll-driven range fetch for that session, sliced by
+`session_load::slice_light`. Time-filtered loads bypass this cache entirely (rare, used by the
+by-id range endpoint) and call `session_load::load_session` directly.
+
+```mermaid
+flowchart LR
+    REQ["load_session_windowed(path, opts)"]
+    REQ --> TF{"time filter\nactive?"}
+    TF -->|"yes"| BYPASS["load_session()\nno caching"]
+    TF -->|"no"| LOOKUP{"cache hit?\n(path, size) match"}
+    LOOKUP -->|"hit"| SLICE["slice_light()\nreuse LightBuild"]
+    LOOKUP -->|"miss"| BUILD["build_light_session()\nparse + lighten_messages"]
+    BUILD --> STORE["store as CachedLight\n(path, size, light)"]
+    STORE --> SLICE
+```
+
+Because the cache holds only one slot, switching sessions (a different `path`) or a
+grown/truncated file (`size` changed) simply rebuilds it — memory stays bounded to the active
+session's lightened build. `clear_session_build_cache()` drops the slot explicitly, e.g. when
+leaving a session for the picker.
+
+### Detail view: always fresh, never cached (`state.rs`)
+
+`full_message_at` serves a single message's full detail (including heavy tool bodies). It calls
+`session_load::build_session` fresh on every single call, extracts the one requested message by
+index, and returns it — the full `BuiltSession` (containing every message's heavy tool
+input/output) is dropped as soon as the function returns. It never reads from or writes to
+`session_light_cache`.
+
+This is a deliberate memory-vs-latency tradeoff: a tool-output-heavy session can be hundreds of
+MB. Caching the full heavy build for as long as the session stays open would mean holding that
+much memory in the Rust process the entire time. Re-parsing on every detail click instead costs
+roughly the same latency as the session's first list load, but never persists heavy tool bodies
+between clicks — memory is freed the instant the click is served.
+
+```mermaid
+flowchart LR
+    REQ["full_message_at(path, index)"]
+    REQ --> BUILD["build_session()\nfull heavy parse, every call"]
+    BUILD --> PICK["extract messages[index]"]
+    PICK --> DROP["heavy BuiltSession dropped\non return"]
+    PICK --> RET["Some(DisplayMessage)"]
 ```
 
 ---
 
-## Session Cache (`cache.rs`)
+## Session Metadata Cache (`parser/cache.rs`)
 
-The session cache avoids re-parsing unchanged files. It uses a composite key:
+`SessionCache` is a distinct, older mechanism that has nothing to do with message bodies or the
+light cache above — it caches lightweight `SessionInfo` metadata (title, timestamps, token
+totals, ongoing flag) so the **picker** doesn't rescan every session file's content on every
+refresh. It backs `AppState::discover_sessions_cached` via `session_cache: Mutex<SessionCache>`,
+which is separate from `session_light_cache`. It uses a composite key:
 
 ```
 CacheKey = (file_path, modification_time, file_size)
@@ -55,25 +144,31 @@ CacheKey = (file_path, modification_time, file_size)
 
 ```mermaid
 flowchart LR
-    REQ["Request to load\nsession X"]
+    REQ["Request to scan\nsession X for the picker"]
     REQ --> LOOKUP{"Cache hit?\n(path, mtime, size)"}
-    LOOKUP -->|"hit"| RET["Return cached\nDisplayMessage[]"]
-    LOOKUP -->|"miss"| PARSE["Run full\nparser pipeline"]
-    PARSE --> STORE["Store in cache\nwith new key"]
+    LOOKUP -->|"hit"| RET["Return cached\nSessionInfo"]
+    LOOKUP -->|"miss"| SCAN["Rescan file metadata\n(scan_session_metadata)"]
+    SCAN --> STORE["Store in cache\nwith new key"]
     STORE --> RET
 ```
 
 ### Ongoing Session Freshness
 
-For sessions marked `is_ongoing = true`, the cached result is considered **stale after 60 seconds**
-even if the file appears unchanged (the parser may have new subagent data).
+Even on a cache hit, `SessionInfo.is_ongoing` is re-checked at read time rather than trusted
+as-is: a session's `is_ongoing` flag is considered **stale after 60 seconds** of no file
+modification (`apply_staleness`, `parser/ongoing.rs`), and if not ongoing by that check, a
+follow-up check looks for recently-active orphan subagent files (which can update without
+touching the parent session file). This means a `SessionInfo` can be served from cache while its
+`is_ongoing` value is still recomputed fresh every read.
 
 ```mermaid
 flowchart LR
-    CACHED["Cached entry\n(is_ongoing=true)"]
-    CACHED --> AGE{"Age > 60 s?"}
-    AGE -->|"yes"| STALE["Treat as miss\nre-parse"]
-    AGE -->|"no"| USE["Use cache"]
+    CACHED["Cached SessionInfo\n(is_ongoing=true)"]
+    CACHED --> AGE{"mtime age > 60 s?"}
+    AGE -->|"yes"| SUBCHECK{"recently-active\norphan subagents?"}
+    AGE -->|"no"| USE["is_ongoing stays true"]
+    SUBCHECK -->|"yes"| USE
+    SUBCHECK -->|"no"| STALE["is_ongoing = false"]
 ```
 
 ---
@@ -101,7 +196,10 @@ sequenceDiagram
 ```
 
 This prevents thundering-herd filesystem scans when the picker-refresh signal causes multiple
-clients to call `/api/sessions` simultaneously.
+clients to call `/api/sessions` simultaneously. Once the underlying scan resolves (cached or
+fresh), `discover_sessions_cached` joins the live `/rename` session-name registry on every call,
+via the short-TTL `session_names_cache` (1 s) — a rename never touches the JSONL file, so the
+transcript-file cache above cannot see it, and the name registry is joined after the fact.
 
 ---
 
@@ -114,7 +212,7 @@ time). The session watcher, however, has the authoritative result from a full pa
 
 ```mermaid
 flowchart LR
-    WA["watched_session_ongoing\n(Mutex&lt;Option&lt;bool&gt;&gt;)"]
+    WA["watched_session_ongoing\n(Mutex&lt;Option&lt;(String, bool)&gt;&gt;)"]
     PICK["Vec&lt;SessionInfo&gt;\nfrom picker"]
     WA --> PATCH{"Watcher loaded\nsession X?"}
     PATCH -->|"yes"| OVERRIDE["Set sessions[X].is_ongoing\n= watcher verdict"]
@@ -128,7 +226,7 @@ flowchart LR
 
 ## SSE Broadcast Channel
 
-All HTTP clients subscribe to a `broadcast::Sender<SSEMessage>` stored in `AppState`.
+All HTTP clients subscribe to a `broadcast::Sender<SseEvent>` stored in `AppState`.
 
 ```mermaid
 flowchart LR
@@ -155,7 +253,7 @@ User settings live in `~/.config/claude-code-trace/settings.json`.
 ```mermaid
 flowchart LR
     FILE["settings.json\non disk"]
-    FILE -->|"load_settings()"| MEM["Settings in AppState\n(RwLock)"]
+    FILE -->|"load_settings()"| MEM["Settings in AppState\n(Mutex)"]
     MEM -->|"save_settings()"| FILE
     MEM -->|"platform_default_dir()"| DEF["~/.claude/projects\n(if not set)"]
 ```
@@ -172,14 +270,16 @@ The configured value takes precedence; if not set, the platform default is used 
 
 ## Concurrency Invariants
 
-| Resource                  | Protection                            | Notes                                                   |
-| ------------------------- | ------------------------------------- | ------------------------------------------------------- |
-| `session_watcher`         | `Mutex`                               | Replaced atomically; old handle dropped → stops watcher |
-| `picker_watcher`          | `Mutex`                               | Same pattern                                            |
-| `session_cache`           | Internal `Mutex` (via `SessionCache`) | Fine-grained per-entry                                  |
-| `settings`                | `RwLock`                              | Many readers, rare writes                               |
-| `sessions_cache`          | `Mutex`                               | Short critical section; TTL check + replace             |
-| `watched_session_ongoing` | `Mutex`                               | Written by watcher task, read by picker command         |
+| Resource                  | Protection | Notes                                                                |
+| ------------------------- | ---------- | -------------------------------------------------------------------- |
+| `session_watcher`         | `Mutex`    | Replaced atomically; old handle dropped → stops watcher              |
+| `picker_watcher`          | `Mutex`    | Same pattern                                                         |
+| `session_cache`           | `Mutex`    | Guards the metadata `HashMap`; fine-grained per-entry lookups inside |
+| `settings`                | `Mutex`    | Read on most requests, written rarely                                |
+| `sessions_cache`          | `Mutex`    | Short critical section; TTL check + replace                          |
+| `session_names_cache`     | `Mutex`    | Short critical section; 1 s TTL check + replace                      |
+| `session_light_cache`     | `Mutex`    | One slot; replaced on `(path, size)` change or explicit clear        |
+| `watched_session_ongoing` | `Mutex`    | Written by watcher task, read by picker command                      |
 
 ---
 
@@ -188,3 +288,4 @@ The configured value takes precedence; if not set, the platform default is used 
 - [02-file-watcher.md](02-file-watcher.md) — writes `watched_session_ongoing`
 - [04-http-api.md](04-http-api.md) — reads `AppState` for all HTTP handlers
 - [08-session-lifecycle.md](08-session-lifecycle.md) — full state transition sequence
+  </content>

--- a/specs/04-http-api.md
+++ b/specs/04-http-api.md
@@ -23,6 +23,7 @@ graph TB
         GET_DIRS["GET /api/project-dirs"]
         POST_SESSIONS["POST /api/sessions"]
         POST_LOAD["POST /api/session/load"]
+        POST_MESSAGE["POST /api/session/message"]
         GET_META["GET /api/session/meta"]
         POST_WATCH["POST /api/session/watch"]
         POST_UNWATCH["POST /api/session/unwatch"]
@@ -40,6 +41,7 @@ graph TB
     ROUTER --> GET_DIRS
     ROUTER --> POST_SESSIONS
     ROUTER --> POST_LOAD
+    ROUTER --> POST_MESSAGE
     ROUTER --> GET_META
     ROUTER --> POST_WATCH
     ROUTER --> POST_UNWATCH
@@ -120,21 +122,31 @@ Results are cached for 2 seconds (see [03-state-management.md](03-state-manageme
 
 ### `POST /api/session/load`
 
-Fully parses a session JSONL file and returns display-ready messages.
+Fully parses a session JSONL file and returns a windowed slice of display-ready messages,
+plus a lightweight full-session index so virtualized clients can size and scroll the list
+without holding every message's heavy body in memory.
 
 **Request**
 
 ```json
-{ "path": "/path/to/session.jsonl" }
+{ "path": "/path/to/session.jsonl", "start": 0, "limit": 200 }
 ```
+
+`start`/`limit` are optional and request an index window into the message list — `start`
+defaults to `0`, `limit` defaults to unset (load to the end). Omit both to load the whole
+session.
 
 **Response**
 
 ```json
 {
   "messages": [
-    /* DisplayMessage[] */
+    /* DisplayMessage[] — only the requested window */
   ],
+  "count": 5000,
+  "start": 0,
+  "roles": ["user", "assistant", "..."],
+  "context_tokens": 12345,
   "teams": [
     /* TeamSnapshot[] */
   ],
@@ -142,6 +154,35 @@ Fully parses a session JSONL file and returns display-ready messages.
   "meta": { "cwd": "...", "git_branch": "main", "permission_mode": "default" },
   "session_totals": { "total_tokens": 5000, "cost_usd": 0.02, "model": "..." }
 }
+```
+
+- `messages` — the windowed slice only, not the whole session.
+- `count` — total number of messages in the full session.
+- `start` — the index of the first message in the returned `messages` slice.
+- `roles` — the role of every message in the full session (length == `count`); lets a
+  virtualized client render placeholders and drive expand-all without holding the heavy
+  message bodies for rows outside the window.
+- `context_tokens` — latest Claude context-window fill, for the context gauge.
+
+---
+
+### `POST /api/session/message`
+
+Returns the single full (heavy-body) `DisplayMessage` at `index`, for the Detail view to
+fetch on demand — the windowed list from `session/load` carries lightened messages with no
+tool-output bodies, so the detail view fetches the full message separately when the user
+opens it.
+
+**Request**
+
+```json
+{ "path": "/path/to/session.jsonl", "index": 42 }
+```
+
+**Response**
+
+```json
+/* DisplayMessage, or null if index is out of range */
 ```
 
 ---
@@ -278,12 +319,14 @@ The commands share the same `AppState` and call the same parser functions.
 flowchart LR
     subgraph IPC["Tauri IPC (desktop)"]
         T_SESS["load_session command"]
+        T_MSG["load_message command"]
         T_WATCH["watch_session command"]
         T_PICK["discover_sessions command"]
     end
 
     subgraph HTTP["HTTP API (browser/TUI)"]
         H_SESS["POST /api/session/load"]
+        H_MSG["POST /api/session/message"]
         H_WATCH["POST /api/session/watch"]
         H_PICK["POST /api/sessions"]
     end
@@ -291,9 +334,11 @@ flowchart LR
     STATE["Arc&lt;AppState&gt;"]
 
     T_SESS --> STATE
+    T_MSG --> STATE
     T_WATCH --> STATE
     T_PICK --> STATE
     H_SESS --> STATE
+    H_MSG --> STATE
     H_WATCH --> STATE
     H_PICK --> STATE
 ```

--- a/specs/05-frontend-web.md
+++ b/specs/05-frontend-web.md
@@ -72,21 +72,65 @@ stateDiagram-v2
 
 ### `useSession` — Session State
 
-Manages the full lifecycle of a loaded session: loading, live updates, teams, metadata.
+Manages the full lifecycle of a loaded session: paginated loading, live updates, teams, metadata.
+Messages are never held in full — the hook keeps a sparse, page-based window of message bodies
+plus a lightweight session-wide index, so memory stays flat regardless of session size.
 
 ```mermaid
 flowchart TD
-    PATH["session path\n(prop)"]
-    PATH --> LOAD["invoke/fetch\nload_session()"]
-    LOAD --> STATE["messages, teams\nmeta, totals, ongoing\ngit, debug"]
-    STATE --> LISTEN["listen / SSE\n'session-update'"]
-    LISTEN --> STATE
+    PATH["session path"]
+    PATH --> META["load_session(start:0, limit:0)\nmetadata-only fetch"]
+    META --> STATE["count, roles, contextTokens\nteams, totals, ongoing, meta"]
+    STATE --> PRIME["ensureRange(tail window)"]
+    PRIME --> WINDOW["windowMessages\nMap<index, DisplayMessage>"]
+    LISTEN["listen / SSE\n'session-update'"] --> STATE
+    LISTEN --> INVALIDATE["invalidate visible pages"]
+    INVALIDATE --> WINDOW
 ```
 
-Key responsibilities:
+Session-level state (`count`, `roles`, `contextTokens`, `teams`, `ongoing`, `meta`,
+`sessionTotals`) is tracked separately from the message bodies themselves:
 
-- Initial load via `invoke("load_session", ...)` (Tauri) or `POST /api/session/load`
-- Subscribe to `session-update` events and merge diffs
+- `roles: string[]` is a role-per-message index covering the **whole session** (length ===
+  `count`), fetched cheaply up front so the list can render placeholders and drive
+  expand/collapse-all before any bodies are loaded.
+- `windowMessages: Map<number, DisplayMessage>` is a sparse store of only the message bodies
+  currently loaded, keyed by absolute index.
+
+Paging model:
+
+- `PAGE_SIZE = 100` — messages are fetched from the backend a page at a time via
+  `invoke("load_session", { path, start, limit })`.
+- `ensureRange(start, end)` is called by `MessageList` (via Virtuoso's `rangeChanged`) whenever
+  the visible window changes. It computes the pages spanning `[start, end)`, fetches any that
+  aren't already loaded or in flight, and merges results into `windowMessages`.
+- `evictOutsideKeepBand(keepFirstPage, keepLastPage)` drops pages outside a keep band of
+  `KEEP_MARGIN_PAGES = 1` pages beyond the requested range. **It runs on every `ensureRange`
+  call, not only when a fetch actually happens** — eviction must not wait on a fetch, or pages
+  left over from a wider prefetch (or from scrolling back and forth within an already-cached
+  region) would never get cleaned up and memory would only grow.
+- `clearWindow()` drops every loaded page immediately. Called when leaving the list view (e.g.
+  opening Detail) so the list's data doesn't sit in memory while a different view is showing;
+  returning to the list re-fetches the visible window fresh.
+- `getMessage(index)` reads from `windowMessages`; returns `undefined` for indices not currently
+  loaded (rendered as a placeholder row).
+
+Light vs. heavy messages:
+
+- Messages returned by `load_session` (used for the list) are **light** — stripped of
+  `tool_input`/`tool_result`/`tool_result_json` — since the list view only needs headers,
+  previews, and stats.
+- `loadFullMessage(index)` fetches a single **full, heavy-body** message on demand via
+  `invoke("load_message", { path, index })`, for the Detail view only.
+
+Live updates arrive as a lightweight `session-update` signal (counts/roles/teams/totals — no
+message bodies). On receipt, the hook updates session-level state, then invalidates the
+currently visible pages so their bodies are refetched — this covers both growth in `count` (the
+list requests the new tail on its own) and in-place edits to already-loaded messages (e.g. a
+streaming final message).
+
+Other responsibilities:
+
 - Start/stop session watcher (`watch_session` / `unwatch_session`)
 - Fetch git info and debug log on demand
 
@@ -188,6 +232,22 @@ Shared between web and TUI (lives in `shared/hooks/useToggleSet.ts`).
 ---
 
 ## Key Components
+
+### `MessageList` — Virtualized Message Rendering
+
+Renders the message list via `react-virtuoso` (`<Virtuoso totalCount={count}>`) rather than
+mapping over a flat array of messages. Rows are rendered from `getMessage(index)`; indices whose
+body isn't loaded yet render a lightweight placeholder row sized to approximate a typical loaded
+row, so the placeholder-to-content swap causes only a small reflow. Virtuoso's `rangeChanged`
+callback drives `useSession`'s `ensureRange(start, end)` so only the visible (plus a viewport
+margin) window is fetched.
+
+WebKit does not recompute `:hover` state during virtualized scrolling — since content shifts
+under a stationary cursor rather than the cursor moving, a stale hover state can appear "stuck"
+on whatever row ends up under the cursor once scrolling stops. `MessageList` works around this by
+tracking the last known mouse position and, once Virtuoso reports scrolling has settled, forces a
+synthetic `mousemove` event at that position so the browser redoes hit-testing without needing a
+real pointer move.
 
 ### `MessageDetail` — Multi-Panel Detail View
 
@@ -305,6 +365,37 @@ flowchart LR
     IS_TAURI -->|"yes"| TAURI_EVT["@tauri-apps/api event.listen()"]
     IS_TAURI -->|"no"| SSE["EventSource /api/events\nfiltered by event name"]
 ```
+
+---
+
+## Webview Lifecycle
+
+WebKit (Tauri's macOS webview engine) retains render-tree/layout memory across repeated large DOM
+swaps within this long-lived single-page app — physical footprint climbs steadily across
+repeated session switches even though JS heap and DOM node counts stay flat. There's no public
+WKWebView API to reclaim it, so a full page reload is used as a periodic reset.
+
+```mermaid
+flowchart TD
+    OPEN["session opened"]
+    OPEN --> COUNT["switchCountRef += 1"]
+    COUNT --> CHECK{"shouldRecycle()?\n(every RELOAD_AFTER_N_SWITCHES\n= 25 opens)"}
+    CHECK -->|"no"| NORMAL["openSessionByPath()"]
+    CHECK -->|"yes"| SAVE["saveRestoreState()\n(sessionStorage)"]
+    SAVE --> WAIT["wait for in-flight\ninvoke() calls to settle"]
+    WAIT --> RELOAD["window.location.reload()"]
+    RELOAD --> RESTORE["takeRestoreState()\non next mount"]
+    RESTORE --> NORMAL
+```
+
+- `src/lib/webviewRecycle.ts` tracks `switchCountRef` in `App.tsx` — how many sessions have been
+  opened this page lifetime. Every `RELOAD_AFTER_N_SWITCHES` (25) opens, it saves the current
+  session path to `sessionStorage` via `saveRestoreState` and calls `reloadWebview()`.
+- `reloadWebview()` waits for `inFlightInvokeCount()` (from `src/lib/invoke.ts`) to reach zero
+  (polling with a timeout) before calling `window.location.reload()` — reloading while a Tauri
+  IPC call is still pending is a known crash cause on macOS.
+- On the next mount, `App.tsx` calls `takeRestoreState()` and, if a pending restore exists, reopens
+  that session automatically so the reload isn't disruptive to the user.
 
 ---
 

--- a/specs/08-session-lifecycle.md
+++ b/specs/08-session-lifecycle.md
@@ -35,15 +35,26 @@ sequenceDiagram
 
 ## Phase 2: Session Selection and Loading
 
+Loading a session is windowed, not whole-file: the frontend (`useSession.ts`) fetches
+message bodies a `PAGE_SIZE=100` page at a time via `ensureRange`, and keeps only a
+sparse in-memory `Map<index, DisplayMessage>` of the pages near the viewport — far pages
+are evicted as the user scrolls. `load_session` (Tauri command / `POST
+/api/session/load`) accepts `start`/`limit` windowing params and always returns a
+`LoadResult`: the requested `messages` slice plus `count` (total message count), `start`,
+`roles` (role of every message, the lightweight full-session index), `context_tokens`,
+and the existing `teams`/`ongoing`/`meta`/`session_totals` fields (which describe the
+whole session regardless of the window).
+
 ```mermaid
 sequenceDiagram
     participant USER as User
-    participant FE as Frontend
+    participant FE as Frontend (useSession)
     participant RUST as Rust Backend
     participant FS as File System
 
     USER ->> FE: select session from picker
-    FE ->> RUST: POST /api/session/load\n{ path: "...session.jsonl" }
+    FE ->> RUST: load_session\n{ path, start: 0, limit: 0 }
+    Note over FE,RUST: metadata-only fetch to learn count/roles
 
     RUST ->> FS: read JSONL file\n(LineReader, buffered)
     FS -->> RUST: raw lines
@@ -60,14 +71,47 @@ sequenceDiagram
     RUST ->> RUST: reconstruct_teams()
     RUST ->> RUST: OngoingChecker.is_ongoing()
     RUST ->> RUST: chunks_to_messages()\nChunk[] → DisplayMessage[]
-    RUST ->> RUST: cache result\n(path, mtime, size) → CachedSession
+    RUST ->> RUST: lighten_messages()\nstrip tool_input/tool_result/tool_result_json
+    RUST ->> RUST: cache lightened build\n(path, size) → CachedLight
 
-    RUST -->> FE: { messages, teams, ongoing, meta, session_totals }
+    RUST -->> FE: LoadResult\n{ messages: [], count, roles, context_tokens,\nteams, ongoing, meta, session_totals }
 
-    FE ->> FE: render MessageList
+    FE ->> FE: render MessageList shell\n(placeholders for count rows)
+    FE ->> RUST: ensureRange(tail window)\nload_session { start, limit: PAGE_SIZE }
+    RUST ->> RUST: slice_light()\nreuse cached CachedLight, no re-parse
+    RUST -->> FE: LoadResult\n{ messages: [...page...], ... }
+    FE ->> FE: insert page into windowMessages Map
+
     FE ->> RUST: POST /api/session/watch\n{ path: "...session.jsonl" }
     RUST ->> RUST: start_session_watcher()\nnotify watcher on session dir
 ```
+
+As the user scrolls, the virtualized list calls `ensureRange(start, end)` again, which
+fetches only the missing pages in that range and evicts pages outside a small keep-margin
+band around the viewport — the session's full message list is never held in memory on
+the frontend.
+
+### Detail view message fetch
+
+Detail-view message bodies are fetched separately and on demand, never as part of the
+list load. Opening a message in Detail calls a distinct backend entry point:
+
+```mermaid
+sequenceDiagram
+    participant USER as User
+    participant FE as Frontend
+    participant RUST as Rust Backend
+
+    USER ->> FE: click a message row
+    FE ->> FE: view = "detail"\nsession.clearWindow()
+    FE ->> RUST: load_message\n(or POST /api/session/message)\n{ path, index }
+    RUST ->> RUST: full_message_at()\nre-parse whole session fresh\n(no cache, heavy build dropped after)
+    RUST -->> FE: DisplayMessage | null\n(full tool_input/tool_result bodies)
+    FE ->> FE: render Detail view
+```
+
+See "Opening the Detail view drops the list window" below for what happens to the list's
+loaded pages when this fetch begins.
 
 ---
 
@@ -166,21 +210,55 @@ flowchart TD
 
 ## Caching Strategy Throughout Lifecycle
 
+There are three independent caches in `AppState`, each serving a different consumer.
+They are not layers of the same cache — a request only ever touches one of them.
+
+**`session_cache` (`SessionCache`, keyed by `(path, mtime, size)`)** — the picker's
+per-file metadata cache. It backs `discover_all_project_sessions` (called from
+`discover_sessions_cached`): scanning every project directory's `SessionInfo` (title,
+timestamps, ongoing flag, token totals) on every picker refresh would mean re-reading
+every session file's tail on every refresh. A cache hit re-applies ongoing staleness
+(`apply_staleness`, ~60s) and a subagent-activity recheck to the cached `SessionInfo`
+rather than reparsing, so an ongoing session still reports fresh liveness without a full
+rescan. This is the cache the "First Load / Subsequent Loads / Ongoing Session" flow
+below describes; it never holds `DisplayMessage[]` — only lightweight `SessionInfo`.
+
+**`session_light_cache` (`CachedLight`, keyed by `(path, size)` — no mtime)** — the
+active session's windowed-list-fetch cache, used only by `load_session_windowed`.
+Scrolling the message list calls `ensureRange`, which issues one `load_session` per
+missing page; without this cache each page fetch would re-parse and re-link the whole
+session file. On a cache hit, `slice_light` windows the already-built `LightBuild`
+(messages with heavy tool bodies stripped by `lighten_messages`) instead of rebuilding.
+A different path, or the same path with a changed size (grown or truncated), invalidates
+and rebuilds. Time-filtered loads bypass this cache entirely (rare, used only by the
+by-id range endpoint). Only one session's build is held at a time — `AppState` has a
+single `Mutex<Option<CachedLight>>` slot, not a map — so opening a new session evicts
+the previous one automatically. `clear_session_build_cache()` also drops it explicitly
+(see "Opening the Detail view drops the list window" below).
+
+**No cache for `full_message_at`** — the Detail view's single-message fetch. This
+deliberately re-parses the whole session fresh (`build_session`) on every call and drops
+the heavy build as soon as one message is extracted. A tool-output-heavy session's full
+build can be hundreds of MB; caching it for as long as the session stays open would hold
+that in the Rust process the whole time. Re-parsing trades per-click latency (roughly the
+cost of the session's first list load) for never persisting heavy tool-output bodies in
+memory between Detail clicks.
+
 ```mermaid
 flowchart LR
-    subgraph First_Load["First Load"]
-        L1["Read JSONL\n(full parse)"]
-        L1 --> CACHE["SessionCache.insert\n(path, mtime, size → CachedSession)"]
+    subgraph First_Load["First Load (picker metadata)"]
+        L1["Read JSONL tail\n(scan_session_metadata)"]
+        L1 --> CACHE["SessionCache.insert\n(path, mtime, size → SessionInfo)"]
     end
 
     subgraph Subsequent_Loads["Subsequent Loads (same file, no change)"]
         L2["SessionCache.get\n(path, mtime, size)"]
-        L2 -->|"hit"| CACHED["Return cached\nDisplayMessage[]"]
+        L2 -->|"hit"| CACHED["Return cached SessionInfo\n(re-applies ongoing staleness)"]
         L2 -->|"miss"| L1
     end
 
-    subgraph Ongoing_Session["Ongoing Session (> 60 s since last parse)"]
-        L3["SessionCache.get"] -->|"stale (ongoing)"| L1
+    subgraph Ongoing_Session["Ongoing Session (mtime/size changed)"]
+        L3["SessionCache.get"] -->|"stale (file changed)"| L1
     end
 
     subgraph Picker["Picker Requests"]
@@ -188,7 +266,36 @@ flowchart LR
         P1 -->|"fresh (< 2 s)"| PCACHED["Return cached\nSessionInfo[]"]
         P1 -->|"stale"| PSCAN["Scan FS\n+ re-populate cache"]
     end
+
+    subgraph List_Window["List window fetch (active session)"]
+        W1["load_session_windowed"] --> W2{"session_light_cache\nsame (path, size)?"}
+        W2 -->|"hit"| W3["slice_light()\nwindow existing LightBuild"]
+        W2 -->|"miss"| W4["build_light_session()\nfull parse + lighten"]
+        W4 --> W5["cache as CachedLight\n(path, size)"]
+        W5 --> W3
+    end
+
+    subgraph Detail_Fetch["Detail message fetch (never cached)"]
+        D1["load_message / full_message_at"] --> D2["build_session()\nfull parse, heavy bodies"]
+        D2 --> D3["extract messages[index]\ndrop the rest immediately"]
+    end
 ```
+
+---
+
+## Opening the Detail view drops the list window
+
+Opening the Detail view calls `session.clearWindow()` before fetching the message body:
+this drops every page currently held in the frontend's `windowMessages` map (the sparse
+`Map<index, DisplayMessage>` `ensureRange` populates) since the list is no longer
+visible while Detail is showing. The backend's `session_light_cache` is untouched by
+this — it isn't cleared here, only the frontend's in-memory window is.
+
+Returning to the list view does not restore anything cached: `ensureRange` runs again
+for whatever range is now visible and re-fetches those pages fresh via `load_session`.
+If the backend's `session_light_cache` is still warm for that `(path, size)`, the refetch
+is a cheap `slice_light` rather than a full re-parse; if the file changed size in the
+meantime (e.g. the session grew while Detail was open), the next fetch rebuilds it.
 
 ---
 
@@ -242,14 +349,15 @@ flowchart LR
 
 ## Platform Paths Summary
 
-| Step              | Desktop (Tauri IPC)           | Browser / TUI (HTTP)      |
-| ----------------- | ----------------------------- | ------------------------- |
-| Discover sessions | `invoke("discover_sessions")` | `POST /api/sessions`      |
-| Load session      | `invoke("load_session")`      | `POST /api/session/load`  |
-| Watch session     | `invoke("watch_session")`     | `POST /api/session/watch` |
-| Receive updates   | `listen("session-update")`    | `EventSource /api/events` |
-| Watch picker      | `invoke("watch_picker")`      | `POST /api/picker/watch`  |
-| Picker refresh    | `listen("picker-refresh")`    | `EventSource /api/events` |
+| Step                         | Desktop (Tauri IPC)           | Browser / TUI (HTTP)        |
+| ---------------------------- | ----------------------------- | --------------------------- |
+| Discover sessions            | `invoke("discover_sessions")` | `POST /api/sessions`        |
+| Load session (windowed list) | `invoke("load_session")`      | `POST /api/session/load`    |
+| Load full message (detail)   | `invoke("load_message")`      | `POST /api/session/message` |
+| Watch session                | `invoke("watch_session")`     | `POST /api/session/watch`   |
+| Receive updates              | `listen("session-update")`    | `EventSource /api/events`   |
+| Watch picker                 | `invoke("watch_picker")`      | `POST /api/picker/watch`    |
+| Picker refresh               | `listen("picker-refresh")`    | `EventSource /api/events`   |
 
 ---
 

--- a/specs/13-item-rendering.md
+++ b/specs/13-item-rendering.md
@@ -1,7 +1,8 @@
 # Spec: Item Rendering by Type
 
 **Locations**:
-`src/components/DetailItem.tsx`, `src/components/MessageItem.tsx`, `src/components/Icons.tsx`,
+`src/components/DetailItem.tsx`, `src/components/MessageItem.tsx`, `src/components/MessageList.tsx`,
+`src/components/Icons.tsx`,
 `shared/diff.ts`, `tui-py/diff_utils.py`,
 `tui-py/widgets/detail_view.py`, `tui-py/widgets/message_list.py`,
 `tui-py/items.py`, `tui-py/theme.py`,
@@ -280,10 +281,53 @@ TUI: implemented by `App.tsx` state variables `subagentItem` and `subagentDetail
 
 ---
 
-## Auto-Scroll (`useAutoScroll`)
+## Virtualization (`MessageList`)
 
-Auto-scrolls the message list to the bottom when new content arrives, but only if the user was
-already near the bottom.
+`MessageList.tsx` renders the main message list through react-virtuoso rather than mapping the
+full message array. Only messages inside (and slightly beyond) the viewport are mounted; the rest
+render as lightweight placeholders until their bodies load.
+
+```mermaid
+flowchart TD
+    VIRT["Virtuoso\ntotalCount={count}\nitemContent={renderMessageRow}"]
+    VIRT --> ROW["renderMessageRow(index)"]
+    ROW --> GET["ctx.getMessage(index)"]
+    GET --> LOADED{"body loaded?"}
+    LOADED -->|"yes"| ITEM["MessageItem\n(full render)"]
+    LOADED -->|"no"| PH["placeholder\n.message--placeholder\n(header + content + short line,\nrole class from roles[] index)"]
+
+    VIRT --> RANGE["rangeChanged(range)"]
+    RANGE --> STORE["rangeRef.current = range"]
+    RANGE --> LOAD["onRangeChange(start, end)\n→ triggers body fetch for window"]
+```
+
+- `roles: string[]` is a lightweight full-session role index (length === `count`) kept separate
+  from loaded message bodies, so a placeholder can still pick the correct role class
+  (`message--user` / `message--claude` / `message--compact` / `message--system`) before its body
+  arrives.
+- `increaseViewportBy={{ top: 600, bottom: 600 }}` pre-renders rows 600px outside the visible
+  viewport in both directions, so bodies load and the placeholder→content swap happens off-screen
+  instead of visibly reflowing at the viewport edge.
+- `rangeChanged` reports the currently rendered window; `onRangeChange` is the caller's hook to
+  ensure those message bodies are loaded (paged `useSession`, see
+  [reference_messagelist_virtualized_virtuoso]).
+
+---
+
+## Auto-Scroll
+
+### Main message list — Virtuoso `followOutput`
+
+`MessageList.tsx` does **not** use `useAutoScroll`. It passes `followOutput="smooth"` directly to
+`Virtuoso`, which sticks to the bottom on new/streamed content but only while the user is already
+scrolled to the bottom — the same "don't disturb the reader" behaviour, implemented natively by
+the virtualization library instead of a scroll-event/MutationObserver hook.
+
+### Everywhere else — `useAutoScroll`
+
+`useAutoScroll` still exists and is used by `MessageDetail.tsx` (item list, message list, and
+detail body panels) to auto-scroll to the bottom when new content arrives, but only if the user
+was already near the bottom.
 
 ```mermaid
 flowchart TD
@@ -310,10 +354,38 @@ on an existing item) do not cause unwanted scroll.
 
 ---
 
-## Scroll-to-Selected (`useScrollToSelected`)
+## Scroll-to-Selected
 
-When the keyboard selection changes, the selected item must come into view. The hook walks up
-the DOM to find the scrollable ancestor and aligns based on position.
+### Main message list — `selectionScrollTarget` + Virtuoso
+
+`MessageList.tsx` does **not** use `useScrollToSelected`. It computes the scroll target with a
+pure helper, `selectionScrollTarget(selectedIndex, range)`, and applies it through Virtuoso's
+imperative handle instead of DOM ancestor-walking.
+
+```mermaid
+flowchart TD
+    SEL["selectedIndex changes"]
+    SEL --> FN["selectionScrollTarget(selectedIndex, rangeRef.current)"]
+    FN --> POS{"position?"}
+    POS -->|"selectedIndex < range.startIndex"| TOP["{index, align: 'start'}"]
+    POS -->|"selectedIndex > range.endIndex"| END["{index, align: 'end'}"]
+    POS -->|"within range"| NULLR["null (no-op)"]
+    TOP --> CALL["virtuosoRef.current.scrollToIndex({index, align})"]
+    END --> CALL
+```
+
+`rangeRef` is kept in sync with Virtuoso's `rangeChanged` callback (see
+[Virtualization](#virtualization-messagelist)), so the "currently rendered window" always
+reflects what's actually mounted. Above the window aligns to `"start"` (keeps the header
+visible); below aligns to `"end"`; already visible is a no-op — same behavioural contract as
+`useScrollToSelected`, expressed as index/window arithmetic instead of `getBoundingClientRect()`.
+
+### Everywhere else — `useScrollToSelected`
+
+`useScrollToSelected` still exists and is used by `MessageDetail.tsx`, `DebugViewer.tsx`,
+`SessionPicker.tsx`, and `ProjectTree.tsx`. When the keyboard selection changes, the selected item
+must come into view. The hook walks up the DOM to find the scrollable ancestor and aligns based
+on position.
 
 ```mermaid
 flowchart TD
@@ -328,6 +400,36 @@ flowchart TD
 
 The "no-op when already visible" branch matters: without it, every keyboard move would
 re-centre the selected item, causing visible jitter.
+
+---
+
+## Hover Recompute Under Virtualized Scroll
+
+WebKit (and browsers generally) only recompute `:hover` styling in response to a real pointer
+move — not when the content underneath a stationary cursor shifts, as it does while scrolling a
+virtualized list. This is particularly visible in Tauri's macOS webview, which is WebKit-based:
+after scrolling stops, whatever row happens to land under the cursor can appear "stuck" with a
+stale hover state until the mouse actually moves.
+
+`MessageList.tsx` works around this via Virtuoso's `isScrolling` callback:
+
+```mermaid
+flowchart TD
+    MM["window 'mousemove' listener"]
+    MM --> LAST["lastMouseRef.current = {x, y}"]
+
+    ISS["Virtuoso isScrolling(scrolling)"]
+    ISS --> CLASS["message-list--scrolling class\n(suppresses hover/transition flicker\nwhile actively scrolling)"]
+    ISS --> STOP{"scrolling → false?"}
+    STOP -->|"yes"| RAF["requestAnimationFrame\n(wait for settled scroll to paint)"]
+    RAF --> SYN["dispatch synthetic 'mousemove'\nat lastMouseRef position"]
+    SYN --> REHOVER["browser redoes :hover hit-testing\nwithout a real pointer move"]
+```
+
+The `message-list--scrolling` CSS class is applied to the Virtuoso container while `isScrolling`
+is true, suppressing hover and transition effects so rows don't visibly flicker mid-scroll. Once
+scrolling settles, the synthetic `mousemove` (dispatched at the last real cursor position tracked
+by a `window` listener) forces the browser to redo hit-testing and clear the stale hover.
 
 ---
 

--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -3,6 +3,7 @@ description = "Default permissions for all claude-code-trace commands"
 permissions = [
   "allow-discover-sessions",
   "allow-load-session",
+  "allow-load-message",
   "allow-get-session-meta",
   "allow-watch-session",
   "allow-unwatch-session",
@@ -27,6 +28,11 @@ commands.allow = ["discover_sessions"]
 identifier = "allow-load-session"
 description = "Allow loading a session file"
 commands.allow = ["load_session"]
+
+[[permission]]
+identifier = "allow-load-message"
+description = "Allow loading a single full (heavy-body) message by index"
+commands.allow = ["load_message"]
 
 [[permission]]
 identifier = "allow-get-session-meta"

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -3,62 +3,52 @@ use std::sync::Arc;
 use tauri::{AppHandle, State};
 
 use crate::convert::*;
-use crate::parser::chunk::build_chunks;
-use crate::parser::ongoing::OngoingChecker;
-use crate::parser::session::{extract_session_meta, read_session_with_debug_hooks, SessionMeta};
-use crate::parser::subagent::{discover_and_link_all, inject_orphan_subagents};
-use crate::parser::team::reconstruct_teams;
+use crate::parser::session::{extract_session_meta, SessionMeta};
+use crate::session_load::{LoadOptions, MessageRange};
 use crate::state::AppState;
 use crate::watcher::start_session_watcher;
 
 /// Load a session file and return display messages.
+///
+/// `start`/`limit` request a windowed slice for virtualized clients; omit both
+/// (the default) to load the whole session. The returned `count` is always the
+/// total message count so the client can size the list.
 #[tauri::command]
 pub async fn load_session(
     path: String,
+    start: Option<usize>,
+    limit: Option<usize>,
     state: State<'_, Arc<AppState>>,
 ) -> Result<LoadResult, String> {
     if path.is_empty() {
         return Err("no session path provided".to_string());
     }
 
-    let (classified, _new_offset, _) = read_session_with_debug_hooks(&path)?;
-    let mut chunks = build_chunks(&classified);
+    let opts = LoadOptions::window(MessageRange {
+        start: start.unwrap_or(0),
+        limit,
+    });
+    let result = state.load_session_windowed(&path, opts)?;
 
-    // Discover and link subagent execution traces.
-    let (mut all_procs, color_map) = discover_and_link_all(&path, &chunks);
+    // Set initial ongoing status so the picker has it immediately.
+    state.set_watched_ongoing(path.clone(), result.ongoing);
 
-    // Inject orphan subagents (no parent tool_use in main session yet).
-    inject_orphan_subagents(&mut chunks, &mut all_procs);
+    Ok(result)
+}
 
-    let ongoing = OngoingChecker::new(&chunks, &all_procs, &path).is_ongoing();
-
-    // Set initial ongoing status so picker has it immediately.
-    state.set_watched_ongoing(path.clone(), ongoing);
-
-    let teams = reconstruct_teams(&chunks, &all_procs);
-    let messages = chunks_to_messages(&chunks, &all_procs, &color_map);
-    let meta = extract_session_meta(&path);
-
-    // Scan main session + subagent files with global requestId dedup.
-    let scanned = crate::parser::session::scan_session_metadata(&path);
-    let session_totals = SessionTotals {
-        total_tokens: scanned.total_tokens,
-        input_tokens: scanned.input_tokens,
-        output_tokens: scanned.output_tokens,
-        cache_read_tokens: scanned.cache_read_tokens,
-        cache_creation_tokens: scanned.cache_creation_tokens,
-        cost_usd: scanned.cost_usd,
-        model: scanned.model,
-    };
-
-    Ok(LoadResult {
-        messages,
-        teams,
-        path: path.clone(),
-        ongoing,
-        meta,
-        session_totals,
-    })
+/// Return the full (heavy-body) message at `index` for the detail view. List
+/// windows carry lightened messages (no tool bodies), so the detail view fetches
+/// the full message on demand.
+#[tauri::command]
+pub async fn load_message(
+    path: String,
+    index: usize,
+    state: State<'_, Arc<AppState>>,
+) -> Result<Option<DisplayMessage>, String> {
+    if path.is_empty() {
+        return Err("no session path provided".to_string());
+    }
+    state.full_message_at(&path, index)
 }
 
 /// Get session metadata without loading the full session.
@@ -106,5 +96,6 @@ pub async fn get_project_dirs(state: State<'_, Arc<AppState>>) -> Result<Vec<Str
 #[tauri::command]
 pub async fn unwatch_session(state: State<'_, Arc<AppState>>) -> Result<(), String> {
     state.clear_watched_ongoing();
+    state.clear_session_build_cache();
     state.stop_session_watcher()
 }

--- a/src-tauri/src/convert.rs
+++ b/src-tauri/src/convert.rs
@@ -106,6 +106,12 @@ pub struct SessionTotals {
 }
 
 /// LoadResult holds everything needed to bootstrap the frontend.
+///
+/// `messages` may be a windowed slice of the full session (for virtualized
+/// clients that fetch ranges on demand); `count` is always the total number of
+/// messages in the session and `start` is the index of the first returned
+/// message. When the whole session is returned, `start == 0` and
+/// `count == messages.len()`.
 #[derive(Debug, Clone, Serialize)]
 pub struct LoadResult {
     pub messages: Vec<DisplayMessage>,
@@ -114,6 +120,17 @@ pub struct LoadResult {
     pub ongoing: bool,
     pub meta: crate::parser::session::SessionMeta,
     pub session_totals: SessionTotals,
+    /// Total number of messages in the session (not just the returned window).
+    pub count: usize,
+    /// Index of the first message in `messages` within the full session.
+    pub start: usize,
+    /// Role of every message in the full session (length == `count`). Lets a
+    /// virtualized client render placeholders and drive expand-all without
+    /// holding the heavy message bodies for rows outside the window.
+    pub roles: Vec<String>,
+    /// Latest Claude context-window fill (tokens); 0 if none. The client uses
+    /// this for the context gauge since it can't scan the full message list.
+    pub context_tokens: i64,
 }
 
 /// Format a timestamp as "yyyy-mm-dd hh:mm:ss".

--- a/src-tauri/src/http_api.rs
+++ b/src-tauri/src/http_api.rs
@@ -15,13 +15,8 @@ use tokio_stream::StreamExt;
 use tower_http::cors::CorsLayer;
 use tower_http::services::ServeDir;
 
-use crate::convert::*;
-use crate::parser::chunk::build_chunks;
 use crate::parser::debuglog::*;
-use crate::parser::ongoing::OngoingChecker;
-use crate::parser::session::{extract_session_meta, read_session_with_debug_hooks};
-use crate::parser::subagent::{discover_and_link_all, inject_orphan_subagents};
-use crate::parser::team::reconstruct_teams;
+use crate::parser::session::extract_session_meta;
 use crate::state::AppState;
 use crate::watcher::{start_picker_watcher, start_session_watcher};
 
@@ -99,6 +94,7 @@ async fn run_server(state: Arc<HttpState>) {
         .route("/api/sessions", post(api_discover_sessions))
         .route("/api/session", get(api_get_session_by_id))
         .route("/api/session/load", post(api_load_session))
+        .route("/api/session/message", post(api_load_message))
         .route("/api/session/meta", get(api_get_session_meta))
         .route("/api/session/watch", post(api_watch_session))
         .route("/api/session/unwatch", post(api_unwatch_session))
@@ -275,53 +271,41 @@ async fn api_discover_sessions(
 #[derive(Deserialize)]
 struct PathBody {
     path: String,
+    /// Optional window for virtualized clients — first message index.
+    #[serde(default)]
+    start: Option<usize>,
+    /// Optional window size; omit to load to the end.
+    #[serde(default)]
+    limit: Option<usize>,
 }
 
+/// Load a session by timestamp window (used by the by-id range endpoint).
 fn load_session_by_path(
     app_state: &AppState,
     path: String,
     since: Option<DateTime<Utc>>,
     before: Option<DateTime<Utc>>,
 ) -> Response {
-    let (classified, _new_offset, _) = match read_session_with_debug_hooks(&path) {
-        Ok(v) => v,
+    let opts = crate::session_load::LoadOptions::filtered(crate::session_load::TimeFilter {
+        since,
+        before,
+    });
+    load_session_with(app_state, path, opts)
+}
+
+/// Shared tail for every HTTP session-load path: build via the single pipeline,
+/// record ongoing status, and serialize. Keeps the endpoints thin pass-throughs.
+fn load_session_with(
+    app_state: &AppState,
+    path: String,
+    opts: crate::session_load::LoadOptions,
+) -> Response {
+    let result = match app_state.load_session_windowed(&path, opts) {
+        Ok(r) => r,
         Err(e) => return err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e),
     };
-    let mut chunks = build_chunks(&classified);
-    let (mut all_procs, color_map) = discover_and_link_all(&path, &chunks);
-    inject_orphan_subagents(&mut chunks, &mut all_procs);
-    if since.is_some() || before.is_some() {
-        chunks.retain(|c| {
-            since.map_or(true, |s| c.timestamp >= s) && before.map_or(true, |b| c.timestamp < b)
-        });
-    }
-
-    let ongoing = OngoingChecker::new(&chunks, &all_procs, &path).is_ongoing();
-    app_state.set_watched_ongoing(path.clone(), ongoing);
-
-    let teams = reconstruct_teams(&chunks, &all_procs);
-    let messages = chunks_to_messages(&chunks, &all_procs, &color_map);
-    let meta = extract_session_meta(&path);
-
-    let scanned = crate::parser::session::scan_session_metadata(&path);
-    let session_totals = SessionTotals {
-        total_tokens: scanned.total_tokens,
-        input_tokens: scanned.input_tokens,
-        output_tokens: scanned.output_tokens,
-        cache_read_tokens: scanned.cache_read_tokens,
-        cache_creation_tokens: scanned.cache_creation_tokens,
-        cost_usd: scanned.cost_usd,
-        model: scanned.model,
-    };
-
-    ok_json(&LoadResult {
-        messages,
-        teams,
-        path,
-        ongoing,
-        meta,
-        session_totals,
-    })
+    app_state.set_watched_ongoing(path, result.ongoing);
+    ok_json(&result)
 }
 
 async fn api_load_session(
@@ -334,7 +318,38 @@ async fn api_load_session(
             "no session path provided".to_string(),
         );
     }
-    load_session_by_path(app_state(&state), body.path, None, None)
+    let opts = crate::session_load::LoadOptions::window(crate::session_load::MessageRange {
+        start: body.start.unwrap_or(0),
+        limit: body.limit,
+    });
+    load_session_with(app_state(&state), body.path, opts)
+}
+
+#[derive(Deserialize)]
+struct MessageBody {
+    path: String,
+    index: usize,
+}
+
+/// Return the full (heavy-body) message at `index` for the detail view.
+async fn api_load_message(
+    State(state): State<Arc<HttpState>>,
+    Json(body): Json<MessageBody>,
+) -> Response {
+    if body.path.is_empty() {
+        return err_response(
+            axum::http::StatusCode::BAD_REQUEST,
+            "no session path provided".to_string(),
+        );
+    }
+    match app_state(&state).full_message_at(&body.path, body.index) {
+        Ok(Some(msg)) => ok_json(&msg),
+        Ok(None) => err_response(
+            axum::http::StatusCode::NOT_FOUND,
+            "message not found".to_string(),
+        ),
+        Err(e) => err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e),
+    }
 }
 
 #[derive(Deserialize)]
@@ -447,6 +462,7 @@ async fn api_watch_session(
 async fn api_unwatch_session(State(state): State<Arc<HttpState>>) -> Response {
     let app_state = app_state(&state);
     app_state.clear_watched_ongoing();
+    app_state.clear_session_build_cache();
     match app_state.stop_session_watcher() {
         Ok(()) => ok_json(&serde_json::json!({ "ok": true })),
         Err(e) => err_response(axum::http::StatusCode::INTERNAL_SERVER_ERROR, e),
@@ -558,91 +574,10 @@ async fn api_events(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::parser::chunk::{Chunk, ChunkType};
-    use chrono::TimeZone;
 
-    fn chunk_at(year: i32, month: u32, day: u32) -> Chunk {
-        Chunk {
-            chunk_type: ChunkType::User,
-            timestamp: Utc.with_ymd_and_hms(year, month, day, 0, 0, 0).unwrap(),
-            ..Chunk::default()
-        }
-    }
-
-    fn apply_filter(
-        chunks: &mut Vec<Chunk>,
-        since: Option<DateTime<Utc>>,
-        before: Option<DateTime<Utc>>,
-    ) {
-        if since.is_some() || before.is_some() {
-            chunks.retain(|c| {
-                since.map_or(true, |s| c.timestamp >= s) && before.map_or(true, |b| c.timestamp < b)
-            });
-        }
-    }
-
-    #[test]
-    fn since_future_excludes_all() {
-        let mut chunks = vec![chunk_at(2025, 1, 1), chunk_at(2025, 6, 1)];
-        let since = Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).unwrap();
-        apply_filter(&mut chunks, Some(since), None);
-        assert!(chunks.is_empty());
-    }
-
-    #[test]
-    fn before_ancient_excludes_all() {
-        let mut chunks = vec![chunk_at(2025, 1, 1), chunk_at(2025, 6, 1)];
-        let before = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
-        apply_filter(&mut chunks, None, Some(before));
-        assert!(chunks.is_empty());
-    }
-
-    #[test]
-    fn since_filters_older_keeps_newer() {
-        let mut chunks = vec![
-            chunk_at(2025, 1, 1),
-            chunk_at(2025, 6, 1),
-            chunk_at(2026, 1, 1),
-        ];
-        let since = Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap();
-        apply_filter(&mut chunks, Some(since), None);
-        assert_eq!(chunks.len(), 2);
-        assert!(chunks.iter().all(|c| c.timestamp >= since));
-    }
-
-    #[test]
-    fn before_filters_newer_keeps_older() {
-        let mut chunks = vec![
-            chunk_at(2025, 1, 1),
-            chunk_at(2025, 6, 1),
-            chunk_at(2026, 1, 1),
-        ];
-        let before = Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap();
-        apply_filter(&mut chunks, None, Some(before));
-        assert_eq!(chunks.len(), 1);
-        assert!(chunks.iter().all(|c| c.timestamp < before));
-    }
-
-    #[test]
-    fn since_and_before_window() {
-        let mut chunks = vec![
-            chunk_at(2025, 1, 1),
-            chunk_at(2025, 6, 1),
-            chunk_at(2025, 9, 1),
-            chunk_at(2026, 1, 1),
-        ];
-        let since = Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap();
-        let before = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
-        apply_filter(&mut chunks, Some(since), Some(before));
-        assert_eq!(chunks.len(), 2);
-    }
-
-    #[test]
-    fn no_filter_keeps_all() {
-        let mut chunks = vec![chunk_at(2025, 1, 1), chunk_at(2025, 6, 1)];
-        apply_filter(&mut chunks, None, None);
-        assert_eq!(chunks.len(), 2);
-    }
+    // Timestamp-window filtering is owned and tested by `crate::session_load`
+    // (`TimeFilter`). Here we only cover the HTTP-layer concern of parsing the
+    // `since`/`before` query strings.
 
     #[test]
     fn invalid_since_parse_fails() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod commands;
 mod convert;
 mod http_api;
 mod parser;
+mod session_load;
 mod settings;
 mod state;
 mod watcher;
@@ -58,6 +59,7 @@ pub fn run() {
         .manage(app_state)
         .invoke_handler(tauri::generate_handler![
             commands::session::load_session,
+            commands::session::load_message,
             commands::session::get_session_meta,
             commands::session::watch_session,
             commands::session::unwatch_session,

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -412,10 +412,17 @@ pub fn discover_all_project_sessions(project_dirs: &[String]) -> Result<Vec<Sess
 /// under the real `~/.claude/sessions`, regardless of any `CLAUDE_PROJECTS_DIR`
 /// override.
 pub fn live_session_names() -> HashMap<String, String> {
-    match dirs::home_dir() {
-        Some(home) => session_names_from_dir(&home.join(".claude").join("sessions")),
+    match live_session_names_dir() {
+        Some(dir) => session_names_from_dir(&dir),
         None => HashMap::new(),
     }
+}
+
+/// Resolve the live session-name registry directory (`~/.claude/sessions`).
+/// `None` when the home directory cannot be determined. The registry always
+/// lives under the real home, regardless of any `CLAUDE_PROJECTS_DIR` override.
+pub fn live_session_names_dir() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|home| home.join(".claude").join("sessions"))
 }
 
 /// Build the `session_id -> name` map from a session registry directory. Split
@@ -459,6 +466,42 @@ pub fn apply_session_names(sessions: &mut [SessionInfo], names: &HashMap<String,
         if let Some(name) = names.get(&session.session_id) {
             session.name = Some(name.clone());
         }
+    }
+}
+
+/// Short-TTL cache for the live session-name registry.
+///
+/// The registry (`~/.claude/sessions/*.json`) is scanned at most once per TTL
+/// window, so a burst of `discover_sessions_cached` calls — and the
+/// picker-refresh broadcast fan-out across all connected clients — share a
+/// single disk scan instead of each re-reading and re-parsing every file.
+/// Renames still surface within roughly one TTL window.
+#[derive(Default)]
+pub struct SessionNamesCache {
+    /// `(captured_at, names)` of the last scan, or `None` before the first read.
+    entry: Option<(std::time::Instant, HashMap<String, String>)>,
+}
+
+impl SessionNamesCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached name map if the last scan is younger than `ttl`,
+    /// otherwise re-scan `dir` via [`session_names_from_dir`] and cache it.
+    pub fn get_or_load(
+        &mut self,
+        dir: &std::path::Path,
+        ttl: std::time::Duration,
+    ) -> HashMap<String, String> {
+        if let Some((captured_at, ref names)) = self.entry {
+            if captured_at.elapsed() < ttl {
+                return names.clone();
+            }
+        }
+        let names = session_names_from_dir(dir);
+        self.entry = Some((std::time::Instant::now(), names.clone()));
+        names
     }
 }
 
@@ -1471,6 +1514,74 @@ mod tests {
 
         assert_eq!(sessions[0].name.as_deref(), Some("my-cache"));
         assert_eq!(sessions[1].name, None);
+    }
+
+    #[test]
+    fn session_names_cache_serves_hits_without_rescanning() {
+        use std::time::Duration;
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("1.json"),
+            r#"{"sessionId":"sid-a","name":"first"}"#,
+        )
+        .unwrap();
+
+        let mut cache = SessionNamesCache::new();
+        // Long TTL: the first load populates the cache.
+        let first = cache.get_or_load(dir.path(), Duration::from_secs(60));
+        assert_eq!(first.get("sid-a").map(String::as_str), Some("first"));
+
+        // Change the registry on disk; a cache hit must not see it yet.
+        fs::write(
+            dir.path().join("1.json"),
+            r#"{"sessionId":"sid-a","name":"second"}"#,
+        )
+        .unwrap();
+        let cached = cache.get_or_load(dir.path(), Duration::from_secs(60));
+        assert_eq!(cached.get("sid-a").map(String::as_str), Some("first"));
+    }
+
+    #[test]
+    fn session_names_cache_reloads_after_expiry() {
+        use std::time::Duration;
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("1.json"),
+            r#"{"sessionId":"sid-a","name":"first"}"#,
+        )
+        .unwrap();
+
+        let mut cache = SessionNamesCache::new();
+        let first = cache.get_or_load(dir.path(), Duration::from_secs(60));
+        assert_eq!(first.get("sid-a").map(String::as_str), Some("first"));
+
+        // Rename on disk, then force expiry with a zero TTL: the entry is always
+        // older than zero, so the next call re-scans and picks up the new name.
+        fs::write(
+            dir.path().join("1.json"),
+            r#"{"sessionId":"sid-a","name":"second"}"#,
+        )
+        .unwrap();
+        let reloaded = cache.get_or_load(dir.path(), Duration::ZERO);
+        assert_eq!(reloaded.get("sid-a").map(String::as_str), Some("second"));
+    }
+
+    #[test]
+    fn session_names_cache_reload_clears_removed_names() {
+        use std::time::Duration;
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("1.json");
+        fs::write(&file, r#"{"sessionId":"sid-a","name":"first"}"#).unwrap();
+
+        let mut cache = SessionNamesCache::new();
+        let first = cache.get_or_load(dir.path(), Duration::from_secs(60));
+        assert_eq!(first.get("sid-a").map(String::as_str), Some("first"));
+
+        // Removing the registry file (e.g. session exit) must clear the name on
+        // the next expired read.
+        fs::remove_file(&file).unwrap();
+        let reloaded = cache.get_or_load(dir.path(), Duration::ZERO);
+        assert!(reloaded.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/session_load.rs
+++ b/src-tauri/src/session_load.rs
@@ -1,0 +1,784 @@
+//! Shared session-load pipeline.
+//!
+//! Building the display messages for a session (parse → chunk → link subagents →
+//! inject orphans → reconstruct teams → convert to messages) was duplicated
+//! across the Tauri command, the HTTP API, and the watcher. This module owns the
+//! single implementation and adds index-range windowing so virtualized clients
+//! can fetch only the slice they're viewing.
+//!
+//! Windowing slices the *fully built* message list by index. The build itself is
+//! still whole-file (message linking has cross-message dependencies), so this is
+//! correct but O(file) per call; an incremental byte-offset index can later make
+//! range fetches O(window) without changing this module's contract.
+
+use chrono::{DateTime, Utc};
+
+use crate::convert::{chunks_to_messages, DisplayMessage, LoadResult, SessionTotals};
+use crate::parser::chunk::{build_chunks, Chunk};
+use crate::parser::classify::ClassifiedMsg;
+use crate::parser::ongoing::OngoingChecker;
+use crate::parser::session::{extract_session_meta, read_session_with_debug_hooks, SessionMeta};
+use crate::parser::subagent::{discover_and_link_all, inject_orphan_subagents};
+use crate::parser::team::{reconstruct_teams, TeamSnapshot};
+
+/// The display-level build of a session: messages, teams, ongoing status and the
+/// live permission mode. Deliberately excludes session totals and file metadata
+/// so the watcher can reuse it on every change without paying for a full token
+/// re-scan (it keeps its own incremental scanner).
+pub struct ViewBuild {
+    pub messages: Vec<DisplayMessage>,
+    pub teams: Vec<TeamSnapshot>,
+    pub ongoing: bool,
+    /// Latest permission mode, derived from the classified messages (free — the
+    /// entries were already read to build the view).
+    pub permission_mode: String,
+}
+
+/// A fully built session: the display view plus file metadata and token totals.
+/// The caller decides what to do with `ongoing` (e.g. record it in `AppState`).
+pub struct BuiltSession {
+    pub messages: Vec<DisplayMessage>,
+    pub teams: Vec<TeamSnapshot>,
+    pub ongoing: bool,
+    pub meta: SessionMeta,
+    pub session_totals: SessionTotals,
+}
+
+/// A session build with the heavy message bodies already stripped — the shape
+/// safe to persist in a long-lived cache (e.g. across scroll-driven range
+/// fetches) without holding tool output in memory for the session's lifetime.
+/// Built by lightening a [`BuiltSession`] and dropping the heavy original.
+pub struct LightBuild {
+    pub light_messages: Vec<DisplayMessage>,
+    pub teams: Vec<TeamSnapshot>,
+    pub ongoing: bool,
+    pub meta: SessionMeta,
+    pub session_totals: SessionTotals,
+}
+
+/// A timestamp window applied to the session's chunks before messages are built.
+/// `since` is inclusive, `before` is exclusive; either may be `None`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TimeFilter {
+    pub since: Option<DateTime<Utc>>,
+    pub before: Option<DateTime<Utc>>,
+}
+
+impl TimeFilter {
+    fn is_active(&self) -> bool {
+        self.since.is_some() || self.before.is_some()
+    }
+
+    /// Keep only chunks whose timestamp falls within the window.
+    pub(crate) fn retain(&self, chunks: &mut Vec<Chunk>) {
+        if !self.is_active() {
+            return;
+        }
+        chunks.retain(|c| {
+            self.since.map_or(true, |s| c.timestamp >= s)
+                && self.before.map_or(true, |b| c.timestamp < b)
+        });
+    }
+}
+
+/// An index range into a session's message list. `start` is inclusive; `limit`
+/// caps the number of messages returned (`None` = to the end).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MessageRange {
+    pub start: usize,
+    pub limit: Option<usize>,
+}
+
+impl MessageRange {
+    /// The full session — every message from the beginning.
+    pub fn full() -> Self {
+        Self {
+            start: 0,
+            limit: None,
+        }
+    }
+
+    /// Resolve `[start, end)` against a concrete message count, clamping both
+    /// ends so out-of-range requests return an empty slice rather than panic.
+    fn resolve(&self, count: usize) -> (usize, usize) {
+        let start = self.start.min(count);
+        let end = match self.limit {
+            Some(limit) => start.saturating_add(limit).min(count),
+            None => count,
+        };
+        (start, end)
+    }
+}
+
+/// Options for a session load: an optional timestamp filter (applied to chunks)
+/// and an optional index window (applied to the resulting messages). Both
+/// default to "everything".
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LoadOptions {
+    pub time: TimeFilter,
+    pub range: MessageRange,
+}
+
+impl LoadOptions {
+    /// Load the whole session, no filtering or windowing.
+    pub fn full() -> Self {
+        Self::default()
+    }
+
+    /// Load with an index window only.
+    pub fn window(range: MessageRange) -> Self {
+        Self {
+            range,
+            ..Self::default()
+        }
+    }
+
+    /// Load with a timestamp filter only.
+    pub fn filtered(time: TimeFilter) -> Self {
+        Self {
+            time,
+            ..Self::default()
+        }
+    }
+}
+
+/// Latest non-empty permission mode across the classified messages (the tip of
+/// the conversation wins). Empty when none is set.
+fn last_permission_mode(classified: &[ClassifiedMsg]) -> String {
+    for msg in classified.iter().rev() {
+        if let ClassifiedMsg::User(u) = msg {
+            if !u.permission_mode.is_empty() {
+                return u.permission_mode.clone();
+            }
+        }
+    }
+    String::new()
+}
+
+/// Build the display view of a session (messages, teams, ongoing, permission
+/// mode), applying an optional timestamp filter to the chunks before messages
+/// are built.
+///
+/// This is the single owner of the parse→chunk→link→messages pipeline — every
+/// caller (Tauri command, HTTP API, watcher) goes through here rather than
+/// re-assembling the steps, so the build stays consistent everywhere.
+pub fn build_view(path: &str, time: TimeFilter) -> Result<ViewBuild, String> {
+    let (classified, _offset, _bytes) = read_session_with_debug_hooks(path)?;
+    let mut chunks = build_chunks(&classified);
+
+    // Discover and link subagent execution traces, then inject any orphans that
+    // have no parent tool_use in the main session yet.
+    let (mut all_procs, color_map) = discover_and_link_all(path, &chunks);
+    inject_orphan_subagents(&mut chunks, &mut all_procs);
+
+    // Apply the timestamp window after linking so ongoing/teams/messages all
+    // agree on the same filtered chunk set.
+    time.retain(&mut chunks);
+
+    let ongoing = OngoingChecker::new(&chunks, &all_procs, path).is_ongoing();
+    let teams = reconstruct_teams(&chunks, &all_procs);
+    let messages = chunks_to_messages(&chunks, &all_procs, &color_map);
+    let permission_mode = last_permission_mode(&classified);
+
+    Ok(ViewBuild {
+        messages,
+        teams,
+        ongoing,
+        permission_mode,
+    })
+}
+
+/// Build the display view plus file metadata and token totals. Used by the
+/// one-shot load paths (Tauri command, HTTP API); the watcher uses
+/// [`build_view`] directly with its own incremental token scanner.
+pub fn build_session(path: &str, time: TimeFilter) -> Result<BuiltSession, String> {
+    let view = build_view(path, time)?;
+    let meta = extract_session_meta(path);
+
+    let scanned = crate::parser::session::scan_session_metadata(path);
+    let session_totals = SessionTotals {
+        total_tokens: scanned.total_tokens,
+        input_tokens: scanned.input_tokens,
+        output_tokens: scanned.output_tokens,
+        cache_read_tokens: scanned.cache_read_tokens,
+        cache_creation_tokens: scanned.cache_creation_tokens,
+        cost_usd: scanned.cost_usd,
+        model: scanned.model,
+    };
+
+    Ok(BuiltSession {
+        messages: view.messages,
+        teams: view.teams,
+        ongoing: view.ongoing,
+        meta,
+        session_totals,
+    })
+}
+
+/// Build a session, then immediately lighten and discard the heavy message
+/// bodies — the caller ends up holding only [`LightBuild`], never the full
+/// tool-output-heavy `messages`. Use this for anything that persists the
+/// result in a long-lived cache; use [`build_session`] when the heavy bodies
+/// are needed for that one call only (e.g. a single detail lookup) so they can
+/// be dropped right after without ever being cached.
+pub fn build_light_session(path: &str, time: TimeFilter) -> Result<LightBuild, String> {
+    let built = build_session(path, time)?;
+    let light_messages = lighten_messages(&built.messages);
+    Ok(LightBuild {
+        light_messages,
+        teams: built.teams,
+        ongoing: built.ongoing,
+        meta: built.meta,
+        session_totals: built.session_totals,
+    })
+    // `built.messages` (heavy) is dropped here, at the end of this function —
+    // never persisted by the caller.
+}
+
+/// The role string of every message, in order — the lightweight index a
+/// virtualized client needs (placeholders, expand-all) without the bodies.
+pub fn message_roles(messages: &[DisplayMessage]) -> Vec<String> {
+    messages.iter().map(|m| m.role.clone()).collect()
+}
+
+/// Context-window fill: the `context_tokens` of the most recent Claude message
+/// that reports a non-zero value, or 0 if none. A virtualized client needs this
+/// as a scalar because it can no longer scan the full message list itself.
+pub fn latest_context_tokens(messages: &[DisplayMessage]) -> i64 {
+    messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "claude" && m.context_tokens > 0)
+        .map_or(0, |m| m.context_tokens)
+}
+
+/// Build a session and return a [`LoadResult`] honoring `opts`: `messages` is
+/// the requested (optionally filtered, optionally windowed) slice, while `count`
+/// is always the total message count after filtering so the client can size a
+/// virtualized list. `teams`, `meta` and `session_totals` describe the whole
+/// (filtered) session regardless of the index window.
+pub fn load_session(path: &str, opts: LoadOptions) -> Result<LoadResult, String> {
+    let built = build_session(path, opts.time)?;
+    Ok(slice_built(&built, &built.messages, path, opts.range))
+}
+
+/// Assemble a windowed [`LoadResult`] from an already-built session, windowing
+/// over the given `messages` (which may be the full or the lightened list).
+/// Split out so a cached build can be sliced repeatedly (different windows)
+/// without rebuilding — the cache-hit path in `AppState`.
+pub fn slice_built(
+    built: &BuiltSession,
+    messages: &[DisplayMessage],
+    path: &str,
+    range: MessageRange,
+) -> LoadResult {
+    assemble_load_result(
+        messages,
+        built.teams.clone(),
+        built.ongoing,
+        built.meta.clone(),
+        built.session_totals.clone(),
+        path,
+        range,
+    )
+}
+
+/// Same as [`slice_built`], but for a [`LightBuild`] — the cache-hit path for
+/// list windows when only the lightened messages are kept in memory.
+pub fn slice_light(light: &LightBuild, path: &str, range: MessageRange) -> LoadResult {
+    assemble_load_result(
+        &light.light_messages,
+        light.teams.clone(),
+        light.ongoing,
+        light.meta.clone(),
+        light.session_totals.clone(),
+        path,
+        range,
+    )
+}
+
+/// Shared tail for [`slice_built`] and [`slice_light`]: window `messages` and
+/// pair it with the (already-owned) session-level fields.
+fn assemble_load_result(
+    messages: &[DisplayMessage],
+    teams: Vec<TeamSnapshot>,
+    ongoing: bool,
+    meta: SessionMeta,
+    session_totals: SessionTotals,
+    path: &str,
+    range: MessageRange,
+) -> LoadResult {
+    let count = messages.len();
+    // Roles and context fill cover the whole session; messages is only the window.
+    let roles = message_roles(messages);
+    let context_tokens = latest_context_tokens(messages);
+    let (start, end) = range.resolve(count);
+    let window = messages[start..end].to_vec();
+
+    LoadResult {
+        messages: window,
+        teams,
+        path: path.to_string(),
+        ongoing,
+        meta,
+        session_totals,
+        count,
+        start,
+        roles,
+        context_tokens,
+    }
+}
+
+/// Produce a memory-light copy of the messages for the list view: the heavy
+/// per-item bodies the list never renders (`tool_input`, `tool_result`,
+/// `tool_result_json`) and the last-output snapshot are dropped, recursively
+/// including nested subagent transcripts. Structure, roles, counts and
+/// `subagent_messages` boundaries are preserved so stats/expand-all stay correct.
+/// The full bodies remain available via [`BuiltSession::messages`] for the
+/// detail view. This is what keeps the renderer flat on tool-output-heavy
+/// sessions (a 100-message session can otherwise be >100 MB of tool output).
+pub fn lighten_messages(messages: &[DisplayMessage]) -> Vec<DisplayMessage> {
+    messages.iter().map(lighten_message).collect()
+}
+
+/// Build a light copy of one message field-by-field. Constructing the heavy
+/// fields directly as `String::new()` — rather than cloning the message and
+/// then overwriting them — means the heavy buffer is never duplicated: a naive
+/// `m.clone()` would allocate a full second copy of every `tool_result` /
+/// `tool_result_json` string before immediately discarding it, doubling peak
+/// memory for tool-output-heavy sessions.
+fn lighten_message(m: &crate::convert::DisplayMessage) -> crate::convert::DisplayMessage {
+    crate::convert::DisplayMessage {
+        role: m.role.clone(),
+        model: m.model.clone(),
+        content: m.content.clone(),
+        timestamp: m.timestamp.clone(),
+        thinking_count: m.thinking_count,
+        tool_call_count: m.tool_call_count,
+        output_count: m.output_count,
+        tokens_raw: m.tokens_raw,
+        input_tokens: m.input_tokens,
+        output_tokens: m.output_tokens,
+        cache_read_tokens: m.cache_read_tokens,
+        cache_creation_tokens: m.cache_creation_tokens,
+        context_tokens: m.context_tokens,
+        duration_ms: m.duration_ms,
+        items: m.items.iter().map(lighten_item).collect(),
+        last_output: None,
+        is_error: m.is_error,
+        teammate_spawns: m.teammate_spawns,
+        teammate_messages: m.teammate_messages,
+        subagent_label: m.subagent_label.clone(),
+    }
+}
+
+fn lighten_item(it: &crate::convert::FrontendDisplayItem) -> crate::convert::FrontendDisplayItem {
+    crate::convert::FrontendDisplayItem {
+        id: it.id.clone(),
+        item_type: it.item_type.clone(),
+        text: it.text.clone(),
+        tool_name: it.tool_name.clone(),
+        tool_summary: it.tool_summary.clone(),
+        tool_category: it.tool_category.clone(),
+        tool_input: String::new(),
+        tool_result: String::new(),
+        tool_error: it.tool_error,
+        duration_ms: it.duration_ms,
+        token_count: it.token_count,
+        subagent_type: it.subagent_type.clone(),
+        subagent_desc: it.subagent_desc.clone(),
+        team_member_name: it.team_member_name.clone(),
+        teammate_id: it.teammate_id.clone(),
+        team_color: it.team_color.clone(),
+        subagent_ongoing: it.subagent_ongoing,
+        agent_id: it.agent_id.clone(),
+        subagent_messages: lighten_messages(&it.subagent_messages),
+        hook_event: it.hook_event.clone(),
+        hook_name: it.hook_name.clone(),
+        hook_command: it.hook_command.clone(),
+        hook_metadata: it.hook_metadata.clone(),
+        tool_result_json: String::new(),
+        is_orphan: it.is_orphan,
+        subagent_prompt: it.subagent_prompt.clone(),
+        is_deferred: it.is_deferred,
+        hook_source_agent_name: it.hook_source_agent_name.clone(),
+        hook_requesting_agent_uuid: it.hook_requesting_agent_uuid.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write a minimal two-message session (one user, one assistant) to a temp
+    /// JSONL file and return its path.
+    fn write_fixture(dir: &std::path::Path) -> String {
+        let path = dir.join("session.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","uuid":"u1","timestamp":"2025-01-01T12:00:00Z","message":{{"role":"user","content":"hello"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2025-01-01T12:00:01Z","message":{{"role":"assistant","model":"claude-sonnet-4-20250514","content":[{{"type":"text","text":"hi there"}}]}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","uuid":"u2","parentUuid":"a1","timestamp":"2025-01-01T12:00:02Z","message":{{"role":"user","content":"bye"}}}}"#
+        )
+        .unwrap();
+        path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn window_full_matches_build_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_fixture(dir.path());
+
+        let full = build_session(&path, TimeFilter::default()).unwrap();
+        let windowed = load_session(&path, LoadOptions::full()).unwrap();
+
+        // Parity: the full window must equal the direct build, one-for-one.
+        assert_eq!(windowed.count, full.messages.len());
+        assert_eq!(windowed.start, 0);
+        assert_eq!(windowed.messages.len(), full.messages.len());
+        for (a, b) in windowed.messages.iter().zip(full.messages.iter()) {
+            assert_eq!(a.role, b.role);
+            assert_eq!(a.content, b.content);
+            assert_eq!(a.timestamp, b.timestamp);
+        }
+    }
+
+    #[test]
+    fn window_slice_returns_requested_range_with_total_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_fixture(dir.path());
+        let full = build_session(&path, TimeFilter::default()).unwrap();
+        assert!(
+            full.messages.len() >= 3,
+            "fixture should yield >=3 messages"
+        );
+
+        let win = load_session(
+            &path,
+            LoadOptions::window(MessageRange {
+                start: 1,
+                limit: Some(1),
+            }),
+        )
+        .unwrap();
+        assert_eq!(
+            win.count,
+            full.messages.len(),
+            "count is the total, not the slice"
+        );
+        assert_eq!(win.start, 1);
+        assert_eq!(win.messages.len(), 1);
+        assert_eq!(win.messages[0].content, full.messages[1].content);
+    }
+
+    #[test]
+    fn window_out_of_range_is_empty_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_fixture(dir.path());
+        let full = build_session(&path, TimeFilter::default()).unwrap();
+
+        let win = load_session(
+            &path,
+            LoadOptions::window(MessageRange {
+                start: 9999,
+                limit: Some(10),
+            }),
+        )
+        .unwrap();
+        assert_eq!(win.count, full.messages.len());
+        assert_eq!(win.start, full.messages.len());
+        assert!(win.messages.is_empty());
+    }
+
+    #[test]
+    fn range_resolve_clamps_both_ends() {
+        assert_eq!(
+            MessageRange {
+                start: 0,
+                limit: None
+            }
+            .resolve(5),
+            (0, 5)
+        );
+        assert_eq!(
+            MessageRange {
+                start: 2,
+                limit: Some(2)
+            }
+            .resolve(5),
+            (2, 4)
+        );
+        assert_eq!(
+            MessageRange {
+                start: 3,
+                limit: Some(10)
+            }
+            .resolve(5),
+            (3, 5)
+        );
+        assert_eq!(
+            MessageRange {
+                start: 8,
+                limit: Some(2)
+            }
+            .resolve(5),
+            (5, 5)
+        );
+    }
+
+    #[test]
+    fn time_filter_future_since_excludes_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_fixture(dir.path());
+        let since = "2099-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let win = load_session(
+            &path,
+            LoadOptions::filtered(TimeFilter {
+                since: Some(since),
+                before: None,
+            }),
+        )
+        .unwrap();
+        assert_eq!(win.count, 0);
+        assert!(win.messages.is_empty());
+    }
+
+    #[test]
+    fn time_filter_wide_window_keeps_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_fixture(dir.path());
+        let full = build_session(&path, TimeFilter::default()).unwrap();
+        let before = "2099-01-01T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+
+        let win = load_session(
+            &path,
+            LoadOptions::filtered(TimeFilter {
+                since: None,
+                before: Some(before),
+            }),
+        )
+        .unwrap();
+        assert_eq!(win.count, full.messages.len());
+    }
+
+    // --- TimeFilter::retain predicate (synthetic chunks) ---
+
+    use crate::parser::chunk::{Chunk, ChunkType};
+    use chrono::TimeZone;
+
+    fn chunk_at(year: i32, month: u32, day: u32) -> Chunk {
+        Chunk {
+            chunk_type: ChunkType::User,
+            timestamp: Utc.with_ymd_and_hms(year, month, day, 0, 0, 0).unwrap(),
+            ..Chunk::default()
+        }
+    }
+
+    fn retained(mut chunks: Vec<Chunk>, filter: TimeFilter) -> Vec<Chunk> {
+        filter.retain(&mut chunks);
+        chunks
+    }
+
+    #[test]
+    fn retain_future_since_excludes_all() {
+        let chunks = vec![chunk_at(2025, 1, 1), chunk_at(2025, 6, 1)];
+        let since = Utc.with_ymd_and_hms(2099, 1, 1, 0, 0, 0).unwrap();
+        assert!(retained(
+            chunks,
+            TimeFilter {
+                since: Some(since),
+                before: None
+            }
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn retain_ancient_before_excludes_all() {
+        let chunks = vec![chunk_at(2025, 1, 1), chunk_at(2025, 6, 1)];
+        let before = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
+        assert!(retained(
+            chunks,
+            TimeFilter {
+                since: None,
+                before: Some(before)
+            }
+        )
+        .is_empty());
+    }
+
+    #[test]
+    fn retain_since_keeps_newer() {
+        let chunks = vec![
+            chunk_at(2025, 1, 1),
+            chunk_at(2025, 6, 1),
+            chunk_at(2026, 1, 1),
+        ];
+        let since = Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap();
+        let kept = retained(
+            chunks,
+            TimeFilter {
+                since: Some(since),
+                before: None,
+            },
+        );
+        assert_eq!(kept.len(), 2);
+        assert!(kept.iter().all(|c| c.timestamp >= since));
+    }
+
+    #[test]
+    fn retain_before_keeps_older() {
+        let chunks = vec![
+            chunk_at(2025, 1, 1),
+            chunk_at(2025, 6, 1),
+            chunk_at(2026, 1, 1),
+        ];
+        let before = Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap();
+        let kept = retained(
+            chunks,
+            TimeFilter {
+                since: None,
+                before: Some(before),
+            },
+        );
+        assert_eq!(kept.len(), 1);
+        assert!(kept.iter().all(|c| c.timestamp < before));
+    }
+
+    #[test]
+    fn retain_since_and_before_window() {
+        let chunks = vec![
+            chunk_at(2025, 1, 1),
+            chunk_at(2025, 6, 1),
+            chunk_at(2025, 9, 1),
+            chunk_at(2026, 1, 1),
+        ];
+        let since = Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap();
+        let before = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        let kept = retained(
+            chunks,
+            TimeFilter {
+                since: Some(since),
+                before: Some(before),
+            },
+        );
+        assert_eq!(kept.len(), 2);
+    }
+
+    #[test]
+    fn retain_no_filter_keeps_all() {
+        let chunks = vec![chunk_at(2025, 1, 1), chunk_at(2025, 6, 1)];
+        assert_eq!(retained(chunks, TimeFilter::default()).len(), 2);
+    }
+
+    // --- lighten_messages ---
+
+    use crate::convert::{FrontendDisplayItem, FrontendLastOutput};
+
+    fn heavy_item(id: &str, subs: Vec<DisplayMessage>) -> FrontendDisplayItem {
+        FrontendDisplayItem {
+            id: id.to_string(),
+            item_type: "ToolCall".to_string(),
+            text: String::new(),
+            tool_name: "Read".to_string(),
+            tool_summary: "read a file".to_string(),
+            tool_category: String::new(),
+            tool_input: "big input".to_string(),
+            tool_result: "big result".to_string(),
+            tool_error: false,
+            duration_ms: 0,
+            token_count: 0,
+            subagent_type: String::new(),
+            subagent_desc: String::new(),
+            team_member_name: String::new(),
+            teammate_id: String::new(),
+            team_color: String::new(),
+            subagent_ongoing: false,
+            agent_id: String::new(),
+            subagent_messages: subs,
+            hook_event: String::new(),
+            hook_name: String::new(),
+            hook_command: String::new(),
+            hook_metadata: String::new(),
+            tool_result_json: "{\"big\":\"json\"}".to_string(),
+            is_orphan: false,
+            subagent_prompt: String::new(),
+            is_deferred: false,
+            hook_source_agent_name: String::new(),
+            hook_requesting_agent_uuid: String::new(),
+        }
+    }
+
+    fn msg_with(role: &str, items: Vec<FrontendDisplayItem>) -> DisplayMessage {
+        DisplayMessage {
+            role: role.to_string(),
+            model: String::new(),
+            content: "hi".to_string(),
+            timestamp: "2025-01-01T00:00:00Z".to_string(),
+            thinking_count: 0,
+            tool_call_count: 0,
+            output_count: 0,
+            tokens_raw: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            context_tokens: 0,
+            duration_ms: 0,
+            items,
+            last_output: Some(FrontendLastOutput {
+                output_type: String::new(),
+                text: "big output".to_string(),
+                tool_name: String::new(),
+                tool_result: "big".to_string(),
+                is_error: false,
+                tool_calls: vec![],
+            }),
+            is_error: false,
+            teammate_spawns: 0,
+            teammate_messages: 0,
+            subagent_label: String::new(),
+        }
+    }
+
+    #[test]
+    fn lighten_strips_bodies_recursively_and_keeps_structure() {
+        let inner = msg_with("claude", vec![heavy_item("s1", vec![])]);
+        let outer = msg_with("claude", vec![heavy_item("i1", vec![inner])]);
+
+        let light = lighten_messages(&[outer.clone()]);
+        assert_eq!(light.len(), 1);
+
+        let it = &light[0].items[0];
+        // Heavy bodies dropped.
+        assert!(it.tool_input.is_empty());
+        assert!(it.tool_result.is_empty());
+        assert!(it.tool_result_json.is_empty());
+        // Metadata + structure preserved.
+        assert_eq!(it.id, "i1");
+        assert_eq!(it.tool_name, "Read");
+        assert_eq!(it.tool_summary, "read a file");
+        assert_eq!(it.subagent_messages.len(), 1, "subagent boundary preserved");
+        // Recursion into nested subagent transcripts.
+        let inner_it = &it.subagent_messages[0].items[0];
+        assert_eq!(inner_it.id, "s1");
+        assert!(inner_it.tool_result.is_empty());
+        assert!(inner_it.tool_result_json.is_empty());
+        // last_output snapshot dropped.
+        assert!(light[0].last_output.is_none());
+
+        // Roles/context are unchanged by lightening (parity for the index).
+        assert_eq!(message_roles(&light), message_roles(&[outer]));
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2,8 +2,14 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 
+use std::collections::HashMap;
+
+use crate::convert::{DisplayMessage, LoadResult};
 use crate::parser::cache::SessionCache;
-use crate::parser::session::SessionInfo;
+use crate::parser::session::{SessionInfo, SessionNamesCache};
+use crate::session_load::{
+    build_light_session, build_session, slice_light, LightBuild, LoadOptions, TimeFilter,
+};
 use crate::settings::Settings;
 use crate::watcher::WatcherHandle;
 
@@ -26,6 +32,24 @@ struct SessionsCache {
 
 const SESSIONS_CACHE_TTL: Duration = Duration::from_secs(2);
 
+/// TTL for the live session-name registry scan. Short enough that `/rename`
+/// names (and their removal) appear within roughly one picker-refresh cycle,
+/// long enough that a burst of refreshes shares a single scan.
+const SESSION_NAMES_CACHE_TTL: Duration = Duration::from_secs(1);
+
+/// A lightened session build cached for the active session, keyed by
+/// `(path, size)`. Lets range fetches during list scrolling slice an
+/// already-built session instead of re-parsing the file on every scroll step.
+/// Holds only the heavy-body-stripped messages — the full tool output is never
+/// persisted here (see [`AppState::full_message_at`], which re-parses fresh and
+/// discards the heavy build immediately after each detail lookup, trading
+/// per-click latency for not holding tool output in memory between clicks).
+struct CachedLight {
+    path: String,
+    size: u64,
+    light: LightBuild,
+}
+
 /// AppState holds shared state managed by Tauri.
 pub struct AppState {
     pub session_watcher: Mutex<Option<WatcherHandle>>,
@@ -39,6 +63,13 @@ pub struct AppState {
     pub event_tx: broadcast::Sender<SseEvent>,
     /// 2-second TTL cache for the picker session list.
     sessions_cache: Mutex<Option<SessionsCache>>,
+    /// Short-TTL cache for the live `/rename` session-name registry, shared by
+    /// all concurrent `discover_sessions_cached` callers.
+    session_names_cache: Mutex<SessionNamesCache>,
+    /// Lightened-build cache for the active session so windowed list fetches
+    /// slice an existing build instead of re-parsing the file on every scroll.
+    /// Never holds heavy tool bodies — see [`CachedLight`].
+    session_light_cache: Mutex<Option<CachedLight>>,
 }
 
 impl AppState {
@@ -52,6 +83,89 @@ impl AppState {
             watched_session_ongoing: Mutex::new(None),
             event_tx,
             sessions_cache: Mutex::new(None),
+            session_names_cache: Mutex::new(SessionNamesCache::new()),
+            session_light_cache: Mutex::new(None),
+        }
+    }
+
+    /// Load a windowed slice of a session, caching the lightened build for the
+    /// active session so repeated list range fetches (scrolling) don't re-parse
+    /// the file. Never holds heavy tool bodies — see [`full_message_at`] for
+    /// those.
+    ///
+    /// The cache holds one session, keyed by `(path, size)`: a different path or
+    /// a grown/truncated file rebuilds it, so memory stays bounded to the active
+    /// session. Time-filtered loads bypass the cache (they're rare and would
+    /// pollute the single slot).
+    ///
+    /// [`full_message_at`]: Self::full_message_at
+    pub fn load_session_windowed(
+        &self,
+        path: &str,
+        opts: LoadOptions,
+    ) -> Result<LoadResult, String> {
+        // Time-filtered loads bypass the cache and return full messages (rare,
+        // used by the by-id range endpoint).
+        if opts.time.since.is_some() || opts.time.before.is_some() {
+            return crate::session_load::load_session(path, opts);
+        }
+
+        let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        let mut cache = self.session_light_cache.lock().map_err(|e| e.to_string())?;
+        let fresh = cache
+            .as_ref()
+            .is_some_and(|c| c.path == path && c.size == size);
+        if !fresh {
+            let light = build_light_session(path, TimeFilter::default())?;
+            *cache = Some(CachedLight {
+                path: path.to_string(),
+                size,
+                light,
+            });
+        }
+        Ok(slice_light(
+            &cache.as_ref().unwrap().light,
+            path,
+            opts.range,
+        ))
+    }
+
+    /// Return the full (heavy-body) message at `index` for the detail view.
+    ///
+    /// Deliberately re-parses the whole session fresh on every call rather than
+    /// caching the heavy build: a tool-output-heavy session can be hundreds of
+    /// MB, and caching it for as long as the session is open would hold that in
+    /// the Rust process the whole time. Re-parsing trades per-click latency
+    /// (roughly the same cost as the session's first list load) for never
+    /// persisting the heavy bodies between clicks — the full build is dropped
+    /// as soon as this function returns.
+    pub fn full_message_at(
+        &self,
+        path: &str,
+        index: usize,
+    ) -> Result<Option<DisplayMessage>, String> {
+        let built = build_session(path, TimeFilter::default())?;
+        Ok(built.messages.get(index).cloned())
+    }
+
+    /// Drop the lightened-build cache (e.g. when leaving a session for the picker).
+    pub fn clear_session_build_cache(&self) {
+        if let Ok(mut cache) = self.session_light_cache.lock() {
+            *cache = None;
+        }
+    }
+
+    /// Read the live `/rename` session-name registry through a short-TTL cache so
+    /// concurrent/rapid callers share a single disk scan. Falls back to an
+    /// uncached scan if the cache lock is poisoned or the home dir is unknown.
+    fn live_session_names_cached(&self) -> HashMap<String, String> {
+        let dir = match crate::parser::session::live_session_names_dir() {
+            Some(d) => d,
+            None => return HashMap::new(),
+        };
+        match self.session_names_cache.lock() {
+            Ok(mut cache) => cache.get_or_load(&dir, SESSION_NAMES_CACHE_TTL),
+            Err(_) => crate::parser::session::live_session_names(),
         }
     }
 
@@ -146,10 +260,12 @@ impl AppState {
         // Join the live `/rename` names on every call. Names live in the pid-keyed
         // `~/.claude/sessions/*.json` registry, which the transcript-file cache does
         // not track (a rename never touches the JSONL), so the join runs after the
-        // cache rather than being baked into the cached `SessionInfo`.
+        // cache rather than being baked into the cached `SessionInfo`. The registry
+        // read itself is behind its own short-TTL cache so a burst of refreshes and
+        // the broadcast fan-out share one disk scan.
         crate::parser::session::apply_session_names(
             &mut sessions,
-            &crate::parser::session::live_session_names(),
+            &self.live_session_names_cached(),
         );
         Ok(sessions)
     }
@@ -160,5 +276,125 @@ impl AppState {
             event: event.to_string(),
             data: data.to_string(),
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session_load::MessageRange;
+    use std::io::Write;
+
+    fn write_session(dir: &std::path::Path) -> String {
+        let path = dir.join("s.jsonl");
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","uuid":"u1","timestamp":"2025-01-01T12:00:00Z","message":{{"role":"user","content":"hello"}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2025-01-01T12:00:01Z","message":{{"role":"assistant","model":"claude-sonnet-4-20250514","content":[{{"type":"text","text":"hi there"}}]}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"type":"user","uuid":"u2","parentUuid":"a1","timestamp":"2025-01-01T12:00:02Z","message":{{"role":"user","content":"bye"}}}}"#
+        )
+        .unwrap();
+        path.to_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn load_session_windowed_returns_window_with_total_count() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_session(dir.path());
+        let state = AppState::new();
+
+        let full = state
+            .load_session_windowed(&path, LoadOptions::full())
+            .unwrap();
+        assert_eq!(full.count, full.messages.len());
+        assert!(full.count >= 3);
+
+        let win = state
+            .load_session_windowed(
+                &path,
+                LoadOptions::window(MessageRange {
+                    start: 1,
+                    limit: Some(1),
+                }),
+            )
+            .unwrap();
+        assert_eq!(win.count, full.count, "count is the total, not the window");
+        assert_eq!(win.start, 1);
+        assert_eq!(win.messages.len(), 1);
+        assert_eq!(win.messages[0].content, full.messages[1].content);
+    }
+
+    #[test]
+    fn light_cache_serves_repeated_windows_and_clears() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_session(dir.path());
+        let state = AppState::new();
+
+        // First call builds and caches; second (same path+size) hits the cache
+        // and must return identical content.
+        let a = state
+            .load_session_windowed(&path, LoadOptions::full())
+            .unwrap();
+        assert!(state.session_light_cache.lock().unwrap().is_some());
+        let b = state
+            .load_session_windowed(&path, LoadOptions::full())
+            .unwrap();
+        assert_eq!(a.count, b.count);
+        let contents_a: Vec<_> = a.messages.iter().map(|m| &m.content).collect();
+        let contents_b: Vec<_> = b.messages.iter().map(|m| &m.content).collect();
+        assert_eq!(contents_a, contents_b);
+
+        state.clear_session_build_cache();
+        assert!(state.session_light_cache.lock().unwrap().is_none());
+        // Still works after clearing (rebuilds).
+        let c = state
+            .load_session_windowed(&path, LoadOptions::full())
+            .unwrap();
+        assert_eq!(c.count, a.count);
+    }
+
+    #[test]
+    fn full_message_at_works_without_a_warm_light_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_session(dir.path());
+        let state = AppState::new();
+
+        // No list load has happened yet — full_message_at must not depend on
+        // the light cache being populated first.
+        assert!(state.session_light_cache.lock().unwrap().is_none());
+        let msg = state.full_message_at(&path, 1).unwrap();
+        assert!(msg.is_some());
+        assert_eq!(msg.unwrap().content, "hi there");
+    }
+
+    #[test]
+    fn full_message_at_never_populates_the_light_cache() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_session(dir.path());
+        let state = AppState::new();
+
+        state.full_message_at(&path, 0).unwrap();
+        state.full_message_at(&path, 1).unwrap();
+        // Detail lookups re-parse fresh each time and never persist the heavy
+        // build — the light cache (used only by list windows) stays empty.
+        assert!(state.session_light_cache.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn full_message_at_out_of_range_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_session(dir.path());
+        let state = AppState::new();
+
+        assert!(state.full_message_at(&path, 9999).unwrap().is_none());
     }
 }

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -6,13 +6,8 @@ use std::time::Duration;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
 
-use crate::convert::*;
-use crate::parser::chunk::build_chunks;
-use crate::parser::classify::ClassifiedMsg;
-use crate::parser::ongoing::OngoingChecker;
-use crate::parser::session::{read_session_with_debug_hooks, IncrementalTokenScanner};
-use crate::parser::subagent::{discover_and_link_all, inject_orphan_subagents};
-use crate::parser::team::reconstruct_teams;
+use crate::parser::session::IncrementalTokenScanner;
+use crate::session_load::{build_view, TimeFilter};
 use crate::state::AppState;
 
 const WATCHER_DEBOUNCE: Duration = Duration::from_millis(1000);
@@ -70,10 +65,20 @@ impl WatcherHandle {
     }
 }
 
-/// Serializable session update event.
+/// Serializable session-update signal.
+///
+/// This is a lightweight signal, not a data dump: it carries the total message
+/// `count` and the per-message `roles` index (so a virtualized client can resize
+/// its list and refetch the visible window), plus session-level fields, but
+/// never the heavy message bodies. Clients re-fetch the window they're viewing.
 #[derive(Clone, serde::Serialize)]
 struct SessionUpdatePayload {
-    messages: Vec<DisplayMessage>,
+    /// Total number of messages after the update.
+    count: usize,
+    /// Role of every message, in order (length == `count`).
+    roles: Vec<String>,
+    /// Latest Claude context-window fill (tokens); 0 if none.
+    context_tokens: i64,
     teams: Vec<crate::parser::team::TeamSnapshot>,
     ongoing: bool,
     permission_mode: String,
@@ -180,35 +185,29 @@ pub fn start_session_watcher(
                     }
                     prev_file_size = file_size;
 
-                    // Re-read the full session from scratch on every event.
+                    // Re-build the display view from scratch on every event.
                     // Using a local variable (dropped at end of each iteration)
                     // avoids holding all classified messages in memory for the
                     // entire session lifetime — which caused multi-GB growth
-                    // for long sessions with large tool inputs/outputs.
-                    let all_classified = match read_session_with_debug_hooks(&path_for_rebuild) {
-                        Ok((msgs, _, _)) => msgs,
+                    // for long sessions with large tool inputs/outputs. The
+                    // heavy message bodies are used only to derive count/roles
+                    // and are never sent — clients refetch the window they view.
+                    let view = match build_view(&path_for_rebuild, TimeFilter::default()) {
+                        Ok(v) => v,
                         Err(_) => continue,
                     };
 
-                    let mut chunks = build_chunks(&all_classified);
-
-                    let (mut all_procs, color_map) = discover_and_link_all(&path_for_rebuild, &chunks);
-                    inject_orphan_subagents(&mut chunks, &mut all_procs);
-
-                    let ongoing = OngoingChecker::new(&chunks, &all_procs, &path_for_rebuild).is_ongoing();
+                    let ongoing = view.ongoing;
 
                     // Share ongoing status with AppState so the picker can use it.
                     state.set_watched_ongoing(path_for_rebuild.clone(), ongoing);
-
-                    let teams = reconstruct_teams(&chunks, &all_procs);
-                    let messages = chunks_to_messages(&chunks, &all_procs, &color_map);
 
                     // Skip emit if nothing meaningful changed.
                     // Track both message count and total item count so that hook
                     // events (which are added inside existing AI chunks without
                     // creating a new top-level message) still trigger an emit.
-                    let msg_count = messages.len();
-                    let item_count: usize = messages.iter().map(|m| m.items.len()).sum();
+                    let msg_count = view.messages.len();
+                    let item_count: usize = view.messages.iter().map(|m| m.items.len()).sum();
                     if msg_count == prev_msg_count
                         && item_count == prev_item_count
                         && !ongoing
@@ -223,23 +222,22 @@ pub fn start_session_watcher(
                     prev_item_count = item_count;
                     prev_ongoing = ongoing;
 
-                    // Extract last permission_mode from UserMsg entries.
-                    let mut permission_mode = String::from("default");
-                    for msg in all_classified.iter().rev() {
-                        if let ClassifiedMsg::User(u) = msg {
-                            if !u.permission_mode.is_empty() {
-                                permission_mode = u.permission_mode.clone();
-                                break;
-                            }
-                        }
-                    }
+                    let permission_mode = if view.permission_mode.is_empty() {
+                        String::from("default")
+                    } else {
+                        view.permission_mode.clone()
+                    };
+                    let roles = crate::session_load::message_roles(&view.messages);
+                    let context_tokens = crate::session_load::latest_context_tokens(&view.messages);
 
                     // Incrementally scan only new bytes for token totals.
                     let session_totals = token_scanner.scan_new_bytes(&path_for_rebuild);
 
                     let payload = SessionUpdatePayload {
-                        messages,
-                        teams,
+                        count: msg_count,
+                        roles,
+                        context_tokens,
+                        teams: view.teams,
                         ongoing,
                         permission_mode,
                         session_totals,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "./lib/invoke";
-import type { ViewState, SessionInfo } from "./types";
+import type { ViewState, SessionInfo, DisplayMessage } from "./types";
 import { useSession } from "./hooks/useSession";
 import { usePicker } from "./hooks/usePicker";
 import { useToggleSet } from "./hooks/useToggleSet";
 import { useKeyboard } from "./hooks/useKeyboard";
 import { useViewActionsRef, useViewActionCallbacks } from "./hooks/useViewActions";
+import { useFontScale } from "./hooks/useFontScale";
 import { SessionPicker } from "./components/SessionPicker";
 import { MessageList } from "./components/MessageList";
 import { MessageDetail } from "./components/MessageDetail";
@@ -17,6 +18,12 @@ import { ViewToolbar } from "./components/ViewToolbar";
 import { ProjectTree, useProjectKeys, useProjectItems } from "./components/ProjectTree";
 import { ResizeHandle } from "./components/ResizeHandle";
 import { SettingsModal } from "./components/SettingsModal";
+import {
+  shouldRecycle,
+  saveRestoreState,
+  takeRestoreState,
+  reloadWebview,
+} from "./lib/webviewRecycle";
 
 export function App() {
   const [view, setView] = useState<ViewState>("picker");
@@ -29,6 +36,15 @@ export function App() {
   const [sidebarHighlight, setSidebarHighlight] = useState(0); // index in project list (0 = "All")
   const [showSettings, setShowSettings] = useState(false);
   const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
+  const [fontScale, setFontScale] = useFontScale();
+  // Full (heavy-body) message for the detail view, fetched on demand since the
+  // list only holds lightened messages.
+  const [detailMessage, setDetailMessage] = useState<DisplayMessage | null>(null);
+  const [detailError, setDetailError] = useState(false);
+  const detailReqRef = useRef(0);
+  // Counts session opens this page lifetime, to periodically recycle the
+  // webview (see lib/webviewRecycle.ts for why).
+  const switchCountRef = useRef(0);
 
   const toggleCollapse = useCallback((key: string) => {
     setCollapsedKeys((prev) => {
@@ -109,50 +125,102 @@ export function App() {
     }
   }, [session.sessionPath, session.ongoing, updateSessionOngoing]);
 
-  // Handle session selection from picker
-  const handleSelectSession = useCallback(
-    (sessionInfo: SessionInfo) => {
-      void loadSession(sessionInfo.path);
+  const openSessionByPath = useCallback(
+    (path: string) => {
+      void loadSession(path);
       setView("list");
       setSelectedMessage(0);
       clearExpanded();
+      // Release the previous session's full (heavy-body) detail message, if
+      // any was fetched — otherwise it stays retained in state indefinitely.
+      setDetailMessage(null);
+      setDetailError(false);
     },
     [loadSession, clearExpanded],
   );
 
+  // Restore whichever session was open right before a memory-driven webview
+  // reload (see lib/webviewRecycle.ts), so the reload isn't disruptive.
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    const pending = takeRestoreState();
+    if (pending) openSessionByPath(pending.sessionPath);
+  }, [openSessionByPath]);
+
+  // Handle session selection from picker
+  const handleSelectSession = useCallback(
+    (sessionInfo: SessionInfo) => {
+      switchCountRef.current += 1;
+      if (shouldRecycle(switchCountRef.current)) {
+        saveRestoreState({ sessionPath: sessionInfo.path });
+        // Reload is async (waits for in-flight invokes to settle first — see
+        // webviewRecycle.ts). If it ever throws, fall back to opening the
+        // session normally rather than silently doing nothing.
+        void reloadWebview().catch(() => openSessionByPath(sessionInfo.path));
+        return;
+      }
+      openSessionByPath(sessionInfo.path);
+    },
+    [openSessionByPath],
+  );
+
   // Auto-select newest message (last index) when messages load
   useEffect(() => {
-    if (session.messages.length > 0 && view === "list") {
-      setSelectedMessage((prev) =>
-        prev >= session.messages.length ? session.messages.length - 1 : prev,
-      );
+    if (session.count > 0 && view === "list") {
+      setSelectedMessage((prev) => (prev >= session.count ? session.count - 1 : prev));
     }
-  }, [session.messages.length, view]);
+  }, [session.count, view]);
 
-  // Open detail view
-  const openDetail = useCallback((index: number) => {
-    setSelectedMessage(index);
-    setView("detail");
-  }, []);
+  // Open detail view. The list holds only lightened messages, so fetch the full
+  // (heavy-body) message on demand. Guard against out-of-order resolves when the
+  // user opens several messages quickly, and surface failures instead of hanging
+  // on the loading spinner forever.
+  const openDetail = useCallback(
+    (index: number) => {
+      const req = ++detailReqRef.current;
+      setSelectedMessage(index);
+      setDetailMessage(null);
+      setDetailError(false);
+      setView("detail");
+      // Leaving the list view — drop its loaded pages so they don't sit in
+      // memory while Detail is showing. Coming back re-fetches the visible
+      // window fresh instead of holding onto stale data indefinitely.
+      session.clearWindow();
+      session
+        .loadFullMessage(index)
+        .then((msg) => {
+          if (req !== detailReqRef.current) return;
+          if (msg) setDetailMessage(msg);
+          else setDetailError(true);
+        })
+        .catch(() => {
+          if (req === detailReqRef.current) setDetailError(true);
+        });
+    },
+    [session],
+  );
 
   // -- View actions: each view registers its own expand/collapse handlers --
 
   const viewActionsRef = useViewActionsRef();
   const { expandAll, collapseAll } = useViewActionCallbacks(viewActionsRef);
 
-  // Register message list expand/collapse when in list view.
+  // Register message list expand/collapse when in list view. Uses the role
+  // index so it works over the whole session without loading every body.
   const listExpandAll = useCallback(() => {
     const claudeIndices: number[] = [];
-    session.messages.forEach((msg, i) => {
-      if (msg.role === "claude") claudeIndices.push(i);
+    session.roles.forEach((role, i) => {
+      if (role === "claude") claudeIndices.push(i);
     });
     expandMessages(claudeIndices);
-  }, [session.messages, expandMessages]);
+  }, [session.roles, expandMessages]);
 
   // Visual top = newest message = last index (display is reversed)
   const jumpToTop = useCallback(() => {
-    setSelectedMessage(Math.max(session.messages.length - 1, 0));
-  }, [session.messages.length]);
+    setSelectedMessage(Math.max(session.count - 1, 0));
+  }, [session.count]);
 
   // Visual bottom = oldest message = index 0
   const jumpToBottom = useCallback(() => {
@@ -175,7 +243,12 @@ export function App() {
   }, []);
 
   const backToList = useCallback(() => {
-    if (sessionPath) setView("list");
+    if (!sessionPath) return;
+    setView("list");
+    // Leaving Detail — release the full (heavy-body) message it held so it
+    // doesn't linger in memory until the next Detail open overwrites it.
+    setDetailMessage(null);
+    setDetailError(false);
   }, [sessionPath]);
 
   const toggleKeybinds = useCallback(() => {
@@ -222,8 +295,7 @@ export function App() {
   } else {
     switch (view) {
       case "list": {
-        const moveDown = () =>
-          setSelectedMessage((i) => Math.min(i + 1, session.messages.length - 1));
+        const moveDown = () => setSelectedMessage((i) => Math.min(i + 1, session.count - 1));
         const moveUp = () => setSelectedMessage((i) => Math.max(i - 1, 0));
         keyMap["j"] = moveDown;
         keyMap["ArrowDown"] = moveDown;
@@ -233,7 +305,7 @@ export function App() {
         keyMap["g"] = jumpToBottom;
         keyMap["Tab"] = () => toggleMessage(selectedMessage);
         keyMap["Enter"] = () => {
-          if (session.messages.length > 0) openDetail(selectedMessage);
+          if (session.count > 0) openDetail(selectedMessage);
         };
         keyMap["e"] = expandAll;
         keyMap["c"] = collapseAll;
@@ -330,10 +402,13 @@ export function App() {
         }
         return (
           <MessageList
-            messages={session.messages}
+            count={session.count}
+            getMessage={session.getMessage}
+            roles={session.roles}
             selectedIndex={selectedMessage}
             expandedSet={expandedMessages}
             ongoing={session.ongoing}
+            onRangeChange={session.ensureRange}
             onSelect={setSelectedMessage}
             onToggle={toggleMessage}
             onOpenDetail={openDetail}
@@ -343,18 +418,38 @@ export function App() {
           />
         );
 
-      case "detail":
-        if (session.messages.length > 0 && selectedMessage < session.messages.length) {
+      case "detail": {
+        if (detailMessage) {
           return (
             <MessageDetail
-              message={session.messages[selectedMessage]}
+              message={detailMessage}
               ongoing={session.ongoing}
-              onBack={() => setView("list")}
+              onBack={backToList}
               viewActionsRef={viewActionsRef}
             />
           );
         }
+        if (detailError) {
+          return (
+            <div className="session-loading">
+              Failed to load message.{" "}
+              <button className="link-button" onClick={backToList}>
+                Back
+              </button>
+            </div>
+          );
+        }
+        // Full body still loading (fetched on demand from the cached build).
+        if (selectedMessage < session.count) {
+          return (
+            <div className="session-loading">
+              <span className="braille-spinner" />
+              Loading message...
+            </div>
+          );
+        }
         return null;
+      }
 
       case "team":
         return <TeamBoard teams={session.teams} />;
@@ -371,7 +466,7 @@ export function App() {
         <InfoBar
           meta={session.meta}
           gitInfo={session.gitInfo}
-          messages={session.messages}
+          contextTokens={session.contextTokens}
           sessionTotals={session.sessionTotals}
           sessionPath={session.sessionPath}
           ongoing={session.ongoing}
@@ -422,7 +517,12 @@ export function App() {
       />
 
       {showSettings && (
-        <SettingsModal onClose={() => setShowSettings(false)} onSaved={loadProjectDirs} />
+        <SettingsModal
+          onClose={() => setShowSettings(false)}
+          onSaved={loadProjectDirs}
+          fontScale={fontScale}
+          onFontScaleChange={setFontScale}
+        />
       )}
     </div>
   );

--- a/src/components/InfoBar.test.tsx
+++ b/src/components/InfoBar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { InfoBar } from "./InfoBar";
-import type { SessionMeta, SessionTotals, DisplayMessage, GitInfo } from "../types";
+import type { SessionMeta, SessionTotals, GitInfo } from "../types";
 
 function makeMeta(overrides: Partial<SessionMeta> = {}): SessionMeta {
   return {
@@ -25,39 +25,13 @@ function makeTotals(overrides: Partial<SessionTotals> = {}): SessionTotals {
   };
 }
 
-function makeMessage(overrides: Partial<DisplayMessage> = {}): DisplayMessage {
-  return {
-    role: "claude",
-    model: "claude-sonnet-4-20250514",
-    content: "Hello",
-    timestamp: "2025-01-01T00:00:00Z",
-    thinking_count: 0,
-    tool_call_count: 0,
-    output_count: 0,
-    tokens_raw: 0,
-    input_tokens: 0,
-    output_tokens: 0,
-    cache_read_tokens: 0,
-    cache_creation_tokens: 0,
-    context_tokens: 0,
-    duration_ms: 0,
-    items: [],
-    last_output: null,
-    is_error: false,
-    teammate_spawns: 0,
-    teammate_messages: 0,
-    subagent_label: "",
-    ...overrides,
-  };
-}
-
 describe("InfoBar", () => {
   it("shows project name from shortPath(meta.cwd)", () => {
     render(
       <InfoBar
         meta={makeMeta({ cwd: "/home/user/my-project" })}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -71,7 +45,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath="/some/path/abc123.jsonl"
         ongoing={false}
@@ -86,7 +60,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={gitInfo}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -101,7 +75,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={gitInfo}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -117,7 +91,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={gitInfo}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -132,7 +106,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta({ permission_mode: "bypassPermissions" })}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -146,7 +120,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta({ permission_mode: "acceptEdits" })}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -160,7 +134,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta({ permission_mode: "plan" })}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -174,7 +148,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta({ permission_mode: "default" })}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -183,13 +157,12 @@ describe("InfoBar", () => {
     expect(screen.queryByText("default")).not.toBeInTheDocument();
   });
 
-  it("shows context bar when contextPercent >= 0", () => {
-    const msg = makeMessage({ context_tokens: 500_000 });
+  it("shows context bar when contextTokens > 0", () => {
     render(
       <InfoBar
         meta={makeMeta()}
         gitInfo={null}
-        messages={[msg]}
+        contextTokens={500_000}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -203,7 +176,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
@@ -217,7 +190,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals({ total_tokens: 5000 })}
         sessionPath=""
         ongoing={false}
@@ -231,7 +204,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals({ cost_usd: 1.5 })}
         sessionPath=""
         ongoing={false}
@@ -245,7 +218,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={true}
@@ -259,7 +232,7 @@ describe("InfoBar", () => {
       <InfoBar
         meta={makeMeta()}
         gitInfo={null}
-        messages={[]}
+        contextTokens={0}
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}

--- a/src/components/InfoBar.tsx
+++ b/src/components/InfoBar.tsx
@@ -1,13 +1,19 @@
-import { useMemo } from "react";
-import type { DisplayMessage, SessionMeta, SessionTotals, GitInfo } from "../types";
-import { shortPath, shortMode, contextPercent, formatTokens, formatCost } from "../lib/format";
+import type { SessionMeta, SessionTotals, GitInfo } from "../types";
+import {
+  shortPath,
+  shortMode,
+  contextPercentFromTokens,
+  formatTokens,
+  formatCost,
+} from "../lib/format";
 import { getContextColor } from "../lib/theme";
 import { TokensIcon, CostIcon } from "./Icons";
 
 interface InfoBarProps {
   meta: SessionMeta;
   gitInfo: GitInfo | null;
-  messages: DisplayMessage[];
+  /** Latest Claude context-window fill (tokens); 0 hides the gauge. */
+  contextTokens: number;
   sessionTotals: SessionTotals;
   sessionPath: string;
   ongoing: boolean;
@@ -16,7 +22,7 @@ interface InfoBarProps {
 export function InfoBar({
   meta,
   gitInfo,
-  messages,
+  contextTokens,
   sessionTotals,
   sessionPath,
   ongoing,
@@ -26,7 +32,7 @@ export function InfoBar({
   const branch = gitInfo?.branch || meta.git_branch;
   const dirty = gitInfo?.dirty ?? false;
   const mode = meta.permission_mode;
-  const ctxPct = useMemo(() => contextPercent(messages), [messages]);
+  const ctxPct = contextPercentFromTokens(contextTokens);
 
   const totalCost = sessionTotals.cost_usd;
 

--- a/src/components/MessageList.test.tsx
+++ b/src/components/MessageList.test.tsx
@@ -1,9 +1,43 @@
 import { describe, it, expect, vi } from "vitest";
-import { createRef } from "react";
+import { createRef, type ReactNode } from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { MessageList } from "./MessageList";
+import { MessageList, selectionScrollTarget } from "./MessageList";
 import type { DisplayMessage } from "../types";
 import type { ViewActions } from "../hooks/useViewActions";
+
+// react-virtuoso virtualises by measured height, which jsdom does not provide,
+// so it would render nothing in tests. Mock it to render every row via
+// itemContent(index, undefined, context) — these tests exercise MessageList's
+// row rendering/callbacks, not the windowing.
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({
+    totalCount = 0,
+    itemContent,
+    context,
+    className,
+    isScrolling,
+  }: {
+    totalCount?: number;
+    itemContent: (index: number, data: unknown, context: unknown) => ReactNode;
+    context?: unknown;
+    className?: string;
+    isScrolling?: (scrolling: boolean) => void;
+  }) => (
+    <div className={className}>
+      {/* Test-only hooks to simulate Virtuoso reporting scroll start/stop. */}
+      <button type="button" data-testid="simulate-scrolling" onClick={() => isScrolling?.(true)} />
+      <button
+        type="button"
+        data-testid="simulate-scroll-stop"
+        onClick={() => isScrolling?.(false)}
+      />
+      {Array.from({ length: totalCount }, (_, index) => (
+        // oxlint-disable-next-line react/no-array-index-key
+        <div key={index}>{itemContent(index, undefined, context)}</div>
+      ))}
+    </div>
+  ),
+}));
 
 function makeMessage(overrides: Partial<DisplayMessage> = {}): DisplayMessage {
   return {
@@ -31,19 +65,27 @@ function makeMessage(overrides: Partial<DisplayMessage> = {}): DisplayMessage {
   };
 }
 
-function defaultProps(overrides: Partial<Parameters<typeof MessageList>[0]> = {}) {
+/** Build MessageList props from a plain messages array (test convenience): the
+ * component now takes count/getMessage/roles rather than the array itself. */
+function defaultProps(
+  overrides: { messages?: DisplayMessage[] } & Partial<Parameters<typeof MessageList>[0]> = {},
+) {
+  const { messages = [], ...rest } = overrides;
   return {
-    messages: [] as DisplayMessage[],
+    count: messages.length,
+    getMessage: (index: number): DisplayMessage | undefined => messages[index],
+    roles: messages.map((m) => m.role),
     selectedIndex: -1,
     expandedSet: new Set<number>(),
     ongoing: false,
+    onRangeChange: vi.fn(),
     onSelect: vi.fn(),
     onToggle: vi.fn(),
     onOpenDetail: vi.fn(),
     viewActionsRef: createRef() as React.MutableRefObject<ViewActions>,
     onExpandAll: vi.fn(),
     onCollapseAll: vi.fn(),
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -215,9 +257,85 @@ describe("MessageList", () => {
     expect(dots.length).toBe(1);
   });
 
+  it("renders a role-aware placeholder skeleton for an unloaded index", () => {
+    const { container } = render(
+      <MessageList
+        {...defaultProps({
+          count: 2,
+          roles: ["user", "claude"],
+          getMessage: () => undefined,
+        })}
+      />,
+    );
+    const placeholders = container.querySelectorAll(".message--placeholder");
+    expect(placeholders.length).toBe(2);
+    expect(placeholders[0]).toHaveClass("message--user");
+    expect(placeholders[1]).toHaveClass("message--claude");
+    // Multi-line skeleton (header + content + short line), not a single sliver,
+    // so the swap to real content is a small reflow rather than a large jump.
+    expect(placeholders[0].querySelectorAll(".message__placeholder-line").length).toBe(3);
+  });
+
+  it("adds the scrolling class when Virtuoso reports isScrolling(true)", () => {
+    const messages = [makeMessage({ content: "Hi" })];
+    const { container, getByTestId } = render(<MessageList {...defaultProps({ messages })} />);
+
+    expect(container.querySelector(".message-list")).not.toHaveClass("message-list--scrolling");
+    fireEvent.click(getByTestId("simulate-scrolling"));
+    expect(container.querySelector(".message-list")).toHaveClass("message-list--scrolling");
+  });
+
+  it("forces a hover recompute at the last cursor position once scrolling settles", async () => {
+    vi.useFakeTimers();
+    const messages = [makeMessage({ content: "Hi" })];
+    const { getByTestId } = render(<MessageList {...defaultProps({ messages })} />);
+    const dispatchSpy = vi.spyOn(document, "dispatchEvent");
+    const rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb) => window.setTimeout(() => cb(0), 0));
+
+    fireEvent.mouseMove(window, { clientX: 42, clientY: 17 });
+    fireEvent.click(getByTestId("simulate-scrolling"));
+    fireEvent.click(getByTestId("simulate-scroll-stop"));
+    vi.runAllTimers();
+
+    const dispatched = dispatchSpy.mock.calls
+      .map((call) => call[0])
+      .find((event) => event.type === "mousemove") as MouseEvent | undefined;
+    expect(dispatched).toBeDefined();
+    expect(dispatched?.clientX).toBe(42);
+    expect(dispatched?.clientY).toBe(17);
+
+    rafSpy.mockRestore();
+    dispatchSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
   it("does not show ongoing dots when ongoing=false", () => {
     const messages = [makeMessage({ content: "No spinner" })];
     const { container } = render(<MessageList {...defaultProps({ messages, ongoing: false })} />);
     expect(container.querySelector(".ongoing-dots")).not.toBeInTheDocument();
+  });
+});
+
+describe("selectionScrollTarget", () => {
+  const range = { startIndex: 5, endIndex: 10 };
+
+  it("returns null when nothing is selected", () => {
+    expect(selectionScrollTarget(-1, range)).toBeNull();
+  });
+
+  it("returns null when the selection is within the rendered window", () => {
+    expect(selectionScrollTarget(5, range)).toBeNull();
+    expect(selectionScrollTarget(7, range)).toBeNull();
+    expect(selectionScrollTarget(10, range)).toBeNull();
+  });
+
+  it("aligns to the top when the selection is above the window", () => {
+    expect(selectionScrollTarget(2, range)).toEqual({ index: 2, align: "start" });
+  });
+
+  it("aligns to the end when the selection is below the window", () => {
+    expect(selectionScrollTarget(15, range)).toEqual({ index: 15, align: "end" });
   });
 });

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -1,15 +1,85 @@
-import { useCallback, useMemo } from "react";
-import { useScrollToSelected } from "../hooks/useScrollToSelected";
-import { useAutoScroll } from "../hooks/useAutoScroll";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { useRegisterViewActions, type ViewActionsRef } from "../hooks/useViewActions";
 import type { DisplayMessage } from "../types";
 import { MessageItem } from "./MessageItem";
 
-interface MessageListProps {
-  messages: DisplayMessage[];
+/** Decide how to scroll the selected message into view given the currently
+ * rendered window. Returns `null` when no scroll is needed (selection is within
+ * the window, or nothing is selected). Above the window → align to the top so
+ * the message header stays visible; below → align to the end. */
+export function selectionScrollTarget(
+  selectedIndex: number,
+  range: { startIndex: number; endIndex: number },
+): { index: number; align: "start" | "end" } | null {
+  if (selectedIndex < 0) return null;
+  if (selectedIndex < range.startIndex) return { index: selectedIndex, align: "start" };
+  if (selectedIndex > range.endIndex) return { index: selectedIndex, align: "end" };
+  return null;
+}
+
+/** Per-render data threaded to the row renderer via Virtuoso's `context`, so the
+ * renderer can stay a stable module-level function instead of an inline one. */
+interface MessageRowContext {
+  getMessage: (index: number) => DisplayMessage | undefined;
+  roles: string[];
   selectedIndex: number;
   expandedSet: Set<number>;
   ongoing: boolean;
+  lastIndex: number;
+  onClick: (index: number) => void;
+  onOpenDetail: (index: number) => void;
+}
+
+/** Placeholder for a row whose body hasn't been fetched yet. Uses the role from
+ * the lightweight index so it reads correctly before the body loads. */
+function roleModifier(role: string | undefined): string {
+  if (role === "user") return "user";
+  if (role === "claude") return "claude";
+  if (role === "compact" || role === "recap") return "compact";
+  return "system";
+}
+
+function renderMessageRow(index: number, _data: unknown, ctx: MessageRowContext) {
+  const msg = ctx.getMessage(index);
+  if (!msg) {
+    // Height approximates a typical loaded row (header + a couple content
+    // lines + stats bar) so the placeholder->content swap is a small reflow
+    // instead of a large one — a big jump mid-scroll is what causes the
+    // visible overlap/misalignment glitch on virtualized rows.
+    return (
+      <div className={`message message--placeholder message--${roleModifier(ctx.roles[index])}`}>
+        <div className="message__placeholder-line message__placeholder-line--header" />
+        <div className="message__placeholder-line" />
+        <div className="message__placeholder-line message__placeholder-line--short" />
+      </div>
+    );
+  }
+  return (
+    <MessageItem
+      message={msg}
+      index={index}
+      isSelected={index === ctx.selectedIndex}
+      isExpanded={ctx.expandedSet.has(index)}
+      onClick={ctx.onClick}
+      onOpenDetail={ctx.onOpenDetail}
+      isOngoing={index === ctx.lastIndex && ctx.ongoing}
+    />
+  );
+}
+
+interface MessageListProps {
+  /** Total number of messages in the session. */
+  count: number;
+  /** Fetch a loaded message body by absolute index (undefined if not loaded). */
+  getMessage: (index: number) => DisplayMessage | undefined;
+  /** Role of every message (length === count) — drives placeholders. */
+  roles: string[];
+  selectedIndex: number;
+  expandedSet: Set<number>;
+  ongoing: boolean;
+  /** Ensure the bodies covering [start, end) are loaded. */
+  onRangeChange: (start: number, end: number) => void;
   onSelect: (index: number) => void;
   onToggle: (index: number) => void;
   onOpenDetail: (index: number) => void;
@@ -19,10 +89,13 @@ interface MessageListProps {
 }
 
 export function MessageList({
-  messages,
+  count,
+  getMessage,
+  roles,
   selectedIndex,
   expandedSet,
   ongoing,
+  onRangeChange,
   onSelect,
   onToggle,
   onOpenDetail,
@@ -31,8 +104,43 @@ export function MessageList({
   onCollapseAll,
 }: MessageListProps) {
   useRegisterViewActions(viewActionsRef, { expandAll: onExpandAll, collapseAll: onCollapseAll });
-  const listRef = useAutoScroll<HTMLDivElement>(messages.length);
-  const selectedRef = useScrollToSelected(selectedIndex);
+
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  // Track the currently rendered window so we only scroll when the selection
+  // leaves it — mirrors the old "no-op if already visible" behaviour.
+  const rangeRef = useRef({ startIndex: 0, endIndex: 0 });
+  // Browsers only recompute `:hover` on a real pointer move, not when content
+  // shifts under a stationary cursor during virtualized scrolling — so a stale
+  // hover can appear "stuck" on whatever row happens to end up under the
+  // cursor once scrolling stops. Suppressing hover/transitions while actively
+  // scrolling (below) hides the glitch mid-scroll; forcing a synthetic
+  // mousemove at the last known cursor position once scrolling settles (see
+  // handleIsScrolling) fixes the stale state itself by making the browser
+  // redo hit-testing without needing a real pointer move.
+  const [isScrolling, setIsScrolling] = useState(false);
+  const lastMouseRef = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    const handleMove = (e: MouseEvent) => {
+      lastMouseRef.current = { x: e.clientX, y: e.clientY };
+    };
+    window.addEventListener("mousemove", handleMove);
+    return () => window.removeEventListener("mousemove", handleMove);
+  }, []);
+
+  const handleIsScrolling = useCallback((scrolling: boolean) => {
+    setIsScrolling(scrolling);
+    if (!scrolling && lastMouseRef.current) {
+      const { x, y } = lastMouseRef.current;
+      // Wait a frame so the settled scroll position has been painted before
+      // the browser re-does hit-testing at these coordinates.
+      requestAnimationFrame(() => {
+        document.dispatchEvent(
+          new MouseEvent("mousemove", { clientX: x, clientY: y, bubbles: true }),
+        );
+      });
+    }
+  }, []);
 
   const handleClick = useCallback(
     (index: number) => {
@@ -45,37 +153,51 @@ export function MessageList({
     [selectedIndex, onSelect, onToggle],
   );
 
-  // Chronological order: oldest messages first
-  const ordered = useMemo(() => {
-    const indices: number[] = [];
-    for (let i = 0; i < messages.length; i++) {
-      indices.push(i);
-    }
-    return indices;
-  }, [messages.length]);
+  // Bring the selected message into view on keyboard navigation. If it sits
+  // above the window we align to the top (keep the header visible); below the
+  // window we align to the end; already visible is a no-op.
+  useEffect(() => {
+    const target = selectionScrollTarget(selectedIndex, rangeRef.current);
+    if (target) virtuosoRef.current?.scrollToIndex(target);
+  }, [selectedIndex]);
+
+  if (count === 0) {
+    return (
+      <div className="message-list">
+        <div className="message-list__empty">No messages loaded</div>
+      </div>
+    );
+  }
 
   return (
-    <div className="message-list" ref={listRef}>
-      {messages.length === 0 && <div className="message-list__empty">No messages loaded</div>}
-      {ordered.map((i) => {
-        const msg = messages[i];
-        const isSelected = i === selectedIndex;
-        const isLast = i === messages.length - 1;
-
-        return (
-          <MessageItem
-            key={i}
-            ref={isSelected ? selectedRef : undefined}
-            message={msg}
-            index={i}
-            isSelected={isSelected}
-            isExpanded={expandedSet.has(i)}
-            onClick={handleClick}
-            onOpenDetail={onOpenDetail}
-            isOngoing={isLast && ongoing}
-          />
-        );
-      })}
-    </div>
+    <Virtuoso<unknown, MessageRowContext>
+      ref={virtuosoRef}
+      className={`message-list${isScrolling ? " message-list--scrolling" : ""}`}
+      totalCount={count}
+      initialTopMostItemIndex={Math.max(0, count - 1)}
+      // Render rows this many pixels outside the viewport so their bodies load
+      // and the placeholder->content swap happens off-screen, before the row
+      // scrolls into view, instead of visibly reflowing at the viewport edge.
+      increaseViewportBy={{ top: 600, bottom: 600 }}
+      isScrolling={handleIsScrolling}
+      context={{
+        getMessage,
+        roles,
+        selectedIndex,
+        expandedSet,
+        ongoing,
+        lastIndex: count - 1,
+        onClick: handleClick,
+        onOpenDetail,
+      }}
+      // Stick to the bottom on new/streamed content, but only while the user is
+      // already at the bottom (replaces the old near-bottom auto-scroll hook).
+      followOutput="smooth"
+      rangeChanged={(range) => {
+        rangeRef.current = range;
+        onRangeChange(range.startIndex, range.endIndex + 1);
+      }}
+      itemContent={renderMessageRow}
+    />
   );
 }

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -24,6 +24,7 @@ const makeSettings = (
 describe("SettingsModal", () => {
   const onClose = vi.fn();
   const onSaved = vi.fn();
+  const onFontScaleChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -37,7 +38,14 @@ describe("SettingsModal", () => {
   });
 
   it("shows empty input and default hint when no config exists", async () => {
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByText(`Default: ${DEFAULT_DIR}`)).toBeInTheDocument();
     });
@@ -47,7 +55,14 @@ describe("SettingsModal", () => {
   });
 
   it("shows active path when effective dir exists", async () => {
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByText(new RegExp(`✓ Active:`))).toBeInTheDocument();
     });
@@ -58,7 +73,14 @@ describe("SettingsModal", () => {
       if (cmd === "get_settings") return Promise.resolve(makeSettings(null, false));
       return Promise.resolve();
     });
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByText(new RegExp(`✗ Not found:`))).toBeInTheDocument();
     });
@@ -69,14 +91,28 @@ describe("SettingsModal", () => {
       if (cmd === "get_settings") return Promise.resolve(makeSettings("/custom/path"));
       return Promise.resolve();
     });
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByDisplayValue("/custom/path")).toBeInTheDocument();
     });
   });
 
   it("calls set_projects_dir on save", async () => {
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => expect(screen.getByText(`Default: ${DEFAULT_DIR}`)).toBeInTheDocument());
 
     const input = screen.getByLabelText("Projects Directory");
@@ -96,7 +132,14 @@ describe("SettingsModal", () => {
       if (cmd === "set_projects_dir") return Promise.resolve(makeSettings(null));
       return Promise.resolve();
     });
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => expect(screen.getByDisplayValue("/custom/path")).toBeInTheDocument());
 
     fireEvent.click(screen.getByText("Reset to Default"));
@@ -109,7 +152,14 @@ describe("SettingsModal", () => {
   });
 
   it("shows no-distros hint when WSL reports none", async () => {
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => {
       expect(screen.getByText(/No WSL distributions detected/)).toBeInTheDocument();
     });
@@ -121,7 +171,14 @@ describe("SettingsModal", () => {
       if (cmd === "list_wsl_distros") return Promise.resolve(["Ubuntu", "Debian"]);
       return Promise.resolve();
     });
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
 
     await waitFor(() => expect(screen.getByLabelText("Ubuntu")).toBeInTheDocument());
     expect((screen.getByLabelText("Ubuntu") as HTMLInputElement).checked).toBe(true);
@@ -137,7 +194,14 @@ describe("SettingsModal", () => {
         return Promise.resolve(makeSettings(null, true, ["Ubuntu", "Debian"]));
       return Promise.resolve();
     });
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
 
     await waitFor(() => expect(screen.getByLabelText("Debian")).toBeInTheDocument());
     fireEvent.click(screen.getByLabelText("Debian"));
@@ -152,13 +216,37 @@ describe("SettingsModal", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("highlights the active font scale and applies a new one on click", async () => {
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText(`Default: ${DEFAULT_DIR}`)).toBeInTheDocument());
+
+    expect(screen.getByRole("button", { name: "100%", pressed: true })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "150%" }));
+    expect(onFontScaleChange).toHaveBeenCalledWith(1.5);
+  });
+
   it("shows error when save fails", async () => {
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === "get_settings") return Promise.resolve(makeSettings(null));
       if (cmd === "set_projects_dir") return Promise.reject("path does not exist: /bad");
       return Promise.resolve();
     });
-    render(<SettingsModal onClose={onClose} onSaved={onSaved} />);
+    render(
+      <SettingsModal
+        onClose={onClose}
+        onSaved={onSaved}
+        fontScale={1}
+        onFontScaleChange={onFontScaleChange}
+      />,
+    );
     await waitFor(() => expect(screen.getByText(`Default: ${DEFAULT_DIR}`)).toBeInTheDocument());
 
     const input = screen.getByLabelText("Projects Directory");

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "../lib/invoke";
 import { PopoutModal } from "./PopoutModal";
+import { FONT_SCALE_PRESETS, formatFontScale } from "../lib/fontScale";
 
 interface SettingsResponse {
   projects_dir: string | null;
@@ -13,6 +14,10 @@ interface SettingsResponse {
 interface SettingsModalProps {
   onClose: () => void;
   onSaved: () => void;
+  /** Current global UI zoom level (1 = 100%). */
+  fontScale: number;
+  /** Apply a new zoom level immediately (also persisted by the caller). */
+  onFontScaleChange: (scale: number) => void;
 }
 
 /** Merge detected distros with already-configured ones so configured-but-offline
@@ -22,7 +27,12 @@ function mergeDistros(available: string[], configured: string[]): string[] {
   return [...available, ...configured.filter((d) => !seen.has(d))];
 }
 
-export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
+export function SettingsModal({
+  onClose,
+  onSaved,
+  fontScale,
+  onFontScaleChange,
+}: SettingsModalProps) {
   const [projectsDir, setProjectsDir] = useState("");
   const [defaultDir, setDefaultDir] = useState("");
   const [effectiveDir, setEffectiveDir] = useState("");
@@ -177,6 +187,26 @@ export function SettingsModal({ onClose, onSaved }: SettingsModalProps) {
             </div>
           </>
         )}
+
+        <label className="settings-modal__label settings-modal__label--section">Font Size</label>
+        <p className="settings-modal__hint">Zoom the whole interface in or out.</p>
+        <div className="settings-modal__font-scale" role="group" aria-label="Font size">
+          {FONT_SCALE_PRESETS.map((preset) => (
+            <button
+              key={preset}
+              type="button"
+              className={
+                preset === fontScale
+                  ? "settings-modal__font-scale-btn settings-modal__font-scale-btn--active"
+                  : "settings-modal__font-scale-btn"
+              }
+              aria-pressed={preset === fontScale}
+              onClick={() => onFontScaleChange(preset)}
+            >
+              {formatFontScale(preset)}
+            </button>
+          ))}
+        </div>
 
         {error && <p className="settings-modal__error">{error}</p>}
         <div className="settings-modal__actions">

--- a/src/hooks/useFontScale.test.ts
+++ b/src/hooks/useFontScale.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFontScale } from "./useFontScale";
+import { FONT_SCALE_KEY } from "../lib/fontScale";
+
+describe("useFontScale", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.zoom = "";
+  });
+
+  it("defaults to 100% and applies it to the document", () => {
+    const { result } = renderHook(() => useFontScale());
+    expect(result.current[0]).toBe(1);
+    expect(document.documentElement.style.zoom).toBe("1");
+  });
+
+  it("initialises from a persisted value", () => {
+    localStorage.setItem(FONT_SCALE_KEY, "1.5");
+    const { result } = renderHook(() => useFontScale());
+    expect(result.current[0]).toBe(1.5);
+    expect(document.documentElement.style.zoom).toBe("1.5");
+  });
+
+  it("updates, persists, and re-applies on change", () => {
+    const { result } = renderHook(() => useFontScale());
+    act(() => result.current[1](1.25));
+    expect(result.current[0]).toBe(1.25);
+    expect(localStorage.getItem(FONT_SCALE_KEY)).toBe("1.25");
+    expect(document.documentElement.style.zoom).toBe("1.25");
+  });
+
+  it("clamps out-of-range updates", () => {
+    const { result } = renderHook(() => useFontScale());
+    act(() => result.current[1](99));
+    expect(result.current[0]).toBe(2);
+  });
+});

--- a/src/hooks/useFontScale.ts
+++ b/src/hooks/useFontScale.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  DEFAULT_FONT_SCALE,
+  applyFontScale,
+  clampFontScale,
+  readStoredFontScale,
+  storeFontScale,
+} from "../lib/fontScale";
+
+/**
+ * Manage the global UI zoom level. Reads the persisted value on mount, applies
+ * it to the document root, and persists every change. Returns the current scale
+ * and a setter that clamps to the supported range.
+ */
+export function useFontScale(): [number, (scale: number) => void] {
+  // Initialise from storage lazily so the first paint already uses the saved
+  // zoom (guarded for non-DOM environments inside readStoredFontScale).
+  const [scale, setScale] = useState<number>(() => readStoredFontScale() || DEFAULT_FONT_SCALE);
+
+  useEffect(() => {
+    applyFontScale(scale);
+  }, [scale]);
+
+  const updateScale = useCallback((next: number) => {
+    const clamped = clampFontScale(next);
+    setScale(clamped);
+    storeFontScale(clamped);
+  }, []);
+
+  return [scale, updateScale];
+}

--- a/src/hooks/useSession.test.ts
+++ b/src/hooks/useSession.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useSession } from "./useSession";
+import type { DisplayMessage, LoadResult } from "../types";
+
+const mockInvoke = vi.fn();
+vi.mock("../lib/invoke", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+type Listener = (e: { payload: unknown }) => void;
+const listeners = new Map<string, Set<Listener>>();
+vi.mock("../lib/listen", () => ({
+  listen: (event: string, cb: Listener) => {
+    let set = listeners.get(event);
+    if (!set) {
+      set = new Set();
+      listeners.set(event, set);
+    }
+    set.add(cb);
+    return Promise.resolve(() => set?.delete(cb));
+  },
+}));
+
+function emit(event: string, payload: unknown) {
+  for (const cb of listeners.get(event) ?? []) cb({ payload });
+}
+
+function makeMessage(index: number): DisplayMessage {
+  return {
+    role: index % 2 === 0 ? "user" : "claude",
+    model: "",
+    content: `message ${index}`,
+    timestamp: "2025-01-01T12:00:00Z",
+    thinking_count: 0,
+    tool_call_count: 0,
+    output_count: 0,
+    tokens_raw: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+    context_tokens: 0,
+    duration_ms: 0,
+    items: [],
+    last_output: null,
+    is_error: false,
+    teammate_spawns: 0,
+    teammate_messages: 0,
+    subagent_label: "",
+  };
+}
+
+const TOTAL = 250;
+
+/** Build a load_session response for [start, start+limit) against a TOTAL-message session. */
+function windowResult(start: number, limit: number | undefined): LoadResult {
+  const count = TOTAL;
+  const end = limit === undefined ? count : Math.min(start + limit, count);
+  const clampedStart = Math.min(start, count);
+  const messages: DisplayMessage[] = [];
+  for (let i = clampedStart; i < end; i++) messages.push(makeMessage(i));
+  return {
+    messages,
+    teams: [],
+    ongoing: false,
+    meta: { cwd: "/proj", git_branch: "main", permission_mode: "default" },
+    session_totals: {
+      total_tokens: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+      cost_usd: 0,
+      model: "",
+    },
+    count,
+    start: clampedStart,
+    roles: Array.from({ length: count }, (_, i) => (i % 2 === 0 ? "user" : "claude")),
+    context_tokens: 0,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listeners.clear();
+  mockInvoke.mockImplementation(
+    (cmd: string, args?: { start?: number; limit?: number; index?: number }) => {
+      if (cmd === "load_session") {
+        return Promise.resolve(windowResult(args?.start ?? 0, args?.limit));
+      }
+      if (cmd === "load_message") {
+        return Promise.resolve(makeMessage(args?.index ?? 0));
+      }
+      return Promise.resolve(undefined);
+    },
+  );
+});
+
+describe("useSession windowing", () => {
+  it("loads count/roles and primes only the tail window", async () => {
+    const { result } = renderHook(() => useSession());
+
+    await act(async () => {
+      await result.current.loadSession("/proj/s.jsonl");
+    });
+
+    expect(result.current.count).toBe(TOTAL);
+    expect(result.current.roles).toHaveLength(TOTAL);
+    // Tail is loaded, the head is not (memory stays windowed).
+    await waitFor(() => expect(result.current.getMessage(TOTAL - 1)).toBeDefined());
+    expect(result.current.getMessage(0)).toBeUndefined();
+  });
+
+  it("fetches missing pages on ensureRange and evicts far ones", async () => {
+    const { result } = renderHook(() => useSession());
+    await act(async () => {
+      await result.current.loadSession("/proj/s.jsonl");
+    });
+    // Tail (page 2, indices 200-249) is loaded after prime.
+    await waitFor(() => expect(result.current.getMessage(240)).toBeDefined());
+
+    // Scroll to the top pages.
+    await act(async () => {
+      await result.current.ensureRange(0, 100);
+    });
+
+    expect(result.current.getMessage(0)).toBeDefined();
+    // The far tail page is evicted to keep memory bounded.
+    await waitFor(() => expect(result.current.getMessage(240)).toBeUndefined());
+  });
+
+  it("evicts far pages even when the requested range needs no new fetch", async () => {
+    const { result } = renderHook(() => useSession());
+    await act(async () => {
+      await result.current.loadSession("/proj/s.jsonl");
+    });
+    await waitFor(() => expect(result.current.getMessage(240)).toBeDefined());
+
+    // Scroll to the top: evicts the tail page, loads page 0.
+    await act(async () => {
+      await result.current.ensureRange(0, 50);
+    });
+    expect(result.current.getMessage(240)).toBeUndefined();
+
+    // Scroll back down near the tail: re-loads the tail page. Page 0 survives
+    // because it's within this range's wider keep band.
+    await act(async () => {
+      await result.current.ensureRange(150, 250);
+    });
+    expect(result.current.getMessage(240)).toBeDefined();
+    expect(result.current.getMessage(20)).toBeDefined();
+
+    // Move back to a narrow range at the top. Page 0 is already cached (no
+    // fetch needed this time), but the tail page is now two pages outside the
+    // keep band — it must still be evicted even though nothing was fetched.
+    await act(async () => {
+      await result.current.ensureRange(0, 50);
+    });
+    expect(result.current.getMessage(240)).toBeUndefined();
+  });
+
+  it("clearWindow drops all loaded pages so the next range re-fetches", async () => {
+    const { result } = renderHook(() => useSession());
+    await act(async () => {
+      await result.current.loadSession("/proj/s.jsonl");
+    });
+    await waitFor(() => expect(result.current.getMessage(240)).toBeDefined());
+
+    act(() => {
+      result.current.clearWindow();
+    });
+    expect(result.current.getMessage(240)).toBeUndefined();
+
+    mockInvoke.mockClear();
+    await act(async () => {
+      await result.current.ensureRange(200, 250);
+    });
+    // Re-fetched even though this page was already loaded before clearing.
+    expect(mockInvoke).toHaveBeenCalledWith("load_session", {
+      path: "/proj/s.jsonl",
+      start: 200,
+      limit: 100,
+    });
+    expect(result.current.getMessage(240)).toBeDefined();
+  });
+
+  it("loadFullMessage fetches the full message body on demand", async () => {
+    const { result } = renderHook(() => useSession());
+    await act(async () => {
+      await result.current.loadSession("/proj/s.jsonl");
+    });
+
+    let full: DisplayMessage | undefined;
+    await act(async () => {
+      full = await result.current.loadFullMessage(42);
+    });
+    expect(full).toBeDefined();
+    expect(full?.content).toBe("message 42");
+    expect(mockInvoke).toHaveBeenCalledWith("load_message", { path: "/proj/s.jsonl", index: 42 });
+  });
+
+  it("applies the live update signal (count/context) and keeps roles in sync", async () => {
+    const { result } = renderHook(() => useSession());
+    await act(async () => {
+      await result.current.loadSession("/proj/s.jsonl");
+    });
+
+    act(() => {
+      emit("session-update", {
+        count: 260,
+        roles: Array.from({ length: 260 }, () => "user"),
+        context_tokens: 12345,
+        teams: [],
+        ongoing: true,
+        permission_mode: "acceptEdits",
+        session_totals: windowResult(0, 0).session_totals,
+      });
+    });
+
+    expect(result.current.count).toBe(260);
+    expect(result.current.roles).toHaveLength(260);
+    expect(result.current.contextTokens).toBe(12345);
+    expect(result.current.ongoing).toBe(true);
+    expect(result.current.meta.permission_mode).toBe("acceptEdits");
+  });
+});

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { invoke } from "../lib/invoke";
 import type {
   DisplayMessage,
@@ -11,8 +11,21 @@ import type {
 } from "../types";
 import { useTauriEvent } from "./useTauriEvent";
 
+/** Messages are fetched and evicted a page at a time. Only pages near the
+ * viewport are kept in memory, so the JS heap stays flat regardless of how many
+ * messages the session has. */
+const PAGE_SIZE = 100;
+/** Pages within this many pages of the viewport are kept; the rest are evicted. */
+const KEEP_MARGIN_PAGES = 1;
+
+/** Session-level state (everything except the windowed message bodies). */
 interface SessionState {
-  messages: DisplayMessage[];
+  /** Total message count in the session. */
+  count: number;
+  /** Role of every message (length === count) — the lightweight index. */
+  roles: string[];
+  /** Latest Claude context-window fill (tokens); 0 if none. */
+  contextTokens: number;
   teams: TeamSnapshot[];
   ongoing: boolean;
   meta: SessionMeta;
@@ -21,6 +34,17 @@ interface SessionState {
   gitInfo: GitInfo | null;
   debugEntries: DebugEntry[];
   loading: boolean;
+}
+
+/** Lightweight live signal emitted by the watcher (no message bodies). */
+interface SessionUpdateSignal {
+  count: number;
+  roles: string[];
+  context_tokens: number;
+  teams: TeamSnapshot[];
+  ongoing: boolean;
+  permission_mode: string;
+  session_totals: SessionTotals;
 }
 
 const emptyMeta: SessionMeta = {
@@ -39,89 +63,256 @@ const emptyTotals: SessionTotals = {
   model: "",
 };
 
+const emptyState: SessionState = {
+  count: 0,
+  roles: [],
+  contextTokens: 0,
+  teams: [],
+  ongoing: false,
+  meta: emptyMeta,
+  sessionTotals: emptyTotals,
+  sessionPath: "",
+  gitInfo: null,
+  debugEntries: [],
+  loading: false,
+};
+
+const pageOf = (index: number) => Math.floor(index / PAGE_SIZE);
+
 export function useSession() {
-  const [state, setState] = useState<SessionState>({
-    messages: [],
-    teams: [],
-    ongoing: false,
-    meta: emptyMeta,
-    sessionTotals: emptyTotals,
-    sessionPath: "",
-    gitInfo: null,
-    debugEntries: [],
-    loading: false,
-  });
+  const [state, setState] = useState<SessionState>(emptyState);
+  // Sparse store of loaded message bodies, keyed by absolute index. Replaced
+  // (new Map) on every change so React re-renders.
+  const [windowMessages, setWindowMessages] = useState<Map<number, DisplayMessage>>(new Map());
 
-  const loadSession = useCallback(async (path: string) => {
-    setState((prev) => ({ ...prev, loading: true }));
-    try {
-      // Stop watching previous session
-      try {
-        await invoke<void>("unwatch_session");
-      } catch {
-        // ignore if no session was being watched
-      }
+  // Monotonic id: bumped on every loadSession so in-flight fetches for a
+  // previous session are ignored when they resolve.
+  const loadIdRef = useRef(0);
+  const pathRef = useRef("");
+  const loadedPagesRef = useRef<Set<number>>(new Set());
+  const inflightPagesRef = useRef<Set<number>>(new Set());
+  const lastRangeRef = useRef({ start: 0, end: 0 });
 
-      const result = await invoke<LoadResult>("load_session", { path });
+  /** Apply the session-level fields returned by any load_session call. */
+  const applySessionFields = useCallback((res: LoadResult) => {
+    setState((prev) => ({
+      ...prev,
+      count: res.count,
+      roles: res.roles,
+      contextTokens: res.context_tokens,
+      teams: res.teams,
+      ongoing: res.ongoing,
+      sessionTotals: res.session_totals,
+      meta: res.meta,
+    }));
+  }, []);
 
-      // Extract git info from session cwd
-      let gitInfo: GitInfo | null = null;
-      if (result.meta.cwd) {
-        try {
-          gitInfo = await invoke<GitInfo>("get_git_info", {
-            cwd: result.meta.cwd,
-          });
-        } catch {
-          // git info is optional
+  /** Evict pages outside the keep band. Runs on every `ensureRange` call
+   * regardless of whether a fetch is needed — eviction must not wait on a
+   * fetch happening to run, or pages left over from a wider prefetch (or from
+   * scrolling back and forth within an already-cached region) never get
+   * cleaned up and memory only grows. */
+  const evictOutsideKeepBand = useCallback((keepFirstPage: number, keepLastPage: number) => {
+    setWindowMessages((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const idx of next.keys()) {
+        const p = pageOf(idx);
+        if (p < keepFirstPage || p > keepLastPage) {
+          next.delete(idx);
+          changed = true;
         }
       }
-
-      setState({
-        messages: result.messages,
-        teams: result.teams,
-        ongoing: result.ongoing,
-        meta: result.meta,
-        sessionTotals: result.session_totals,
-        sessionPath: path,
-        gitInfo,
-        debugEntries: [],
-        loading: false,
-      });
-
-      // Start watching for updates
-      try {
-        await invoke<void>("watch_session", { path });
-      } catch {
-        // watcher is optional
-      }
-    } catch (err) {
-      console.error("Failed to load session:", err);
-      setState((prev) => ({ ...prev, loading: false }));
+      return changed ? next : prev;
+    });
+    const survivors = new Set<number>();
+    for (const p of loadedPagesRef.current) {
+      if (p >= keepFirstPage && p <= keepLastPage) survivors.add(p);
     }
+    loadedPagesRef.current = survivors;
   }, []);
+
+  /** Insert a freshly fetched page's messages into the store. */
+  const insertWindow = useCallback((res: LoadResult) => {
+    setWindowMessages((prev) => {
+      const next = new Map(prev);
+      res.messages.forEach((msg, i) => next.set(res.start + i, msg));
+      return next;
+    });
+  }, []);
+
+  /** Drop every loaded page. Called when leaving the list view (e.g. opening
+   * Detail) so the list's data doesn't sit in memory while a different view
+   * is showing — coming back re-fetches the visible window fresh instead. */
+  const clearWindow = useCallback(() => {
+    setWindowMessages(new Map());
+    loadedPagesRef.current = new Set();
+  }, []);
+
+  /** Ensure the message bodies covering [start, end) are loaded, fetching any
+   * missing pages and evicting pages far from the range. */
+  const ensureRange = useCallback(
+    async (start: number, end: number) => {
+      const path = pathRef.current;
+      if (!path) return;
+      lastRangeRef.current = { start, end };
+
+      const firstPage = pageOf(Math.max(0, start));
+      const lastPage = pageOf(Math.max(start, end - 1));
+      const keepFirst = Math.max(0, firstPage - KEEP_MARGIN_PAGES);
+      const keepLast = lastPage + KEEP_MARGIN_PAGES;
+
+      // Shrink the store to the current keep band immediately — this must not
+      // wait on a fetch, since the pages this range needs may already be cached.
+      evictOutsideKeepBand(keepFirst, keepLast);
+
+      // Collect the pages that still need fetching, then fetch them together.
+      const missing: number[] = [];
+      for (let page = firstPage; page <= lastPage; page++) {
+        if (loadedPagesRef.current.has(page) || inflightPagesRef.current.has(page)) continue;
+        inflightPagesRef.current.add(page);
+        missing.push(page);
+      }
+
+      await Promise.all(
+        missing.map(async (page) => {
+          const myLoadId = loadIdRef.current;
+          try {
+            const res = await invoke<LoadResult>("load_session", {
+              path,
+              start: page * PAGE_SIZE,
+              limit: PAGE_SIZE,
+            });
+            if (myLoadId !== loadIdRef.current) return; // session changed mid-fetch
+            loadedPagesRef.current.add(page);
+            applySessionFields(res);
+            insertWindow(res);
+          } catch (err) {
+            console.error("Failed to fetch message window:", err);
+          } finally {
+            inflightPagesRef.current.delete(page);
+          }
+        }),
+      );
+    },
+    [applySessionFields, evictOutsideKeepBand, insertWindow],
+  );
+
+  const getMessage = useCallback(
+    (index: number): DisplayMessage | undefined => windowMessages.get(index),
+    [windowMessages],
+  );
+
+  const loadSession = useCallback(
+    async (path: string) => {
+      const myLoadId = ++loadIdRef.current;
+      pathRef.current = path;
+      loadedPagesRef.current = new Set();
+      inflightPagesRef.current = new Set();
+      lastRangeRef.current = { start: 0, end: 0 };
+      setWindowMessages(new Map());
+      setState({ ...emptyState, sessionPath: path, loading: true });
+
+      try {
+        // Stop watching the previous session.
+        try {
+          await invoke<void>("unwatch_session");
+        } catch {
+          // ignore if nothing was being watched
+        }
+
+        // Metadata-only fetch (limit 0) to learn the count and index.
+        const meta = await invoke<LoadResult>("load_session", { path, start: 0, limit: 0 });
+        if (myLoadId !== loadIdRef.current) return;
+
+        let gitInfo: GitInfo | null = null;
+        if (meta.meta.cwd) {
+          try {
+            gitInfo = await invoke<GitInfo>("get_git_info", { cwd: meta.meta.cwd });
+          } catch {
+            // git info is optional
+          }
+        }
+        if (myLoadId !== loadIdRef.current) return;
+
+        // Keep `loading` true until the tail window is primed, so the list
+        // doesn't flash placeholders on open.
+        setState({
+          count: meta.count,
+          roles: meta.roles,
+          contextTokens: meta.context_tokens,
+          teams: meta.teams,
+          ongoing: meta.ongoing,
+          meta: meta.meta,
+          sessionTotals: meta.session_totals,
+          sessionPath: path,
+          gitInfo,
+          debugEntries: [],
+          loading: true,
+        });
+
+        // Prime the tail window (the view opens at the newest message).
+        if (meta.count > 0) {
+          await ensureRange(Math.max(0, meta.count - PAGE_SIZE), meta.count);
+        }
+        if (myLoadId !== loadIdRef.current) return;
+        setState((prev) => ({ ...prev, loading: false }));
+
+        // Start watching for updates.
+        try {
+          await invoke<void>("watch_session", { path });
+        } catch {
+          // watcher is optional
+        }
+      } catch (err) {
+        console.error("Failed to load session:", err);
+        if (myLoadId === loadIdRef.current) {
+          setState((prev) => ({ ...prev, loading: false }));
+        }
+      }
+    },
+    [ensureRange],
+  );
+
+  /** Fetch the full (heavy-body) message at `index` for the detail view. List
+   * windows carry lightened messages (no tool bodies), so the detail view pulls
+   * the full one on demand. Returns undefined if the session changed or errored. */
+  const loadFullMessage = useCallback(
+    async (index: number): Promise<DisplayMessage | undefined> => {
+      const path = pathRef.current;
+      if (!path) return undefined;
+      const myLoadId = loadIdRef.current;
+      try {
+        const msg = await invoke<DisplayMessage | null>("load_message", { path, index });
+        if (myLoadId !== loadIdRef.current) return undefined;
+        return msg ?? undefined;
+      } catch (err) {
+        console.error("Failed to load message:", err);
+        return undefined;
+      }
+    },
+    [],
+  );
 
   const loadDebugLog = useCallback(async (sessionPath: string) => {
     try {
-      const entries = await invoke<DebugEntry[]>("get_debug_log", {
-        sessionPath,
-      });
+      const entries = await invoke<DebugEntry[]>("get_debug_log", { sessionPath });
       setState((prev) => ({ ...prev, debugEntries: entries }));
     } catch (err) {
       console.error("Failed to load debug log:", err);
     }
   }, []);
 
-  // Listen for session-update events
-  useTauriEvent<{
-    messages: DisplayMessage[];
-    teams: TeamSnapshot[];
-    ongoing: boolean;
-    permission_mode: string;
-    session_totals: SessionTotals;
-  }>("session-update", (payload) => {
+  // Live updates: the watcher emits a lightweight signal (no bodies). Update the
+  // session-level fields, then invalidate the visible window so the (possibly
+  // streamed) bodies are refetched. Growth in `count` makes the virtualized list
+  // request the new tail via ensureRange on its own.
+  useTauriEvent<SessionUpdateSignal>("session-update", (payload) => {
     setState((prev) => ({
       ...prev,
-      messages: payload.messages,
+      count: payload.count,
+      roles: payload.roles,
+      contextTokens: payload.context_tokens,
       teams: payload.teams,
       ongoing: payload.ongoing,
       sessionTotals: payload.session_totals,
@@ -130,9 +321,16 @@ export function useSession() {
         permission_mode: payload.permission_mode || prev.meta.permission_mode,
       },
     }));
+    // Force a refetch of the currently visible pages (content may have changed
+    // in place without the count growing, e.g. a streaming final message).
+    const { start, end } = lastRangeRef.current;
+    const firstPage = pageOf(Math.max(0, start));
+    const lastPage = pageOf(Math.max(start, end - 1));
+    for (let p = firstPage; p <= lastPage; p++) loadedPagesRef.current.delete(p);
+    void ensureRange(start, end);
   });
 
-  // Cleanup on unmount
+  // Cleanup on unmount.
   useEffect(() => {
     return () => {
       invoke<void>("unwatch_session").catch(() => {});
@@ -141,6 +339,10 @@ export function useSession() {
 
   return {
     ...state,
+    getMessage,
+    ensureRange,
+    clearWindow,
+    loadFullMessage,
     loadSession,
     loadDebugLog,
   };

--- a/src/lib/fontScale.test.ts
+++ b/src/lib/fontScale.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  FONT_SCALE_KEY,
+  DEFAULT_FONT_SCALE,
+  MIN_FONT_SCALE,
+  MAX_FONT_SCALE,
+  clampFontScale,
+  readStoredFontScale,
+  storeFontScale,
+  applyFontScale,
+  formatFontScale,
+} from "./fontScale";
+
+describe("fontScale", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.zoom = "";
+  });
+
+  describe("clampFontScale", () => {
+    it("keeps in-range values", () => {
+      expect(clampFontScale(1.25)).toBe(1.25);
+    });
+
+    it("clamps below the minimum and above the maximum", () => {
+      expect(clampFontScale(0.1)).toBe(MIN_FONT_SCALE);
+      expect(clampFontScale(99)).toBe(MAX_FONT_SCALE);
+    });
+
+    it("falls back to the default for non-finite values", () => {
+      expect(clampFontScale(Number.NaN)).toBe(DEFAULT_FONT_SCALE);
+      expect(clampFontScale(Number.POSITIVE_INFINITY)).toBe(DEFAULT_FONT_SCALE);
+    });
+  });
+
+  describe("readStoredFontScale", () => {
+    it("returns the default when unset", () => {
+      expect(readStoredFontScale()).toBe(DEFAULT_FONT_SCALE);
+    });
+
+    it("reads and clamps a stored value", () => {
+      localStorage.setItem(FONT_SCALE_KEY, "1.5");
+      expect(readStoredFontScale()).toBe(1.5);
+      localStorage.setItem(FONT_SCALE_KEY, "5");
+      expect(readStoredFontScale()).toBe(MAX_FONT_SCALE);
+    });
+
+    it("returns the default for malformed values", () => {
+      localStorage.setItem(FONT_SCALE_KEY, "not-a-number");
+      expect(readStoredFontScale()).toBe(DEFAULT_FONT_SCALE);
+    });
+  });
+
+  describe("storeFontScale", () => {
+    it("round-trips through readStoredFontScale", () => {
+      storeFontScale(1.75);
+      expect(readStoredFontScale()).toBe(1.75);
+    });
+
+    it("ignores write failures", () => {
+      const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+        throw new Error("quota");
+      });
+      expect(() => storeFontScale(1.25)).not.toThrow();
+      spy.mockRestore();
+    });
+  });
+
+  describe("applyFontScale", () => {
+    it("sets the document zoom, clamping out-of-range values", () => {
+      applyFontScale(1.25);
+      expect(document.documentElement.style.zoom).toBe("1.25");
+      applyFontScale(10);
+      expect(document.documentElement.style.zoom).toBe(String(MAX_FONT_SCALE));
+    });
+  });
+
+  describe("formatFontScale", () => {
+    it("renders a percentage label", () => {
+      expect(formatFontScale(1)).toBe("100%");
+      expect(formatFontScale(1.25)).toBe("125%");
+      expect(formatFontScale(0.8)).toBe("80%");
+    });
+  });
+});

--- a/src/lib/fontScale.ts
+++ b/src/lib/fontScale.ts
@@ -1,0 +1,59 @@
+/**
+ * Global UI zoom ("font size") support.
+ *
+ * The app's CSS is entirely px-based, so changing a root `font-size` would not
+ * scale most of the UI. Instead we apply the CSS `zoom` property to the root
+ * element, which reflows the whole layout — the equivalent of the browser's
+ * built-in zoom — and is supported across the WebViews Tauri uses (WebKit,
+ * WebView2, WebKitGTK) as well as plain browsers in web mode.
+ *
+ * The chosen scale is persisted in `localStorage` so it survives reloads and
+ * applies on both desktop and web.
+ */
+
+export const FONT_SCALE_KEY = "cct.fontScale";
+
+export const DEFAULT_FONT_SCALE = 1;
+
+export const MIN_FONT_SCALE = 0.8;
+export const MAX_FONT_SCALE = 2;
+
+/** Preset zoom levels offered in the settings selector (1 = 100%). */
+export const FONT_SCALE_PRESETS = [0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2] as const;
+
+/** Clamp an arbitrary number into the supported zoom range, falling back to the
+ * default when the value is not a finite number. */
+export function clampFontScale(scale: number): number {
+  if (!Number.isFinite(scale)) return DEFAULT_FONT_SCALE;
+  return Math.min(MAX_FONT_SCALE, Math.max(MIN_FONT_SCALE, scale));
+}
+
+/** Read the persisted zoom level, returning the default when unset, malformed,
+ * or when `localStorage` is unavailable (e.g. SSR / privacy mode). */
+export function readStoredFontScale(): number {
+  if (typeof localStorage === "undefined") return DEFAULT_FONT_SCALE;
+  const raw = localStorage.getItem(FONT_SCALE_KEY);
+  if (raw === null) return DEFAULT_FONT_SCALE;
+  return clampFontScale(Number.parseFloat(raw));
+}
+
+/** Persist the zoom level, ignoring write failures (quota / disabled storage). */
+export function storeFontScale(scale: number): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(FONT_SCALE_KEY, String(scale));
+  } catch {
+    // Storage may be full or disabled; the in-memory scale still applies.
+  }
+}
+
+/** Apply the zoom level to the document root. No-op when there is no DOM. */
+export function applyFontScale(scale: number): void {
+  if (typeof document === "undefined") return;
+  document.documentElement.style.zoom = String(clampFontScale(scale));
+}
+
+/** Format a scale as a percentage label, e.g. `1.25` -> `"125%"`. */
+export function formatFontScale(scale: number): string {
+  return `${Math.round(scale * 100)}%`;
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -111,12 +111,18 @@ export function shortMode(mode: string): string {
  * Returns context window usage percentage (0-100).
  * Returns -1 if no usage data is available.
  */
-export function contextPercent(msgs: DisplayMessage[]): number {
+/** Context-window fill percent from a raw token count. Returns -1 (hidden) when
+ * there is no usage (tokens <= 0). Uses the 1M default context window. */
+export function contextPercentFromTokens(tokens: number): number {
+  if (tokens <= 0) return -1;
   const contextWindowSize = 1_000_000;
+  return Math.min(Math.floor((tokens * 100) / contextWindowSize), 100);
+}
+
+export function contextPercent(msgs: DisplayMessage[]): number {
   for (let i = msgs.length - 1; i >= 0; i--) {
     if (msgs[i].role === "claude" && msgs[i].context_tokens > 0) {
-      const pct = Math.floor((msgs[i].context_tokens * 100) / contextWindowSize);
-      return Math.min(pct, 100);
+      return contextPercentFromTokens(msgs[i].context_tokens);
     }
   }
   return -1;

--- a/src/lib/invoke.test.ts
+++ b/src/lib/invoke.test.ts
@@ -99,6 +99,34 @@ describe("invoke (web/HTTP mode)", () => {
     );
   });
 
+  it("load_session posts path + window (start/limit) to /api/session/load", async () => {
+    const fetchFn = mockFetch({ messages: [], count: 0, start: 0, roles: [] });
+    const { invoke } = await import("./invoke");
+
+    await invoke("load_session", { path: "/a.jsonl", start: 100, limit: 50 });
+    expect(fetchFn).toHaveBeenCalledWith(
+      `${API_BASE}/api/session/load`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ path: "/a.jsonl", start: 100, limit: 50 }),
+      }),
+    );
+  });
+
+  it("load_message posts path + index to /api/session/message", async () => {
+    const fetchFn = mockFetch({ role: "claude" });
+    const { invoke } = await import("./invoke");
+
+    await invoke("load_message", { path: "/a.jsonl", index: 42 });
+    expect(fetchFn).toHaveBeenCalledWith(
+      `${API_BASE}/api/session/message`,
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ path: "/a.jsonl", index: 42 }),
+      }),
+    );
+  });
+
   it("watch/unwatch commands resolve without error", async () => {
     mockFetch({ ok: true });
     const { invoke } = await import("./invoke");

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -41,7 +41,12 @@ const routes: Record<string, Route> = {
   load_session: {
     method: "POST",
     path: "/api/session/load",
-    body: (a) => ({ path: a.path }),
+    body: (a) => ({ path: a.path, start: a.start, limit: a.limit }),
+  },
+  load_message: {
+    method: "POST",
+    path: "/api/session/message",
+    body: (a) => ({ path: a.path, index: a.index }),
   },
   get_session_meta: {
     path: (a) => `/api/session/meta?path=${encodeURIComponent(String(a.path ?? ""))}`,
@@ -107,13 +112,27 @@ async function httpInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
 // Public API
 // ---------------------------------------------------------------------------
 
+let inFlightCount = 0;
+
+/** Number of `invoke` calls currently awaiting a response. Reloading the
+ * webview while a Tauri IPC call is in flight can crash it on macOS — callers
+ * that need to reload (see lib/webviewRecycle.ts) check this first. */
+export function inFlightInvokeCount(): number {
+  return inFlightCount;
+}
+
 /**
  * Drop-in replacement for `import { invoke } from "@tauri-apps/api/core"`.
  * Works in both Tauri and plain-browser environments.
  */
 export async function invoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
-  if (isTauri) {
-    return tauriInvoke<T>(cmd, args);
+  inFlightCount++;
+  try {
+    if (isTauri) {
+      return await tauriInvoke<T>(cmd, args);
+    }
+    return await httpInvoke<T>(cmd, args);
+  } finally {
+    inFlightCount--;
   }
-  return httpInvoke<T>(cmd, args);
 }

--- a/src/lib/webviewRecycle.test.ts
+++ b/src/lib/webviewRecycle.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  shouldRecycle,
+  saveRestoreState,
+  takeRestoreState,
+  reloadWebview,
+  RELOAD_AFTER_N_SWITCHES,
+} from "./webviewRecycle";
+import * as invokeModule from "./invoke";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("shouldRecycle", () => {
+  it("is false below the threshold", () => {
+    expect(shouldRecycle(0)).toBe(false);
+    expect(shouldRecycle(RELOAD_AFTER_N_SWITCHES - 1)).toBe(false);
+  });
+
+  it("is true at and above the threshold", () => {
+    expect(shouldRecycle(RELOAD_AFTER_N_SWITCHES)).toBe(true);
+    expect(shouldRecycle(RELOAD_AFTER_N_SWITCHES + 5)).toBe(true);
+  });
+});
+
+describe("save/takeRestoreState", () => {
+  it("round-trips a saved session path", () => {
+    saveRestoreState({ sessionPath: "/proj/s.jsonl" });
+    expect(takeRestoreState()).toEqual({ sessionPath: "/proj/s.jsonl" });
+  });
+
+  it("clears the state after reading it once", () => {
+    saveRestoreState({ sessionPath: "/proj/s.jsonl" });
+    takeRestoreState();
+    expect(takeRestoreState()).toBeNull();
+  });
+
+  it("returns null when nothing was saved", () => {
+    expect(takeRestoreState()).toBeNull();
+  });
+
+  it("returns null for corrupt stored JSON instead of throwing", () => {
+    sessionStorage.setItem("cctrace.pendingRestore", "{not json");
+    expect(() => takeRestoreState()).not.toThrow();
+    expect(takeRestoreState()).toBeNull();
+  });
+});
+
+describe("reloadWebview", () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    reloadSpy = vi.fn();
+    // jsdom's window.location.reload isn't configurable for vi.spyOn directly.
+    Object.defineProperty(window, "location", {
+      value: { ...originalLocation, reload: reloadSpy },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("reloads immediately when nothing is in flight", async () => {
+    vi.spyOn(invokeModule, "inFlightInvokeCount").mockReturnValue(0);
+    await reloadWebview();
+    expect(reloadSpy).toHaveBeenCalled();
+  });
+
+  it("waits for in-flight invokes to settle before reloading", async () => {
+    // Reloading while a Tauri invoke is pending is a known macOS crash cause
+    // (tauri-apps/tauri#9933) — this app always has one in flight, so
+    // reloadWebview must wait rather than reload unconditionally.
+    let inFlight = 2;
+    vi.spyOn(invokeModule, "inFlightInvokeCount").mockImplementation(() => inFlight);
+
+    const done = reloadWebview();
+    await vi.advanceTimersByTimeAsync(50);
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    inFlight = 0;
+    await vi.advanceTimersByTimeAsync(50);
+    await done;
+    expect(reloadSpy).toHaveBeenCalled();
+  });
+
+  it("reloads anyway after the timeout if invokes never settle", async () => {
+    vi.spyOn(invokeModule, "inFlightInvokeCount").mockReturnValue(1);
+
+    const done = reloadWebview();
+    await vi.advanceTimersByTimeAsync(3000);
+    await done;
+    expect(reloadSpy).toHaveBeenCalled();
+  });
+});

--- a/src/lib/webviewRecycle.ts
+++ b/src/lib/webviewRecycle.ts
@@ -1,0 +1,67 @@
+/**
+ * WebKit (Tauri's macOS webview engine) retains render-tree/layout memory
+ * across repeated large DOM swaps within this long-lived single-page app —
+ * measured via `vmmap`: physical footprint climbed steadily across repeated
+ * session switches even though JS heap and DOM node counts stayed flat.
+ * There's no public WKWebView API to reclaim it; a full reload is the only
+ * reliable reset. This tracks how many sessions have been opened this page
+ * lifetime and, once a threshold is hit, saves which session was open and
+ * reloads, so the reload restores continuity instead of dumping the user
+ * back to an empty picker.
+ */
+
+import { inFlightInvokeCount } from "./invoke";
+
+const STORAGE_KEY = "cctrace.pendingRestore";
+
+/** Reload after this many session opens (empirically, memory growth is
+ * steady enough that this keeps the webview's footprint from compounding
+ * over a long working session without reloading disruptively often). */
+export const RELOAD_AFTER_N_SWITCHES = 25;
+
+export interface PendingRestore {
+  sessionPath: string;
+}
+
+export function shouldRecycle(switchCount: number): boolean {
+  return switchCount >= RELOAD_AFTER_N_SWITCHES;
+}
+
+export function saveRestoreState(state: PendingRestore): void {
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+/** Reads and clears the pending restore state, if any (survives a
+ * `location.reload()` since it uses `sessionStorage`, not module state). */
+export function takeRestoreState(): PendingRestore | null {
+  const raw = sessionStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  sessionStorage.removeItem(STORAGE_KEY);
+  try {
+    const parsed = JSON.parse(raw) as PendingRestore;
+    return typeof parsed.sessionPath === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Waits until no `invoke` call is in flight, polling every `pollMs` up to
+ * `timeoutMs`. Reloading on macOS while a Tauri IPC call is still pending is a
+ * known crash cause (tauri-apps/tauri#9933) — this app always has some async
+ * invoke in flight (session loads, page fetches), so reloading unconditionally
+ * risked never visibly happening. The timeout keeps a call that never
+ * resolves from blocking the reload forever. */
+async function waitForQuietInvokes(timeoutMs = 3000, pollMs = 50): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (inFlightInvokeCount() > 0 && Date.now() < deadline) {
+    // Sequential polling by design: each wait must complete before rechecking
+    // the (externally mutated) in-flight count — nothing to run in parallel.
+    // oxlint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+}
+
+export async function reloadWebview(): Promise<void> {
+  await waitForQuietInvokes();
+  window.location.reload();
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1087,13 +1087,22 @@ body {
   height: 100%;
 }
 
+.link-button {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
+
 /* ---- Message List ---- */
 
 .message-list {
   flex: 1;
   overflow-y: auto;
   padding: 8px 0;
-  scroll-behavior: smooth;
 }
 
 .message-list__empty {
@@ -1117,6 +1126,60 @@ body {
 
 .message:hover {
   background: var(--bg-hover);
+}
+
+/* While actively scrolling a virtualized list, the browser does not recompute
+ * `:hover` for rows that shift under a stationary cursor — only a real pointer
+ * move triggers that. Suppressing the hover/selection transition during scroll
+ * avoids a stale highlight visually lingering on the wrong row; the correct
+ * hover reappears on the next real pointer move once scrolling settles. */
+.message-list--scrolling .message {
+  transition: none;
+}
+
+.message-list--scrolling .message:hover {
+  background: transparent;
+}
+
+/* Placeholder shown for a virtualized row whose body hasn't loaded yet. Sized
+ * to approximate a typical loaded row (header + content lines + stats bar) so
+ * the swap to real content is a small reflow rather than a large one — a big
+ * height jump mid-scroll is what causes rows to visibly overlap/misalign. */
+.message--placeholder {
+  cursor: default;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.message__placeholder-line {
+  height: 12px;
+  width: 70%;
+  border-radius: 3px;
+  background: var(--bg-elevated);
+  opacity: 0.5;
+  animation: message-placeholder-pulse 1.2s ease-in-out infinite;
+}
+
+.message__placeholder-line--header {
+  height: 16px;
+  width: 30%;
+}
+
+.message__placeholder-line--short {
+  width: 45%;
+}
+
+@keyframes message-placeholder-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 0.7;
+  }
 }
 
 .message--selected {
@@ -2578,6 +2641,34 @@ body {
 .settings-modal__wsl-item input {
   cursor: pointer;
   accent-color: var(--accent);
+}
+
+.settings-modal__font-scale {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.settings-modal__font-scale-btn {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.settings-modal__font-scale-btn:hover {
+  background: var(--bg-hover);
+}
+
+.settings-modal__font-scale-btn--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
 }
 
 .settings-modal__input {


### PR DESCRIPTION
## Summary

Fixes GitHub issues #181 (cache session-name registry read) and #180 (font size setting), then addresses a series of memory issues found while profiling the app against large tool-heavy sessions (100-200MB+ JSONL files).

## What changed

### Backend
- New single `session_load.rs` pipeline shared by the Tauri command, HTTP API, and watcher (`build_session`, `build_light_session`, `load_session`, `slice_built`/`slice_light`).
- List-view windows are served from **lightened** messages (`lighten_messages` strips `tool_input`/`tool_result`/`tool_result_json`/`last_output`, recursively including subagent transcripts). Backed by a one-slot cache (`session_light_cache`) keyed by `(path, size)`.
- The Detail view (`full_message_at`) deliberately never caches — it re-parses the full session fresh on every click and drops the heavy build immediately after extracting one message, trading per-click latency for never holding tool output in Rust memory between clicks.
- New `load_message` command / `POST /api/session/message` endpoint for on-demand full-message fetch.

### Frontend
- `MessageList` is virtualized with `react-virtuoso` instead of rendering every message.
- `useSession` fetches/evicts a sparse windowed page map (`PAGE_SIZE=100`) instead of holding the whole session. Eviction now runs on *every* range change, not just when a new page needs fetching — the old code only evicted as a side effect of a fetch, so already-cached stale pages could sit in memory indefinitely if the viewport moved within an already-cached region.
- Leaving the list view (opening Detail) now clears the list's loaded pages (`clearWindow()`); leaving Detail (Back) now clears the full heavy message it held. Both directions previously left data behind until the next unrelated fetch happened to overwrite it.
- Fixed a scroll-time hover glitch: WebKit doesn't recompute `:hover` on scroll without a real pointer move, so a stale row could stay visibly highlighted after scrolling stopped. Forces a synthetic `mousemove` at the last known cursor position once scrolling settles.
- WebKit (Tauri's macOS webview) retains render-tree memory across repeated session switches independent of our own JS/DOM state — verified via a Playwright-driven comparison: the same switching sequence stays flat in Chromium but climbs steadily in real WebKit. There's no public WKWebView API to reclaim this. Mitigated by reloading the webview every 25 session switches, saving/restoring the open session via `sessionStorage` so it's not disruptive. The reload waits for in-flight Tauri `invoke` calls to settle first (tracked via a new `inFlightInvokeCount()` in `invoke.ts`) — reloading mid-flight is a known Tauri macOS crash cause ([tauri-apps/tauri#9933](https://github.com/tauri-apps/tauri/issues/9933)).
- Added font-scale setting (`useFontScale`) for issue #180.

### Specs
Updated `specs/03-state-management.md`, `specs/04-http-api.md`, `specs/05-frontend-web.md`, `specs/08-session-lifecycle.md`, `specs/13-item-rendering.md` to match the new architecture. All mermaid diagrams validated with `mmdc`.

## Verification

- Full frontend suite (`tsc`, `oxlint`, `oxfmt --check`, `vitest`) and backend suite (`cargo test`, `clippy`, `fmt --check`) pass.
- Runtime memory profiling via `vmmap --summary` against real 115-203MB tool-heavy session files (list-window loads, repeated Detail clicks, session switching).
- Playwright-driven end-to-end verification against both Chromium and real WebKit engines confirmed: JS heap/DOM/listeners stay bounded across scrolling and session switching; the periodic webview reload measurably resets WebKit's accumulated footprint (295MB → 184MB at the 25th switch in one test run) and correctly restores the previously-open session afterward.

## Known tradeoffs

- Detail view clicks always take a fresh full re-parse (roughly the session's original cold-load cost) since nothing is cached for it anymore — deliberate memory-vs-latency tradeoff.
- The webview reloads every 25 session switches, which causes a brief visible flash. The threshold (`RELOAD_AFTER_N_SWITCHES` in `src/lib/webviewRecycle.ts`) is a judgment call based on measured growth against worst-case (100MB+) sessions, not a hard formula.
