### PR TITLE
[#190]: handle "manual" as default permission mode for Claude Code v2.1.200+

### DIFF
--- a/specs/04-http-api.md
+++ b/specs/04-http-api.md
@@ -151,7 +151,7 @@ session.
     /* TeamSnapshot[] */
   ],
   "ongoing": true,
-  "meta": { "cwd": "...", "git_branch": "main", "permission_mode": "default" },
+  "meta": { "cwd": "...", "git_branch": "main", "permission_mode": "manual" },
   "session_totals": { "total_tokens": 5000, "cost_usd": 0.02, "model": "..." }
 }
 ```
@@ -293,7 +293,7 @@ they're viewing (`SessionUpdatePayload` in `src-tauri/src/watcher.rs`).
   "context_tokens": 12345,
   "teams": [ /* TeamSnapshot[] */ ],
   "ongoing": true,
-  "permission_mode": "default",
+  "permission_mode": "manual",
   "session_totals": { "total_tokens": ..., "cost_usd": ..., "model": "..." }
 }
 ```

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -919,7 +919,7 @@ pub(crate) fn scan_session_metadata(path: &str) -> SessionMetadata {
         meta.first_msg = meta.first_msg.replace('\n', " ");
     }
     if meta.permission_mode.is_empty() {
-        meta.permission_mode = "default".to_string();
+        meta.permission_mode = "manual".to_string();
     }
 
     // Scan subagent JSONL files into the same request_tokens map (global requestId dedup).

--- a/src/components/InfoBar.test.tsx
+++ b/src/components/InfoBar.test.tsx
@@ -157,6 +157,20 @@ describe("InfoBar", () => {
     expect(screen.queryByText("default")).not.toBeInTheDocument();
   });
 
+  it("does not show permission mode pill for manual (v2.1.200+ default mode)", () => {
+    render(
+      <InfoBar
+        meta={makeMeta({ permission_mode: "manual" })}
+        gitInfo={null}
+        contextTokens={0}
+        sessionTotals={makeTotals()}
+        sessionPath=""
+        ongoing={false}
+      />,
+    );
+    expect(screen.queryByText("manual")).not.toBeInTheDocument();
+  });
+
   it("shows context bar when contextTokens > 0", () => {
     render(
       <InfoBar

--- a/src/components/InfoBar.tsx
+++ b/src/components/InfoBar.tsx
@@ -2,6 +2,7 @@ import type { SessionMeta, SessionTotals, GitInfo } from "../types";
 import {
   shortPath,
   shortMode,
+  isDefaultMode,
   contextPercentFromTokens,
   formatTokens,
   formatCost,
@@ -57,7 +58,7 @@ export function InfoBar({
         </span>
       )}
 
-      {mode && mode !== "default" && (
+      {mode && !isDefaultMode(mode) && (
         <span className={`info-bar__pill ${pillClass}`}>{shortMode(mode)}</span>
       )}
 

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -8,6 +8,7 @@ import {
   formatDuration,
   shortPath,
   shortMode,
+  isDefaultMode,
   contextPercent,
   formatExactTime,
   groupByDate,
@@ -232,6 +233,7 @@ describe("shortPath", () => {
 describe("shortMode", () => {
   it("maps known modes to short labels", () => {
     expect(shortMode("default")).toBe("default");
+    expect(shortMode("manual")).toBe("manual");
     expect(shortMode("acceptEdits")).toBe("auto-edit");
     expect(shortMode("bypassPermissions")).toBe("yolo");
     expect(shortMode("plan")).toBe("plan");
@@ -240,6 +242,24 @@ describe("shortMode", () => {
   it("returns unknown mode as-is", () => {
     expect(shortMode("customMode")).toBe("customMode");
     expect(shortMode("")).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDefaultMode
+// ---------------------------------------------------------------------------
+describe("isDefaultMode", () => {
+  it("returns true for default and manual (both are the no-badge default mode)", () => {
+    expect(isDefaultMode("default")).toBe(true);
+    expect(isDefaultMode("manual")).toBe(true);
+  });
+
+  it("returns false for special modes", () => {
+    expect(isDefaultMode("acceptEdits")).toBe(false);
+    expect(isDefaultMode("bypassPermissions")).toBe(false);
+    expect(isDefaultMode("plan")).toBe(false);
+    expect(isDefaultMode("")).toBe(false);
+    expect(isDefaultMode("customMode")).toBe(false);
   });
 });
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -90,12 +90,22 @@ export function formatDuration(ms: number): string {
 export { shortPath, projectKey, projectDisplayName } from "../../shared/format";
 
 /**
+ * Returns true for permission modes that represent the default (no-special-permissions) state.
+ * Both "default" (pre-v2.1.200) and "manual" (v2.1.200+) are the default mode — no badge shown.
+ */
+export function isDefaultMode(mode: string): boolean {
+  return mode === "default" || mode === "manual";
+}
+
+/**
  * Returns a human-readable label for a permission mode.
  */
 export function shortMode(mode: string): string {
   switch (mode) {
     case "default":
       return "default";
+    case "manual":
+      return "manual";
     case "acceptEdits":
       return "auto-edit";
     case "bypassPermissions":


### PR DESCRIPTION
Fixes #190

## What changed

Claude Code v2.1.200 changed the default `permission_mode` value written to session JSONL from `"default"` to `"manual"`. This caused:

1. **Unwanted badge in InfoBar** — `mode !== "default"` no longer matched the new default value, so sessions running under normal permissions showed a `manual` badge.
2. **Unstyled label in `shortMode()`** — `"manual"` had no case, so it fell through to `return mode`, displaying the raw string unstyled.

## Fix

- **`src/lib/format.ts`** — Added exported `isDefaultMode(mode)` helper that returns `true` for both `"default"` (pre-v2.1.200 sessions) and `"manual"` (v2.1.200+ sessions). Added `case "manual"` to `shortMode()` so the label renders correctly if it ever is shown.
- **`src/components/InfoBar.tsx`** — Changed permission mode pill visibility guard from `mode !== "default"` to `!isDefaultMode(mode)`, covering both old and new default values.
- **`src-tauri/src/parser/session.rs`** — Updated the fallback for empty `permission_mode` fields (old session files) from `"default"` to `"manual"` for consistency with current Claude Code behavior.
- **Tests** — Added `isDefaultMode` unit tests in `format.test.ts` and a new InfoBar test verifying no badge for `"manual"` in `InfoBar.test.tsx`.
- **Docs** — Updated `specs/04-http-api.md` example JSON to reflect current Claude Code behavior (`"manual"` instead of `"default"`).

## Backwards compatibility

Old sessions with `permission_mode: "default"` continue to work correctly — `isDefaultMode("default")` returns `true`, so no badge is shown for them either.
