### PR TITLE
fix: Sonnet 5 promotional pricing in pricing_for_model() (Fixes #189)

### DIFF
--- a/src-tauri/src/parser/subagent.rs
+++ b/src-tauri/src/parser/subagent.rs
@@ -48,8 +48,17 @@ fn pricing_for_model(model: &str) -> ModelPricing {
             cache_read: 0.1,
             cache_write: 1.25,
         }
+    } else if m.contains("sonnet-5") {
+        // Sonnet 5 promotional pricing through Aug 31, 2026.
+        // Review after promotional period ends.
+        ModelPricing {
+            input: 2.0,
+            output: 10.0,
+            cache_read: 0.2,
+            cache_write: 2.5,
+        }
     } else {
-        // Default to sonnet
+        // Default: standard Sonnet pricing (Sonnet 4.x and earlier).
         ModelPricing {
             input: 3.0,
             output: 15.0,
@@ -1862,5 +1871,56 @@ mod tests {
         assert_eq!(specs.len(), 1, "implicit team agent must produce a spec");
         assert_eq!(specs[0].0, "", "team_name must be empty for implicit agent");
         assert_eq!(specs[0].1, "worker-implicit");
+    }
+
+    // ---- pricing_for_model tests ----
+
+    #[test]
+    fn pricing_sonnet5_promotional() {
+        let p = pricing_for_model("claude-sonnet-5-20260701");
+        assert_eq!(p.input, 2.0);
+        assert_eq!(p.output, 10.0);
+        assert_eq!(p.cache_read, 0.2);
+        assert_eq!(p.cache_write, 2.5);
+    }
+
+    #[test]
+    fn pricing_sonnet5_bare() {
+        let p = pricing_for_model("claude-sonnet-5");
+        assert_eq!(p.input, 2.0);
+        assert_eq!(p.output, 10.0);
+    }
+
+    #[test]
+    fn pricing_sonnet4_uses_standard_rates() {
+        let p = pricing_for_model("claude-sonnet-4-20250514");
+        assert_eq!(p.input, 3.0);
+        assert_eq!(p.output, 15.0);
+        assert_eq!(p.cache_read, 0.3);
+        assert_eq!(p.cache_write, 3.75);
+    }
+
+    #[test]
+    fn pricing_opus_family() {
+        let p = pricing_for_model("claude-opus-4-7");
+        assert_eq!(p.input, 5.0);
+        assert_eq!(p.output, 25.0);
+        assert_eq!(p.cache_read, 0.5);
+        assert_eq!(p.cache_write, 6.25);
+    }
+
+    #[test]
+    fn pricing_haiku_family() {
+        let p = pricing_for_model("claude-haiku-4-5-20251001");
+        assert_eq!(p.input, 1.0);
+        assert_eq!(p.output, 5.0);
+        assert_eq!(p.cache_read, 0.1);
+        assert_eq!(p.cache_write, 1.25);
+    }
+
+    #[test]
+    fn pricing_model_name_case_insensitive() {
+        let p = pricing_for_model("Claude-Sonnet-5-20260701");
+        assert_eq!(p.input, 2.0, "model name matching must be case-insensitive");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #189 — `pricing_for_model()` in `src-tauri/src/parser/subagent.rs` used a single generic fallback for all Sonnet-family models at the standard Sonnet 4.x rate ($3/$15 per Mtok). Claude Code v2.1.197 made Sonnet 5 the default model, which carries promotional pricing of $2/$10 per Mtok through Aug 31, 2026 — making every session cost_usd ~33% too high.

## Changes

`src-tauri/src/parser/subagent.rs`
- Added a `sonnet-5` branch in `pricing_for_model()` matching on the "sonnet-5" substring (case-insensitive), covering claude-sonnet-5, claude-sonnet-5-YYYYMMDD, and future date-stamped variants.
- Pricing: input=$2.0, output=$10.0, cache_read=$0.2, cache_write=$2.5 (cache prices follow the 10%/1.25x ratios used by all model families).
- Existing generic Sonnet fallback ($3/$15) is preserved for Sonnet 4.x and earlier.
- Added 6 unit tests covering all four pricing tiers (opus, haiku, sonnet-5, standard sonnet) and case-insensitive matching.

## Testing

All 561 Rust unit tests and 439 frontend vitest tests pass.

New pricing tests:
- pricing_sonnet5_promotional ... ok
- pricing_sonnet5_bare ... ok
- pricing_sonnet4_uses_standard_rates ... ok
- pricing_opus_family ... ok
- pricing_haiku_family ... ok
- pricing_model_name_case_insensitive ... ok

## Notes

The promotional pricing window closes Aug 31, 2026. After that date, the sonnet-5 branch should be updated to standard Sonnet pricing (or a new tier added if Sonnet 5 ships a non-promotional rate).
