### PR TITLE
feat: show a session's end-of-session recap in the picker

### DIFF
--- a/shared/projectTree.test.ts
+++ b/shared/projectTree.test.ts
@@ -21,6 +21,7 @@ function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
     session_id: "session1",
     mod_time: "2025-01-01T00:00:00Z",
     first_message: "Hello",
+    recap: null,
     turn_count: 3,
     is_ongoing: false,
     total_tokens: 1000,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -85,6 +85,8 @@ export interface SessionInfo {
   session_id: string;
   mod_time: string;
   first_message: string;
+  /** Claude Code's end-of-session recap, when it is the session's latest entry; null otherwise. */
+  recap: string | null;
   /** User-assigned session name (Claude Code `/rename`), joined from the live
    *  session registry. `null` when never named or no longer running. */
   name?: string | null;

--- a/src-tauri/src/parser/dategroup.rs
+++ b/src-tauri/src/parser/dategroup.rs
@@ -81,6 +81,7 @@ mod tests {
             session_id: format!("session-{}", mod_time.timestamp()),
             path: "/tmp/test.jsonl".to_string(),
             first_message: "test".to_string(),
+            recap: None,
             name: None,
             mod_time,
             turn_count: 1,

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -18,6 +18,10 @@ pub struct SessionInfo {
     pub session_id: String,
     pub mod_time: DateTime<Utc>,
     pub first_message: String,
+    /// Claude Code's end-of-session recap, when it is the session's latest entry
+    /// (`away_summary`); `None` otherwise. Surfaced as an optional, richer picker
+    /// preview. Derived in `scan_session_metadata`; see `recap_from_entry`.
+    pub recap: Option<String>,
     /// User-assigned session name (Claude Code `/rename`), joined from the
     /// `~/.claude/sessions/*.json` registry. `None` when the session was never
     /// named or has no entry in the registry. The registry is pid-keyed and
@@ -358,6 +362,66 @@ fn is_session_file(name: &str, entry: &fs::DirEntry) -> bool {
         && !entry.file_type().map(|t| t.is_dir()).unwrap_or(true)
 }
 
+/// Recap text iff this parsed JSONL entry is an `away_summary` session recap
+/// (Claude Code's own end-of-session summary), else `None`. Pure and I/O-free so
+/// the metadata scan classifies each line in its existing single pass, and so the
+/// predicate is unit-testable on its own. The recap text is the top-level
+/// `content` field (a string; older shapes wrap it in `{text}` blocks).
+fn recap_from_entry(raw: &serde_json::Value) -> Option<String> {
+    if raw.get("type")?.as_str()? != "system" {
+        return None;
+    }
+    if raw.get("subtype")?.as_str()? != "away_summary" {
+        return None;
+    }
+    let text = match raw.get("content")? {
+        serde_json::Value::String(s) => s.trim().to_string(),
+        serde_json::Value::Array(blocks) => blocks
+            .iter()
+            .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_string(),
+        _ => return None,
+    };
+    (!text.is_empty()).then_some(text)
+}
+
+/// True for a genuine user turn that resumes the session, and only that. This is
+/// the single event that makes an earlier recap stale (see the recap-preview hook
+/// in `scan_session_metadata`): a recap summarises an idle return, so it should be
+/// shown only when the user has not picked the work back up after it.
+///
+/// Deliberately excluded — none of these count as the user resuming, so a recap
+/// before them survives:
+/// - **Channel events.** A channel (Claude Code's channels feature) is an MCP
+///   server that pushes events into the session so Claude can react to things
+///   happening outside the terminal — alerts, webhooks, or chat-bridge messages.
+///   Each arrives as a `user` entry wrapped in a `<channel source="…">` tag.
+///   They are pushed automatically, not typed by the user, so a burst of them
+///   after a recap does not mean the session resumed; the recap is still its real
+///   state. https://code.claude.com/docs/en/channels-reference
+/// - **Assistant turns.** An assistant reply always follows a user turn, so it
+///   never needs to clear a recap on its own, including a short acknowledgement of
+///   a channel event.
+/// - **Bookkeeping entries** (turn_duration, bridge-session, last-prompt,
+///   file-history-snapshot, queue-operation): metadata appended after a recap.
+fn is_resuming_user_turn(raw: &serde_json::Value) -> bool {
+    if raw.get("type").and_then(|v| v.as_str()) != Some("user") {
+        return false;
+    }
+    let text = match raw.get("message").and_then(|m| m.get("content")) {
+        Some(serde_json::Value::String(s)) => s.as_str(),
+        Some(serde_json::Value::Array(blocks)) => blocks
+            .iter()
+            .find_map(|b| b.get("text").and_then(|t| t.as_str()))
+            .unwrap_or(""),
+        _ => "",
+    };
+    !text.trim_start().starts_with("<channel")
+}
+
 /// Discover all session .jsonl files in a project directory.
 pub fn discover_project_sessions(project_dir: &str) -> Result<Vec<SessionInfo>, String> {
     let entries = fs::read_dir(project_dir).map_err(|e| format!("reading {project_dir}: {e}"))?;
@@ -404,6 +468,7 @@ pub fn discover_project_sessions(project_dir: &str) -> Result<Vec<SessionInfo>, 
             session_id,
             mod_time,
             first_message: meta.first_msg,
+            recap: meta.recap,
             name: None,
             turn_count: meta.turn_count,
             is_ongoing,
@@ -563,6 +628,7 @@ pub fn session_info_from_metadata(
         session_id,
         mod_time: mod_time_chrono,
         first_message: meta.first_msg,
+        recap: meta.recap,
         name: None,
         turn_count: meta.turn_count,
         is_ongoing,
@@ -635,6 +701,7 @@ pub(crate) struct SessionMetadata {
     pub(crate) cwd: String,
     pub(crate) git_branch: String,
     pub(crate) permission_mode: String,
+    pub(crate) recap: Option<String>,
 }
 
 impl Default for SessionMetadata {
@@ -654,6 +721,7 @@ impl Default for SessionMetadata {
             cwd: String::new(),
             git_branch: String::new(),
             permission_mode: String::new(),
+            recap: None,
         }
     }
 }
@@ -744,6 +812,17 @@ pub(crate) fn scan_session_metadata(path: &str) -> SessionMetadata {
             if !mode.is_empty() {
                 meta.permission_mode = mode.to_string();
             }
+        }
+
+        // Recap preview: show the recap the session was parked on. Set it on every
+        // away_summary, and clear it only when a genuine user turn resumes the
+        // session. Everything else — assistant replies, channel events, and the
+        // bookkeeping Claude Code appends after a recap — is skipped, so the recap
+        // survives it. See `is_resuming_user_turn` for the excluded cases.
+        if let Some(text) = recap_from_entry(&raw) {
+            meta.recap = Some(text);
+        } else if is_resuming_user_turn(&raw) {
+            meta.recap = None;
         }
 
         let uuid = raw.get("uuid").and_then(|v| v.as_str()).unwrap_or("");
@@ -1483,6 +1562,7 @@ mod tests {
             session_id: session_id.to_string(),
             mod_time: Utc::now(),
             first_message: "first".to_string(),
+            recap: None,
             name: None,
             turn_count: 0,
             is_ongoing: false,
@@ -1498,6 +1578,131 @@ mod tests {
             git_branch: String::new(),
             permission_mode: String::new(),
         }
+    }
+
+    #[test]
+    fn recap_from_entry_matches_away_summary_string() {
+        let v = serde_json::json!({"type":"system","subtype":"away_summary","content":"Migrated X, decided Y."});
+        assert_eq!(
+            recap_from_entry(&v).as_deref(),
+            Some("Migrated X, decided Y.")
+        );
+    }
+
+    #[test]
+    fn recap_from_entry_joins_array_content() {
+        let v = serde_json::json!({"type":"system","subtype":"away_summary","content":[{"text":"a"},{"text":"b"}]});
+        assert_eq!(recap_from_entry(&v).as_deref(), Some("a b"));
+    }
+
+    #[test]
+    fn recap_from_entry_none_for_non_recap() {
+        let v = serde_json::json!({"type":"user","message":{"role":"user","content":"hi"}});
+        assert_eq!(recap_from_entry(&v), None);
+    }
+
+    #[test]
+    fn recap_from_entry_none_for_empty_content() {
+        let v = serde_json::json!({"type":"system","subtype":"away_summary","content":"  "});
+        assert_eq!(recap_from_entry(&v), None);
+    }
+
+    #[test]
+    fn scan_surfaces_recap_only_when_it_is_the_last_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let at_end = dir.path().join("end.jsonl");
+        std::fs::write(
+            &at_end,
+            concat!(
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+                "{\"type\":\"system\",\"subtype\":\"away_summary\",\"content\":\"Did X.\"}\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            scan_session_metadata(at_end.to_str().unwrap())
+                .recap
+                .as_deref(),
+            Some("Did X.")
+        );
+
+        let mid = dir.path().join("mid.jsonl");
+        std::fs::write(
+            &mid,
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"away_summary\",\"content\":\"stale\"}\n",
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"more work\"}}\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(scan_session_metadata(mid.to_str().unwrap()).recap, None);
+    }
+
+    #[test]
+    fn scan_recap_survives_trailing_bookkeeping_entries() {
+        // Claude Code appends non-conversational bookkeeping entries after a recap
+        // (observed on real sessions: turn_duration, bridge-session, last-prompt,
+        // file-history-snapshot, queue-operation). The recap is still the last
+        // *conversational* entry, so it must survive them.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("s.jsonl");
+        std::fs::write(
+            &p,
+            concat!(
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+                "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[]}}\n",
+                "{\"type\":\"system\",\"subtype\":\"turn_duration\"}\n",
+                "{\"type\":\"system\",\"subtype\":\"away_summary\",\"content\":\"Hiring decision.\"}\n",
+                "{\"type\":\"bridge-session\"}\n",
+                "{\"type\":\"last-prompt\"}\n",
+                "{\"type\":\"file-history-snapshot\"}\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            scan_session_metadata(p.to_str().unwrap()).recap.as_deref(),
+            Some("Hiring decision.")
+        );
+
+        // But a real user/assistant turn after the recap still clears it, even
+        // with trailing bookkeeping of its own.
+        let resumed = dir.path().join("resumed.jsonl");
+        std::fs::write(
+            &resumed,
+            concat!(
+                "{\"type\":\"system\",\"subtype\":\"away_summary\",\"content\":\"stale\"}\n",
+                "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"keep going\"}}\n",
+                "{\"type\":\"bridge-session\"}\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(scan_session_metadata(resumed.to_str().unwrap()).recap, None);
+    }
+
+    #[test]
+    fn scan_recap_survives_channel_injections() {
+        // Claude Code's channels feature can post many events after a session parks
+        // on a recap — each a `<channel …>` user entry with a short assistant reply.
+        // None of that is the user resuming, so the recap must still show.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("s.jsonl");
+        let mut body = String::from(
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"build it\"}}\n\
+             {\"type\":\"system\",\"subtype\":\"away_summary\",\"content\":\"Parked cleanly.\"}\n",
+        );
+        for _ in 0..3 {
+            body.push_str(
+                "{\"type\":\"queue-operation\"}\n\
+                 {\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"<channel source=\\\"webhook\\\" type=\\\"probe\\\">ping</channel>\"}}\n\
+                 {\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Acknowledged.\"}]}}\n\
+                 {\"type\":\"system\",\"subtype\":\"turn_duration\"}\n",
+            );
+        }
+        std::fs::write(&p, &body).unwrap();
+        assert_eq!(
+            scan_session_metadata(p.to_str().unwrap()).recap.as_deref(),
+            Some("Parked cleanly.")
+        );
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { useToggleSet } from "./hooks/useToggleSet";
 import { useKeyboard } from "./hooks/useKeyboard";
 import { useViewActionsRef, useViewActionCallbacks } from "./hooks/useViewActions";
 import { useFontScale } from "./hooks/useFontScale";
+import { useRecapPreview } from "./hooks/useRecapPreview";
 import { SessionPicker } from "./components/SessionPicker";
 import { MessageList } from "./components/MessageList";
 import { MessageDetail } from "./components/MessageDetail";
@@ -37,6 +38,7 @@ export function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [collapsedKeys, setCollapsedKeys] = useState<Set<string>>(new Set());
   const [fontScale, setFontScale] = useFontScale();
+  const [recapPreview, setRecapPreview] = useRecapPreview();
   // Full (heavy-body) message for the detail view, fetched on demand since the
   // list only holds lightened messages.
   const [detailMessage, setDetailMessage] = useState<DisplayMessage | null>(null);
@@ -522,6 +524,8 @@ export function App() {
           onSaved={loadProjectDirs}
           fontScale={fontScale}
           onFontScaleChange={setFontScale}
+          recapPreview={recapPreview}
+          onRecapPreviewChange={setRecapPreview}
         />
       )}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -390,6 +390,7 @@ export function App() {
             onSearchChange={picker.setSearchQuery}
             onSelectIndex={setPickerSelectedIndex}
             onVisiblePathsChange={picker.refresh}
+            recapPreview={recapPreview}
           />
         );
 

--- a/src/components/ProjectTree.test.tsx
+++ b/src/components/ProjectTree.test.tsx
@@ -10,6 +10,7 @@ function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
     session_id: "session1",
     mod_time: "2025-01-01T00:00:00Z",
     first_message: "Hello",
+    recap: null,
     turn_count: 3,
     is_ongoing: false,
     total_tokens: 1000,

--- a/src/components/SessionPicker.test.tsx
+++ b/src/components/SessionPicker.test.tsx
@@ -158,6 +158,95 @@ describe("SessionPicker", () => {
     expect(screen.getByText(/Hello world/)).toBeInTheDocument();
   });
 
+  it("unnamed session: keeps first_message as the main line and adds the recap as the subtitle", () => {
+    const sessions = [
+      makeSession({ name: null, first_message: "just do it", recap: "Migrated X, decided Y" }),
+    ];
+    render(
+      <SessionPicker
+        sessions={sessions}
+        loading={false}
+        searchQuery=""
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onSearchChange={vi.fn()}
+        recapPreview={true}
+      />,
+    );
+    // Main line is left untouched (the first message); the recap is a second line below it.
+    expect(screen.getByText(/just do it/)).toBeInTheDocument();
+    expect(screen.getByText(/Migrated X, decided Y/)).toBeInTheDocument();
+  });
+
+  it("unnamed session: no recap subtitle when recapPreview is off", () => {
+    const sessions = [
+      makeSession({ name: null, first_message: "just do it", recap: "Migrated X" }),
+    ];
+    render(
+      <SessionPicker
+        sessions={sessions}
+        loading={false}
+        searchQuery=""
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onSearchChange={vi.fn()}
+        recapPreview={false}
+      />,
+    );
+    expect(screen.getByText(/just do it/)).toBeInTheDocument();
+    expect(screen.queryByText(/Migrated X/)).not.toBeInTheDocument();
+  });
+
+  it("named session: keeps the name as title and shows the recap as the subtitle", () => {
+    const sessions = [
+      makeSession({
+        name: "home-lab-4e",
+        first_message: "bitte lies issue 13",
+        recap: "VictoriaLogs migration planned",
+      }),
+    ];
+    render(
+      <SessionPicker
+        sessions={sessions}
+        loading={false}
+        searchQuery=""
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onSearchChange={vi.fn()}
+        recapPreview={true}
+      />,
+    );
+    // Name stays the title (a `/rename` or derived name is never replaced)...
+    expect(screen.getByText("home-lab-4e")).toHaveClass("picker__session-preview--named");
+    // ...and the recap takes the subtitle line, replacing the first message.
+    expect(screen.getByText(/VictoriaLogs migration planned/)).toBeInTheDocument();
+    expect(screen.queryByText(/bitte lies issue 13/)).not.toBeInTheDocument();
+  });
+
+  it("named session: keeps the first_message subtitle when recapPreview is off", () => {
+    const sessions = [
+      makeSession({
+        name: "home-lab-4e",
+        first_message: "bitte lies issue 13",
+        recap: "VictoriaLogs migration planned",
+      }),
+    ];
+    render(
+      <SessionPicker
+        sessions={sessions}
+        loading={false}
+        searchQuery=""
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onSearchChange={vi.fn()}
+        recapPreview={false}
+      />,
+    );
+    expect(screen.getByText("home-lab-4e")).toBeInTheDocument();
+    expect(screen.getByText(/bitte lies issue 13/)).toBeInTheDocument();
+    expect(screen.queryByText(/VictoriaLogs/)).not.toBeInTheDocument();
+  });
+
   it("shows active badge for ongoing sessions", () => {
     const sessions = [makeSession({ is_ongoing: true })];
     render(

--- a/src/components/SessionPicker.test.tsx
+++ b/src/components/SessionPicker.test.tsx
@@ -45,6 +45,7 @@ function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
     session_id: "session1",
     mod_time: new Date().toISOString(),
     first_message: "Hello world",
+    recap: null,
     turn_count: 5,
     is_ongoing: false,
     total_tokens: 2000,

--- a/src/components/SessionPicker.tsx
+++ b/src/components/SessionPicker.tsx
@@ -31,6 +31,11 @@ interface SessionPickerProps {
    * uses this as a cue to refresh fresh session info.
    */
   onVisiblePathsChange?: (paths: string[]) => void;
+  /**
+   * When true, sessions with an end-of-session recap and no user-assigned name
+   * show the full recap (instead of the truncated name/first_message) as their preview.
+   */
+  recapPreview?: boolean;
 }
 
 export function SessionPicker({
@@ -42,6 +47,7 @@ export function SessionPicker({
   onSearchChange,
   onSelectIndex,
   onVisiblePathsChange,
+  recapPreview = false,
 }: SessionPickerProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const selectedRef = useScrollToSelected(selectedIndex);
@@ -112,6 +118,7 @@ export function SessionPicker({
               const model = shortModel(session.model);
               const modelClr = getModelColor(session.model);
               const sessionCost = session.cost_usd;
+              const showRecap = recapPreview && !!session.recap;
 
               return (
                 <div
@@ -146,11 +153,15 @@ export function SessionPicker({
                       Detail <ForwardIcon />
                     </button>
                   </div>
-                  {session.name && session.first_message && (
+                  {showRecap ? (
+                    <div className="picker__session-subtitle picker__session-subtitle--recap">
+                      <span className="picker__recap-label">Recap:</span> {session.recap}
+                    </div>
+                  ) : session.name && session.first_message ? (
                     <div className="picker__session-subtitle">
                       {truncate(session.first_message, 80)}
                     </div>
-                  )}
+                  ) : null}
                   <div className="picker__session-meta">
                     <span className="picker__session-model" style={{ color: modelClr }}>
                       {model}

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -25,6 +25,7 @@ describe("SettingsModal", () => {
   const onClose = vi.fn();
   const onSaved = vi.fn();
   const onFontScaleChange = vi.fn();
+  const onRecapPreviewChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -44,6 +45,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => {
@@ -61,6 +64,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => {
@@ -79,6 +84,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => {
@@ -97,6 +104,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => {
@@ -111,6 +120,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => expect(screen.getByText(`Default: ${DEFAULT_DIR}`)).toBeInTheDocument());
@@ -138,6 +149,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => expect(screen.getByDisplayValue("/custom/path")).toBeInTheDocument());
@@ -158,6 +171,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => {
@@ -177,6 +192,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
 
@@ -200,6 +217,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
 
@@ -223,6 +242,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => expect(screen.getByText(`Default: ${DEFAULT_DIR}`)).toBeInTheDocument());
@@ -245,6 +266,8 @@ describe("SettingsModal", () => {
         onSaved={onSaved}
         fontScale={1}
         onFontScaleChange={onFontScaleChange}
+        recapPreview={true}
+        onRecapPreviewChange={onRecapPreviewChange}
       />,
     );
     await waitFor(() => expect(screen.getByText(`Default: ${DEFAULT_DIR}`)).toBeInTheDocument());
@@ -257,5 +280,21 @@ describe("SettingsModal", () => {
       expect(screen.getByText("path does not exist: /bad")).toBeInTheDocument();
     });
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("toggles recap preview via the SESSION PREVIEW control", async () => {
+    const onChange = vi.fn();
+    render(
+      <SettingsModal
+        onClose={() => {}}
+        onSaved={() => {}}
+        fontScale={1}
+        onFontScaleChange={() => {}}
+        recapPreview={true}
+        onRecapPreviewChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("switch", { name: /recap preview/i }));
+    expect(onChange).toHaveBeenCalledWith(false);
   });
 });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -18,6 +18,10 @@ interface SettingsModalProps {
   fontScale: number;
   /** Apply a new zoom level immediately (also persisted by the caller). */
   onFontScaleChange: (scale: number) => void;
+  /** Whether a session's recap replaces its list preview when it's the latest entry. */
+  recapPreview: boolean;
+  /** Toggle recap preview (persisted by the caller). */
+  onRecapPreviewChange: (on: boolean) => void;
 }
 
 /** Merge detected distros with already-configured ones so configured-but-offline
@@ -32,6 +36,8 @@ export function SettingsModal({
   onSaved,
   fontScale,
   onFontScaleChange,
+  recapPreview,
+  onRecapPreviewChange,
 }: SettingsModalProps) {
   const [projectsDir, setProjectsDir] = useState("");
   const [defaultDir, setDefaultDir] = useState("");
@@ -207,6 +213,23 @@ export function SettingsModal({
             </button>
           ))}
         </div>
+
+        <label className="settings-modal__label settings-modal__label--section">Session Preview</label>
+        <p className="settings-modal__hint">
+          Show a session's end-of-session recap as its list preview, when the recap is the latest
+          entry.
+        </p>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={recapPreview}
+          aria-label="Recap preview"
+          className={`settings-modal__toggle${recapPreview ? " settings-modal__toggle--on" : ""}`}
+          onClick={() => onRecapPreviewChange(!recapPreview)}
+        >
+          <span className="settings-modal__toggle-knob" />
+          <span className="settings-modal__toggle-label">{recapPreview ? "On" : "Off"}</span>
+        </button>
 
         {error && <p className="settings-modal__error">{error}</p>}
         <div className="settings-modal__actions">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -214,7 +214,9 @@ export function SettingsModal({
           ))}
         </div>
 
-        <label className="settings-modal__label settings-modal__label--section">Session Preview</label>
+        <label className="settings-modal__label settings-modal__label--section">
+          Session Preview
+        </label>
         <p className="settings-modal__hint">
           Show a session's end-of-session recap as its list preview, when the recap is the latest
           entry.

--- a/src/hooks/useRecapPreview.ts
+++ b/src/hooks/useRecapPreview.ts
@@ -1,0 +1,11 @@
+import { useCallback, useState } from "react";
+import { loadRecapPreview, saveRecapPreview } from "../lib/recapPreview";
+
+export function useRecapPreview(): [boolean, (on: boolean) => void] {
+  const [on, setOn] = useState(loadRecapPreview);
+  const set = useCallback((next: boolean) => {
+    setOn(next);
+    saveRecapPreview(next);
+  }, []);
+  return [on, set];
+}

--- a/src/lib/recapPreview.test.ts
+++ b/src/lib/recapPreview.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { RECAP_PREVIEW_KEY, loadRecapPreview, saveRecapPreview } from "./recapPreview";
+
+describe("recapPreview", () => {
+  beforeEach(() => localStorage.clear());
+  it("defaults to true when unset", () => {
+    expect(loadRecapPreview()).toBe(true);
+  });
+  it("round-trips false", () => {
+    saveRecapPreview(false);
+    expect(localStorage.getItem(RECAP_PREVIEW_KEY)).toBe("false");
+    expect(loadRecapPreview()).toBe(false);
+  });
+  it("ignores write failures", () => {
+    const spy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota");
+    });
+    expect(() => saveRecapPreview(false)).not.toThrow();
+    spy.mockRestore();
+  });
+});

--- a/src/lib/recapPreview.ts
+++ b/src/lib/recapPreview.ts
@@ -1,7 +1,7 @@
 /** Whether the picker uses a session's end-of-session recap as its preview.
  *  Persisted in localStorage so it survives reloads. Default ON. */
 export const RECAP_PREVIEW_KEY = "cct.recapPreview";
-export const DEFAULT_RECAP_PREVIEW = true;
+const DEFAULT_RECAP_PREVIEW = true;
 
 export function loadRecapPreview(): boolean {
   if (typeof localStorage === "undefined") return DEFAULT_RECAP_PREVIEW;

--- a/src/lib/recapPreview.ts
+++ b/src/lib/recapPreview.ts
@@ -1,0 +1,20 @@
+/** Whether the picker uses a session's end-of-session recap as its preview.
+ *  Persisted in localStorage so it survives reloads. Default ON. */
+export const RECAP_PREVIEW_KEY = "cct.recapPreview";
+export const DEFAULT_RECAP_PREVIEW = true;
+
+export function loadRecapPreview(): boolean {
+  if (typeof localStorage === "undefined") return DEFAULT_RECAP_PREVIEW;
+  const raw = localStorage.getItem(RECAP_PREVIEW_KEY);
+  if (raw === null) return DEFAULT_RECAP_PREVIEW;
+  return raw !== "false";
+}
+
+export function saveRecapPreview(on: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(RECAP_PREVIEW_KEY, String(on));
+  } catch {
+    // Storage may be full or disabled; the in-memory setting still applies.
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2671,6 +2671,49 @@ body {
   color: #fff;
 }
 
+.settings-modal__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.settings-modal__toggle:hover {
+  background: var(--bg-hover);
+}
+
+.settings-modal__toggle--on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.settings-modal__toggle--on:hover {
+  background: #4a9aee;
+}
+
+.settings-modal__toggle-knob {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  transition: background 0.15s ease;
+}
+
+.settings-modal__toggle--on .settings-modal__toggle-knob {
+  background: #fff;
+}
+
 .settings-modal__input {
   width: 100%;
   padding: 6px 8px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1009,6 +1009,10 @@ body {
   font-weight: 600;
 }
 
+.picker__recap-label {
+  color: var(--text-dim);
+}
+
 .picker__session-subtitle {
   margin-top: 2px;
   color: var(--text-dim);
@@ -1016,6 +1020,15 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Recap shown as the subtitle under a named session: wrap in full (~2-3 lines)
+   rather than truncating to one line, since a recap is a compact summary. */
+.picker__session-subtitle--recap {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  line-height: 1.4;
 }
 
 .picker__session-ongoing {
@@ -2685,7 +2698,10 @@ body {
   font-size: 12px;
   font-family: inherit;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .settings-modal__toggle:hover {

--- a/tui-py/data_types.py
+++ b/tui-py/data_types.py
@@ -116,6 +116,7 @@ class SessionInfo:
     mod_time: str = ""
     first_message: str = ""
     name: str = ""
+    recap: str | None = None
     turn_count: int = 0
     is_ongoing: bool = False
     total_tokens: int = 0
@@ -319,6 +320,7 @@ def session_info_from_dict(d: dict) -> SessionInfo:
         mod_time=d.get("mod_time", ""),
         first_message=d.get("first_message", ""),
         name=d.get("name") or "",
+        recap=d.get("recap"),
         turn_count=int(d.get("turn_count", 0)),
         is_ongoing=bool(d.get("is_ongoing", False)),
         total_tokens=int(d.get("total_tokens", 0)),

--- a/tui-py/tests/test_data_types_recap.py
+++ b/tui-py/tests/test_data_types_recap.py
@@ -1,0 +1,17 @@
+"""Tests for SessionInfo.recap mapping, mirroring the Rust end-of-session recap field."""
+
+from __future__ import annotations
+
+from data_types import session_info_from_dict
+
+
+def test_recap_parsed_from_dict():
+    info = session_info_from_dict(
+        {"path": "p", "session_id": "id", "first_message": "hi", "recap": "did X"}
+    )
+    assert info.recap == "did X"
+
+
+def test_recap_defaults_none_when_absent():
+    info = session_info_from_dict({"path": "p", "session_id": "id", "first_message": "hi"})
+    assert info.recap is None


### PR DESCRIPTION
Claude Code writes a recap (an `away_summary`, or a manual `/recap`) that summarizes where a session got to. The picker now shows it, so each row reflects where the session ended rather than its first prompt.

## What

When a session's latest entry is a recap, the picker shows it in full with a dim `Recap:` prefix on the second line (the subtitle). For a named session the recap replaces the first-message subtitle; for an unnamed session it is added below the first message. The main line stays unchanged, and sessions without an end-of-session recap look the same as before. A Session Preview toggle in Settings turns the recap on or off. It defaults to on and is stored in `localStorage`, like the font-size setting.

The recap does not replace the name. Most registry names are auto-derived slugs (`nameSource: "derived"`), so hiding the recap whenever a name exists would suppress it on nearly every session. Keeping the name as the title and the recap as the subtitle shows both, and a derived slug can be replaced with `/rename`.

Only a genuine user turn ends a recap. The scan sets the recap on each idle-return summary and clears it only when the user resumes with a real message. It skips the bookkeeping Claude Code appends after a recap (turn duration, bridge-session, file-history snapshots) and channel events (Claude Code's [channels](https://code.claude.com/docs/en/channels-reference) feature, where an MCP server pushes alerts, webhooks, or chat messages into the session, each arriving as a `<channel source="…">` user entry), because neither is the user picking the work back up. A recap with real work after it is ignored; a recap the session merely parked on is shown.

## Why / how

`scan_session_metadata` computes the recap in its existing pass: a pure `recap_from_entry(&Value)` predicate runs on each parsed line, and the last parsed line's value is kept. This adds no extra file I/O. The existing `away_summary` handling in `classify.rs` is unchanged. `SessionInfo.recap` is a new optional field, mirrored across the Rust, TypeScript, and Python (TUI) types for shared-shape parity. The TUI carries the field for parity only and does not render it, because a `localStorage` toggle has no TUI equivalent.

## Verification

- `npm run check` passes (tsc, oxlint, oxfmt, clippy, cargo fmt, vitest, cargo test). In `tui-py`, `ruff check` and `pytest` pass.
- Headless end-to-end on real sessions: 11 of 61 sessions end on a recap and now show it as the subtitle; toggling Session Preview off restores the first message. The browser console stayed clean.

---
🤖 Drafted with Claude Code, reviewed before submitting.
