### PR TITLE
feat(toolbar): scope actions to the view and group them on the right

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,7 +207,8 @@ export function App() {
   // -- View actions: each view registers its own expand/collapse handlers --
 
   const viewActionsRef = useViewActionsRef();
-  const { expandAll, collapseAll } = useViewActionCallbacks(viewActionsRef);
+  const { expandAll, collapseAll, scrollToTop, scrollToBottom } =
+    useViewActionCallbacks(viewActionsRef);
 
   // Register message list expand/collapse when in list view. Uses the role
   // index so it works over the whole session without loading every body.
@@ -391,6 +392,7 @@ export function App() {
             onSelectIndex={setPickerSelectedIndex}
             onVisiblePathsChange={picker.refresh}
             recapPreview={recapPreview}
+            viewActionsRef={viewActionsRef}
           />
         );
 
@@ -484,6 +486,8 @@ export function App() {
         onGoToSessions={goToSessions}
         onExpandAll={expandAll}
         onCollapseAll={collapseAll}
+        onScrollToTop={scrollToTop}
+        onScrollToBottom={scrollToBottom}
         onOpenTeams={openTeams}
         onOpenDebug={openDebug}
         onBackToList={backToList}

--- a/src/components/MessageList.test.tsx
+++ b/src/components/MessageList.test.tsx
@@ -9,35 +9,51 @@ import type { ViewActions } from "../hooks/useViewActions";
 // so it would render nothing in tests. Mock it to render every row via
 // itemContent(index, undefined, context) — these tests exercise MessageList's
 // row rendering/callbacks, not the windowing.
-vi.mock("react-virtuoso", () => ({
-  Virtuoso: ({
-    totalCount = 0,
-    itemContent,
-    context,
-    className,
-    isScrolling,
-  }: {
-    totalCount?: number;
-    itemContent: (index: number, data: unknown, context: unknown) => ReactNode;
-    context?: unknown;
-    className?: string;
-    isScrolling?: (scrolling: boolean) => void;
-  }) => (
-    <div className={className}>
-      {/* Test-only hooks to simulate Virtuoso reporting scroll start/stop. */}
-      <button type="button" data-testid="simulate-scrolling" onClick={() => isScrolling?.(true)} />
-      <button
-        type="button"
-        data-testid="simulate-scroll-stop"
-        onClick={() => isScrolling?.(false)}
-      />
-      {Array.from({ length: totalCount }, (_, index) => (
-        // oxlint-disable-next-line react/no-array-index-key
-        <div key={index}>{itemContent(index, undefined, context)}</div>
-      ))}
-    </div>
-  ),
-}));
+// A hoisted spy for the Virtuoso imperative handle so tests can assert scrolls.
+const virtuoso = vi.hoisted(() => ({ scrollToIndex: vi.fn() }));
+
+vi.mock("react-virtuoso", async () => {
+  const React = (await vi.importActual("react")) as typeof import("react");
+  return {
+    Virtuoso: React.forwardRef(function VirtuosoMock(
+      {
+        totalCount = 0,
+        itemContent,
+        context,
+        className,
+        isScrolling,
+      }: {
+        totalCount?: number;
+        itemContent: (index: number, data: unknown, context: unknown) => ReactNode;
+        context?: unknown;
+        className?: string;
+        isScrolling?: (scrolling: boolean) => void;
+      },
+      ref: React.Ref<{ scrollToIndex: (i: number) => void }>,
+    ) {
+      React.useImperativeHandle(ref, () => ({ scrollToIndex: virtuoso.scrollToIndex }));
+      return (
+        <div className={className}>
+          {/* Test-only hooks to simulate Virtuoso reporting scroll start/stop. */}
+          <button
+            type="button"
+            data-testid="simulate-scrolling"
+            onClick={() => isScrolling?.(true)}
+          />
+          <button
+            type="button"
+            data-testid="simulate-scroll-stop"
+            onClick={() => isScrolling?.(false)}
+          />
+          {Array.from({ length: totalCount }, (_, index) => (
+            // oxlint-disable-next-line react/no-array-index-key
+            <div key={index}>{itemContent(index, undefined, context)}</div>
+          ))}
+        </div>
+      );
+    }),
+  };
+});
 
 function makeMessage(overrides: Partial<DisplayMessage> = {}): DisplayMessage {
   return {
@@ -337,5 +353,21 @@ describe("selectionScrollTarget", () => {
 
   it("aligns to the end when the selection is below the window", () => {
     expect(selectionScrollTarget(15, range)).toEqual({ index: 15, align: "end" });
+  });
+});
+
+describe("MessageList toolbar scroll registration", () => {
+  it("registers scrollToTop/scrollToBottom that scroll virtuoso (reversed: top = newest = last index)", () => {
+    virtuoso.scrollToIndex.mockClear();
+    const messages = [makeMessage(), makeMessage(), makeMessage()]; // count === 3
+    const viewActionsRef = createRef() as React.MutableRefObject<ViewActions>;
+    render(<MessageList {...defaultProps({ messages, viewActionsRef })} />);
+
+    expect(viewActionsRef.current.scrollToTop).toBeTypeOf("function");
+    viewActionsRef.current.scrollToTop!();
+    expect(virtuoso.scrollToIndex).toHaveBeenCalledWith(2); // newest at the visual top
+
+    viewActionsRef.current.scrollToBottom!();
+    expect(virtuoso.scrollToIndex).toHaveBeenCalledWith(0); // oldest at the visual bottom
   });
 });

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -103,9 +103,17 @@ export function MessageList({
   onExpandAll,
   onCollapseAll,
 }: MessageListProps) {
-  useRegisterViewActions(viewActionsRef, { expandAll: onExpandAll, collapseAll: onCollapseAll });
-
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+
+  // The message list is displayed reversed (newest first), so the visual top is
+  // the last index and the visual bottom is index 0 — matching the keyboard
+  // Top/Bottom jumps in App.
+  useRegisterViewActions(viewActionsRef, {
+    expandAll: onExpandAll,
+    collapseAll: onCollapseAll,
+    scrollToTop: () => virtuosoRef.current?.scrollToIndex(Math.max(0, count - 1)),
+    scrollToBottom: () => virtuosoRef.current?.scrollToIndex(0),
+  });
   // Track the currently rendered window so we only scroll when the selection
   // leaves it — mirrors the old "no-op if already visible" behaviour.
   const rangeRef = useRef({ startIndex: 0, endIndex: 0 });

--- a/src/components/SessionPicker.test.tsx
+++ b/src/components/SessionPicker.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { SessionPicker } from "./SessionPicker";
 import type { SessionInfo } from "../types";
+import type { ViewActions } from "../hooks/useViewActions";
 
 type IOCallback = (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => void;
 
@@ -406,6 +407,40 @@ describe("SessionPicker", () => {
           />,
         ),
       ).not.toThrow();
+    });
+  });
+
+  describe("toolbar scroll actions", () => {
+    it("registers scrollToTop/scrollToBottom that scroll the session list", () => {
+      const viewActionsRef = { current: {} as ViewActions };
+      const sessions = [
+        makeSession(),
+        makeSession({ session_id: "s2", path: "/home/user/.claude/projects/proj/s2.jsonl" }),
+      ];
+
+      render(
+        <SessionPicker
+          sessions={sessions}
+          loading={false}
+          searchQuery=""
+          selectedIndex={0}
+          onSelect={vi.fn()}
+          onSearchChange={vi.fn()}
+          viewActionsRef={viewActionsRef}
+        />,
+      );
+
+      const list = document.querySelector(".picker__list") as HTMLElement;
+      // jsdom has no layout: fake a scrollable height so top != bottom.
+      Object.defineProperty(list, "scrollHeight", { value: 5000, configurable: true });
+      const scrollTo = vi.fn();
+      list.scrollTo = scrollTo as unknown as typeof list.scrollTo;
+
+      act(() => viewActionsRef.current.scrollToBottom?.());
+      expect(scrollTo).toHaveBeenCalledWith({ top: 5000, behavior: "smooth" });
+
+      act(() => viewActionsRef.current.scrollToTop?.());
+      expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
     });
   });
 });

--- a/src/components/SessionPicker.tsx
+++ b/src/components/SessionPicker.tsx
@@ -1,6 +1,7 @@
 import { useRef, useMemo } from "react";
 import { useScrollToSelected } from "../hooks/useScrollToSelected";
 import { useVisibleSessions } from "../hooks/useVisibleSessions";
+import { useRegisterViewActions, type ViewActionsRef } from "../hooks/useViewActions";
 import type { SessionInfo } from "../types";
 import { OngoingDots } from "./OngoingDots";
 import {
@@ -36,6 +37,11 @@ interface SessionPickerProps {
    * show the full recap (instead of the truncated name/first_message) as their preview.
    */
   recapPreview?: boolean;
+  /**
+   * Shared toolbar-action registry. The picker registers Top/Bottom so they
+   * scroll its own list; without it the toolbar's scroll buttons are inert here.
+   */
+  viewActionsRef?: ViewActionsRef;
 }
 
 export function SessionPicker({
@@ -48,11 +54,21 @@ export function SessionPicker({
   onSelectIndex,
   onVisiblePathsChange,
   recapPreview = false,
+  viewActionsRef,
 }: SessionPickerProps) {
   const listRef = useRef<HTMLDivElement>(null);
   const selectedRef = useScrollToSelected(selectedIndex);
   const searchRef = useRef<HTMLInputElement>(null);
   const registerVisible = useVisibleSessions(onVisiblePathsChange ?? noop);
+
+  // Register Top/Bottom against the picker's own scroll container. Falls back to
+  // a local ref when no registry is supplied (e.g. in isolated tests).
+  const fallbackActionsRef = useRef({});
+  useRegisterViewActions(viewActionsRef ?? fallbackActionsRef, {
+    scrollToTop: () => listRef.current?.scrollTo({ top: 0, behavior: "smooth" }),
+    scrollToBottom: () =>
+      listRef.current?.scrollTo({ top: listRef.current.scrollHeight, behavior: "smooth" }),
+  });
 
   const dateGroups = groupByDate(sessions);
 

--- a/src/components/ViewToolbar.test.tsx
+++ b/src/components/ViewToolbar.test.tsx
@@ -2,6 +2,13 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ViewToolbar } from "./ViewToolbar";
 
+/** Rendered toolbar button labels, in DOM order (icons/settings have no text). */
+function buttonOrder() {
+  return [...document.querySelectorAll(".view-toolbar__btn")]
+    .map((b) => b.textContent?.trim())
+    .filter(Boolean);
+}
+
 function defaultProps(overrides: Partial<Parameters<typeof ViewToolbar>[0]> = {}) {
   return {
     view: "list" as const,
@@ -10,6 +17,8 @@ function defaultProps(overrides: Partial<Parameters<typeof ViewToolbar>[0]> = {}
     onGoToSessions: vi.fn(),
     onExpandAll: vi.fn(),
     onCollapseAll: vi.fn(),
+    onScrollToTop: vi.fn(),
+    onScrollToBottom: vi.fn(),
     onOpenTeams: vi.fn(),
     onOpenDebug: vi.fn(),
     onBackToList: vi.fn(),
@@ -19,8 +28,9 @@ function defaultProps(overrides: Partial<Parameters<typeof ViewToolbar>[0]> = {}
 }
 
 describe("ViewToolbar", () => {
-  describe("common buttons on all views", () => {
-    for (const view of ["list", "picker", "detail", "team", "debug"] as const) {
+  describe("common buttons on views with collapsible content", () => {
+    // The picker has no collapsible entries, so it is handled separately below.
+    for (const view of ["list", "detail", "team", "debug"] as const) {
       it(`${view} view shows Expand All, Collapse All, Top, Bottom`, () => {
         render(<ViewToolbar {...defaultProps({ view, hasSession: true })} />);
         expect(screen.getByText("Expand All")).toBeInTheDocument();
@@ -30,6 +40,15 @@ describe("ViewToolbar", () => {
         expect(screen.getByTitle("Settings")).toBeInTheDocument();
       });
     }
+
+    it("Top and Bottom call the scroll callbacks", () => {
+      const props = defaultProps({ view: "list" });
+      render(<ViewToolbar {...props} />);
+      fireEvent.click(screen.getByText("Top"));
+      expect(props.onScrollToTop).toHaveBeenCalled();
+      fireEvent.click(screen.getByText("Bottom"));
+      expect(props.onScrollToBottom).toHaveBeenCalled();
+    });
   });
 
   describe("list view", () => {
@@ -67,6 +86,23 @@ describe("ViewToolbar", () => {
   });
 
   describe("picker view", () => {
+    it("shows Top and Bottom but not the inert Expand/Collapse", () => {
+      render(<ViewToolbar {...defaultProps({ view: "picker", hasSession: true })} />);
+      expect(screen.getByText("Top")).toBeInTheDocument();
+      expect(screen.getByText("Bottom")).toBeInTheDocument();
+      expect(screen.queryByText("Expand All")).not.toBeInTheDocument();
+      expect(screen.queryByText("Collapse All")).not.toBeInTheDocument();
+    });
+
+    it("Top and Bottom scroll the picker via the callbacks", () => {
+      const props = defaultProps({ view: "picker", hasSession: true });
+      render(<ViewToolbar {...props} />);
+      fireEvent.click(screen.getByText("Top"));
+      expect(props.onScrollToTop).toHaveBeenCalled();
+      fireEvent.click(screen.getByText("Bottom"));
+      expect(props.onScrollToBottom).toHaveBeenCalled();
+    });
+
     it("shows Back to Messages when hasSession=true", () => {
       render(<ViewToolbar {...defaultProps({ view: "picker", hasSession: true })} />);
       expect(screen.getByText(/Back to Messages/)).toBeInTheDocument();
@@ -93,6 +129,31 @@ describe("ViewToolbar", () => {
       render(<ViewToolbar {...props} />);
       fireEvent.click(screen.getByText(/Back to Messages/));
       expect(props.onBackToList).toHaveBeenCalled();
+    });
+  });
+
+  describe("content actions live in the right cluster", () => {
+    it("list view: navigation first, then content actions (Expand/Collapse/Top/Bottom)", () => {
+      render(<ViewToolbar {...defaultProps({ view: "list", hasTeams: false })} />);
+      expect(buttonOrder()).toEqual([
+        "Sessions",
+        "Debug",
+        "Expand All",
+        "Collapse All",
+        "Top",
+        "Bottom",
+      ]);
+    });
+
+    it("detail view: back nav first, then content actions", () => {
+      render(<ViewToolbar {...defaultProps({ view: "detail" })} />);
+      expect(buttonOrder()).toEqual([
+        "Back to Messages",
+        "Expand All",
+        "Collapse All",
+        "Top",
+        "Bottom",
+      ]);
     });
   });
 });

--- a/src/components/ViewToolbar.tsx
+++ b/src/components/ViewToolbar.tsx
@@ -11,47 +11,84 @@ interface ViewToolbarProps {
   onGoToSessions: () => void;
   onExpandAll: () => void;
   onCollapseAll: () => void;
+  onScrollToTop: () => void;
+  onScrollToBottom: () => void;
   onOpenTeams: () => void;
   onOpenDebug: () => void;
   onBackToList: () => void;
   onOpenSettings: () => void;
 }
 
-function scrollContent(to: "top" | "bottom") {
-  const el = document.querySelector(".main-content");
-  if (el) el.scrollTo({ top: to === "top" ? 0 : el.scrollHeight, behavior: "smooth" });
-}
-
-function CommonButtons({
+/**
+ * Content-scoped actions — they act on the main content column (the session list
+ * or the message list), so they live in the RIGHT cluster, above that column,
+ * not on the left above the PROJECTS sidebar. Expand/Collapse only apply where
+ * there are collapsible entries (`collapsible`); Top/Bottom always apply.
+ */
+function ContentActions({
+  collapsible,
   onExpandAll,
   onCollapseAll,
+  onScrollToTop,
+  onScrollToBottom,
 }: {
+  collapsible: boolean;
   onExpandAll: () => void;
   onCollapseAll: () => void;
+  onScrollToTop: () => void;
+  onScrollToBottom: () => void;
 }) {
   return (
     <>
-      <button className="view-toolbar__btn" onClick={onExpandAll}>
-        Expand All
-      </button>
-      <button className="view-toolbar__btn" onClick={onCollapseAll}>
-        Collapse All
-      </button>
-      <span className="view-toolbar__separator" />
-      <button className="view-toolbar__btn" onClick={() => scrollContent("top")}>
+      {collapsible && (
+        <>
+          <button className="view-toolbar__btn" onClick={onExpandAll}>
+            Expand All
+          </button>
+          <button className="view-toolbar__btn" onClick={onCollapseAll}>
+            Collapse All
+          </button>
+          <span className="view-toolbar__separator" />
+        </>
+      )}
+      <button className="view-toolbar__btn" onClick={onScrollToTop}>
         Top
       </button>
-      <button className="view-toolbar__btn" onClick={() => scrollContent("bottom")}>
+      <button className="view-toolbar__btn" onClick={onScrollToBottom}>
         Bottom
       </button>
     </>
   );
 }
 
-function RightButtons({ onOpenSettings }: { onOpenSettings: () => void }) {
+/** Right cluster: spacer pushes it to the right edge, then content actions,
+ * then the app-level Open-in-Browser / Settings. */
+function RightCluster({
+  collapsible,
+  onExpandAll,
+  onCollapseAll,
+  onScrollToTop,
+  onScrollToBottom,
+  onOpenSettings,
+}: {
+  collapsible: boolean;
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
+  onScrollToTop: () => void;
+  onScrollToBottom: () => void;
+  onOpenSettings: () => void;
+}) {
   return (
     <>
       <span className="view-toolbar__spacer" />
+      <ContentActions
+        collapsible={collapsible}
+        onExpandAll={onExpandAll}
+        onCollapseAll={onCollapseAll}
+        onScrollToTop={onScrollToTop}
+        onScrollToBottom={onScrollToBottom}
+      />
+      <span className="view-toolbar__separator" />
       {isTauri && (
         <button
           className="view-toolbar__btn"
@@ -79,19 +116,30 @@ export function ViewToolbar({
   onGoToSessions,
   onExpandAll,
   onCollapseAll,
+  onScrollToTop,
+  onScrollToBottom,
   onOpenTeams,
   onOpenDebug,
   onBackToList,
   onOpenSettings,
 }: ViewToolbarProps) {
+  const right = (collapsible: boolean) => (
+    <RightCluster
+      collapsible={collapsible}
+      onExpandAll={onExpandAll}
+      onCollapseAll={onCollapseAll}
+      onScrollToTop={onScrollToTop}
+      onScrollToBottom={onScrollToBottom}
+      onOpenSettings={onOpenSettings}
+    />
+  );
+
   if (view === "list") {
     return (
       <div className="view-toolbar">
         <button className="view-toolbar__btn" onClick={onGoToSessions}>
           <BackIcon /> Sessions
         </button>
-        <CommonButtons onExpandAll={onExpandAll} onCollapseAll={onCollapseAll} />
-        <span className="view-toolbar__separator" />
         {hasTeams && (
           <button className="view-toolbar__btn" onClick={onOpenTeams}>
             Teams
@@ -100,7 +148,7 @@ export function ViewToolbar({
         <button className="view-toolbar__btn" onClick={onOpenDebug}>
           Debug
         </button>
-        <RightButtons onOpenSettings={onOpenSettings} />
+        {right(true)}
       </div>
     );
   }
@@ -113,8 +161,8 @@ export function ViewToolbar({
             <BackIcon /> Back to Messages
           </button>
         )}
-        <CommonButtons onExpandAll={onExpandAll} onCollapseAll={onCollapseAll} />
-        <RightButtons onOpenSettings={onOpenSettings} />
+        {/* Picker has no collapsible entries — only scroll actions apply. */}
+        {right(false)}
       </div>
     );
   }
@@ -125,8 +173,7 @@ export function ViewToolbar({
       <button className="view-toolbar__btn" onClick={onBackToList}>
         <BackIcon /> Back to Messages
       </button>
-      <CommonButtons onExpandAll={onExpandAll} onCollapseAll={onCollapseAll} />
-      <RightButtons onOpenSettings={onOpenSettings} />
+      {right(true)}
     </div>
   );
 }

--- a/src/hooks/useViewActions.test.ts
+++ b/src/hooks/useViewActions.test.ts
@@ -46,4 +46,22 @@ describe("useViewActions", () => {
     unmount();
     expect(refResult.current.current.expandAll).toBeUndefined();
   });
+
+  it("scroll callbacks delegate to registered handlers", () => {
+    const top = vi.fn();
+    const bottom = vi.fn();
+
+    const { result: refResult } = renderHook(() => useViewActionsRef());
+    const { result: cbResult } = renderHook(() => useViewActionCallbacks(refResult.current));
+
+    renderHook(() =>
+      useRegisterViewActions(refResult.current, { scrollToTop: top, scrollToBottom: bottom }),
+    );
+
+    act(() => cbResult.current.scrollToTop());
+    act(() => cbResult.current.scrollToBottom());
+
+    expect(top).toHaveBeenCalledTimes(1);
+    expect(bottom).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/hooks/useViewActions.ts
+++ b/src/hooks/useViewActions.ts
@@ -4,6 +4,8 @@ import { useRef, useEffect, useCallback, type MutableRefObject } from "react";
 export interface ViewActions {
   expandAll?: () => void;
   collapseAll?: () => void;
+  scrollToTop?: () => void;
+  scrollToBottom?: () => void;
 }
 
 export type ViewActionsRef = MutableRefObject<ViewActions>;
@@ -30,5 +32,7 @@ export function useRegisterViewActions(ref: ViewActionsRef, actions: ViewActions
 export function useViewActionCallbacks(ref: ViewActionsRef) {
   const expandAll = useCallback(() => ref.current.expandAll?.(), [ref]);
   const collapseAll = useCallback(() => ref.current.collapseAll?.(), [ref]);
-  return { expandAll, collapseAll };
+  const scrollToTop = useCallback(() => ref.current.scrollToTop?.(), [ref]);
+  const scrollToBottom = useCallback(() => ref.current.scrollToBottom?.(), [ref]);
+  return { expandAll, collapseAll, scrollToTop, scrollToBottom };
 }


### PR DESCRIPTION
<!-- Title (gh pr create --title): "feat(toolbar): scope actions to the active view and group content actions on the right" -->
<!-- BEFORE SUBMIT: 4 screenshots to drag in below under "Before / after" (see UPLOAD markers): pr-picker-before.png, pr-picker-after.png, pr-messages-before.png, pr-messages-after.png. Left-over UPLOAD comments render invisibly, so they are harmless if missed. -->

## Summary

The top toolbar is shared across every view, but a few of its actions don't fit the view they appear in — and two don't work at all. This PR makes `Top`/`Bottom` actually scroll, hides `Expand All`/`Collapse All` where there's nothing to expand, and groups the content actions on the side of the window they act on.

The scroll wiring reuses the existing `viewActionsRef` registry (the same one already driving Expand/Collapse), so it's additive rather than a new global.

## What changed

- **`Top` / `Bottom` now scroll.** They called `scrollContent(".main-content")`, but `.main-content` is `overflow: hidden` and isn't the scroll container, so they were no-ops in every view. Each view now registers its own scroller through `viewActionsRef` — the picker scrolls `.picker__list`, the message list scrolls through the Virtuoso handle (reversed indices, so the visual top is the newest message, matching the keyboard jumps).
- **`Expand All` / `Collapse All` are hidden in the picker.** The session list has no collapsible entries, so the two buttons had no effect there. The list, detail, and debug views keep them.
- **Content actions moved to the right cluster.** `Expand`/`Collapse`/`Top`/`Bottom` sat on the left, above the `PROJECTS` sidebar, yet they act on the right column. They now live on the right, above the content they scroll, next to Settings. The left keeps navigation (`Sessions` / `Back to Messages` / `Debug`).

## Before / after

Picker — `Top`/`Bottom` were dead and sat over the sidebar; `Expand`/`Collapse` did nothing here.

<img width="1300" height="820" alt="pr-picker-before" src="https://github.com/user-attachments/assets/5103ea63-41f7-4939-a4a1-f7453b6afe85" />
<img width="1300" height="820" alt="pr-picker-after" src="https://github.com/user-attachments/assets/cb2fe3e1-bcce-4726-abc2-c2b9b9d10a84" />

Message list — content actions were crammed on the left; now grouped on the right, over the content.

<img width="1300" height="820" alt="pr-messages-before" src="https://github.com/user-attachments/assets/76b3b324-8f32-4fef-a696-c08eab298756" />
<img width="1300" height="820" alt="pr-messages-after" src="https://github.com/user-attachments/assets/6d27702b-7a5f-488f-8262-0fa4397c8eac" />

(Web UI, session text redacted.)

## Why the regrouping

The functional fixes — scrolling, hiding the inert buttons — are unambiguous. The regrouping is the opinionated part: it lines each control up with the column it affects, and leaves the picker (the entry screen) showing only the actions that apply there. It's your call on the layout, so I'm glad to split it into a follow-up if you'd rather take just the fixes.

## Verification

`npm run check` passes end to end:

- **tsc / oxlint / oxfmt** — clean
- **vitest** — 457 pass, with new coverage for per-view scroll registration (`SessionPicker`, `MessageList`), the picker hiding Expand/Collapse, `Top`/`Bottom` calling the callbacks, and toolbar button order (navigation before content actions)
- **cargo fmt / clippy `-D warnings` / test** — clean, 568+2 (unchanged; the diff is frontend-only, no Rust or Python TUI touched)

The unit tests cover the wiring and the grouping. The scroll itself I checked in a browser — clicking `Bottom` moves `.picker__list` scrollTop from `0` to ~`3165`, and `Top` brings it back — since vitest runs in jsdom, which has no layout.

<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
