### PR TITLE
feat: resume, fork, or focus the session you're viewing

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -90,6 +90,10 @@ export interface SessionInfo {
   /** User-assigned session name (Claude Code `/rename`), joined from the live
    *  session registry. `null` when never named or no longer running. */
   name?: string | null;
+  /** Live-session liveness from the pid-keyed registry; null when not running.
+   *  `status` is an open string (Claude-Code-internal, may gain values) — the
+   *  badge special-cases "busy"/"idle" and renders anything else neutrally. */
+  liveness?: { status: string; idle_seconds: number; pid: number } | null;
   turn_count: number;
   is_ongoing: boolean;
   total_tokens: number;

--- a/specs/03-state-management.md
+++ b/specs/03-state-management.md
@@ -201,6 +201,27 @@ fresh), `discover_sessions_cached` joins the live `/rename` session-name registr
 via the short-TTL `session_names_cache` (1 s) — a rename never touches the JSONL file, so the
 transcript-file cache above cannot see it, and the name registry is joined after the fact.
 
+### Registry Format Dependency (Compat)
+
+`read_session_registry` (`src-tauri/src/parser/session.rs`) reads the same
+`~/.claude/sessions/*.json` files as the name join above, plus the fields
+`apply_liveness` needs to derive `SessionInfo.liveness`:
+
+| Field             | Used for                                                 | Observed Claude Code version |
+| ----------------- | -------------------------------------------------------- | ---------------------------- |
+| `status`          | `Liveness.status` (open string, e.g. `busy`/`idle`)      | v2.1.202                     |
+| `statusUpdatedAt` | `Liveness.idle_seconds = (now - statusUpdatedAt) / 1000` | v2.1.202                     |
+| `pid`             | staleness guard (`is_pid_alive`) + `Liveness.pid`        | v2.1.202                     |
+| `bridgeSessionId` | parsed and retained on `RegEntry`, not yet surfaced      | v2.1.202                     |
+
+Parsed the same lenient way as the name join (`serde_json::Value` + `.get().and_then(as_str/as_i64)`,
+skip-on-error per file, never panic). `registry_reads_status_and_guards_stale_pid`
+(`session.rs`) pins the exact fixture shape, so a future Claude Code rename/retype of
+any of these fields surfaces as a failing test — not a silently dead liveness feature.
+`status` is kept as an open `String` rather than an enum for the same reason
+`hook_event` is (see [01-parser-pipeline.md](./01-parser-pipeline.md)): a new
+status value must render neutrally, not fail to parse.
+
 ---
 
 ## Watched Session Ongoing Override

--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -17,6 +17,7 @@ permissions = [
   "allow-list-wsl-distros",
   "allow-set-wsl-distros",
   "allow-switch-to-browser",
+  "allow-focus-session-window",
 ]
 
 [[permission]]
@@ -98,3 +99,8 @@ commands.allow = ["set_wsl_distros"]
 identifier = "allow-switch-to-browser"
 description = "Allow switching to browser mode"
 commands.allow = ["switch_to_browser"]
+
+[[permission]]
+identifier = "allow-focus-session-window"
+description = "Allow focusing a live session's terminal window"
+commands.allow = ["focus_session_window"]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod git;
 pub mod picker;
 pub mod session;
 pub mod settings;
+pub mod terminal;
 pub mod wsl;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -18,6 +18,11 @@ pub struct SettingsResponse {
     pub effective_dir_exists: bool,
     /// WSL distributions whose projects are also discovered.
     pub wsl_distros: Vec<String>,
+    /// Whether this backend can focus a session's terminal window (see
+    /// `commands::terminal::can_focus`). Drives the frontend's Focus button —
+    /// true for any local + macOS backend, whether the frontend is the Tauri
+    /// app or a browser talking to the HTTP API.
+    pub can_focus: bool,
 }
 
 pub fn platform_default_dir() -> String {
@@ -41,6 +46,7 @@ pub fn build_response_pub(settings: &crate::settings::Settings) -> SettingsRespo
         effective_dir: effective.to_string_lossy().to_string(),
         effective_dir_exists,
         wsl_distros: settings.wsl_distros.clone(),
+        can_focus: crate::commands::terminal::can_focus(),
     }
 }
 
@@ -69,4 +75,19 @@ pub async fn set_projects_dir(
     guard.projects_dir = path;
     crate::settings::save_settings(&guard)?;
     Ok(build_response_pub(&guard))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_response_serializes_can_focus() {
+        let response = build_response_pub(&crate::settings::Settings::default());
+        let json = serde_json::to_value(&response).expect("serializes");
+        assert_eq!(
+            json.get("can_focus").and_then(|v| v.as_bool()),
+            Some(crate::commands::terminal::can_focus())
+        );
+    }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -1,0 +1,297 @@
+//! Focus the terminal window/tab a live session is running in.
+//!
+//! v1 scope: Terminal.app only (macOS). Other terminal apps resolve to
+//! `FocusError::Unsupported` — a small, explicit registry (`TerminalAdapter`)
+//! keeps adding a new terminal a matter of implementing the trait, not
+//! branching deeper into this command. Shells out via `std::process::Command`
+//! (`ps`, `osascript`), matching the codebase's existing OS-integration idiom
+//! (git.rs, wsl.rs, process.rs) — no new dependency, no `unsafe`.
+
+use crate::process::is_pid_alive;
+
+/// Why focusing a session's terminal window failed.
+#[derive(Debug)]
+pub enum FocusError {
+    /// No adapter recognizes the detected terminal app.
+    Unsupported(String),
+    /// The session's pid is no longer running.
+    NotLive,
+    /// Could not resolve a controlling terminal app for the pid.
+    NoTerminal,
+    /// The adapter's shell-out (e.g. `osascript`) failed or exited non-zero.
+    Osascript(String),
+}
+
+impl FocusError {
+    /// The user-facing message for this failure. Kept as a single pure
+    /// mapping so every failure path produces a distinct, accurate message —
+    /// in particular so a runtime `osascript` failure on a *supported*
+    /// terminal is never confused with an actually unsupported terminal app.
+    pub fn user_message(&self) -> String {
+        match self {
+            FocusError::Unsupported(app) => format!("Focus for {app} not supported yet"),
+            FocusError::Osascript(_) => {
+                "Couldn't focus the terminal window — it may have closed, or Terminal needs \
+                 Automation permission"
+                    .to_string()
+            }
+            FocusError::NotLive => "Session is not currently running".to_string(),
+            FocusError::NoTerminal => "Couldn't find the session's terminal".to_string(),
+        }
+    }
+}
+
+impl From<FocusError> for String {
+    fn from(e: FocusError) -> Self {
+        e.user_message()
+    }
+}
+
+/// A terminal application this command knows how to bring to the front.
+pub trait TerminalAdapter {
+    /// True if `app` (the detected terminal app name, e.g. `"Terminal"`) is
+    /// handled by this adapter.
+    fn matches(&self, app: &str) -> bool;
+    /// Bring the window/tab associated with `pid`/`tty` to the front.
+    fn focus(&self, pid: i64, tty: &str) -> Result<(), FocusError>;
+}
+
+struct TerminalAppAdapter;
+
+impl TerminalAdapter for TerminalAppAdapter {
+    fn matches(&self, app: &str) -> bool {
+        app == "Terminal"
+    }
+
+    fn focus(&self, _pid: i64, tty: &str) -> Result<(), FocusError> {
+        let script = osascript_focus_for_tty(tty);
+        let output = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .output()
+            .map_err(|e| {
+                let detail = e.to_string();
+                eprintln!("Focus: failed to spawn osascript: {detail}");
+                FocusError::Osascript(detail)
+            })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = if stderr.trim().is_empty() {
+            format!("exit code {}", output.status)
+        } else {
+            format!("exit code {}: {}", output.status, stderr.trim())
+        };
+        eprintln!("Focus: osascript failed: {detail}");
+        Err(FocusError::Osascript(detail))
+    }
+}
+
+/// The AppleScript that brings the Terminal.app tab whose tty matches `tty` to
+/// the front. Pure string-building — kept separate from the adapter's
+/// `focus()` so it can be unit-tested without shelling out to `osascript`
+/// (which would steal window focus during a test run).
+pub fn osascript_focus_for_tty(tty: &str) -> String {
+    format!(
+        // Guard each window with `try`: Terminal.app has windows without tabs
+        // (e.g. the Settings window), and `tabs of w` on those throws -1728,
+        // which would abort the whole script. Skip such windows instead.
+        r#"tell application "Terminal"
+  repeat with w in windows
+    try
+      repeat with t in tabs of w
+        if (tty of t) is "{tty}" then
+          set selected of t to true
+          set frontmost of w to true
+          activate
+        end if
+      end repeat
+    end try
+  end repeat
+end tell"#
+    )
+}
+
+/// The adapter registry. v1 = Terminal.app only; add new adapters here as
+/// support grows.
+fn adapters() -> Vec<Box<dyn TerminalAdapter>> {
+    vec![Box::new(TerminalAppAdapter)]
+}
+
+/// Select the adapter that handles `app` (the detected terminal app name), or
+/// `None` if no adapter supports it yet.
+pub fn pick_adapter(app: &str) -> Option<Box<dyn TerminalAdapter>> {
+    adapters().into_iter().find(|a| a.matches(app))
+}
+
+/// Walk up the process tree from `pid` via `ps -o ppid=,comm=` looking for the
+/// nearest ancestor whose command path ends in a `.app` bundle (e.g.
+/// `/System/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal`),
+/// returning the app's bundle name (e.g. `"Terminal"`). Returns `"unknown"`
+/// if no `.app` ancestor is found or the walk fails.
+pub fn detect_terminal_app(pid: i64) -> String {
+    let mut current = pid;
+    // Bounded walk: a runaway ppid chain (or a cycle from a stale/reused pid)
+    // must not loop forever.
+    for _ in 0..32 {
+        if current <= 1 {
+            break;
+        }
+        let output = match std::process::Command::new("ps")
+            .args(["-o", "ppid=,comm=", "-p", &current.to_string()])
+            .output()
+        {
+            Ok(o) if o.status.success() => o,
+            Ok(o) => {
+                // Distinct from a normal "walked off the top of the tree":
+                // `ps` ran but rejected the pid/args. Log it so a broken `ps`
+                // doesn't silently masquerade as "no .app ancestor found".
+                eprintln!(
+                    "detect_terminal_app: `ps -p {current}` exited {}: {}",
+                    o.status,
+                    String::from_utf8_lossy(&o.stderr).trim()
+                );
+                break;
+            }
+            Err(e) => {
+                eprintln!("detect_terminal_app: failed to spawn `ps -p {current}`: {e}");
+                break;
+            }
+        };
+        let line = String::from_utf8_lossy(&output.stdout);
+        let line = line.trim();
+        let Some((ppid_str, comm)) = line.split_once(' ') else {
+            break;
+        };
+        let comm = comm.trim();
+        if let Some(name) = app_name_from_comm(comm) {
+            return name;
+        }
+        current = match ppid_str.trim().parse::<i64>() {
+            Ok(p) => p,
+            Err(_) => break,
+        };
+    }
+    "unknown".to_string()
+}
+
+/// Extract the `.app` bundle name from a `comm` path, e.g.
+/// `/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal` -> `Terminal`.
+fn app_name_from_comm(comm: &str) -> Option<String> {
+    comm.split('/')
+        .find_map(|segment| segment.strip_suffix(".app").map(|name| name.to_string()))
+}
+
+/// Resolve the controlling tty for `pid` via `ps -o tty= -p <pid>`, e.g.
+/// `"ttys002"` -> `"/dev/ttys002"`. `None` if `ps` fails or reports no tty
+/// (`"??"`, detached processes).
+pub fn resolve_tty(pid: i64) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "tty=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let tty = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if tty.is_empty() || tty == "??" {
+        return None;
+    }
+    Some(format!("/dev/{tty}"))
+}
+
+/// Bring the terminal window/tab that owns a live session's process to the
+/// front. Exposed both as a Tauri command (desktop) and, via
+/// `focus_session_window_impl`, over the HTTP API (`POST /api/focus`) — any
+/// frontend whose backend is local + macOS can focus a terminal window, not
+/// just the Tauri app.
+#[tauri::command]
+pub async fn focus_session_window(session_id: String) -> Result<(), String> {
+    focus_session_window_impl(&session_id).map_err(|e| e.user_message())
+}
+
+/// Whether this backend can focus a session's terminal window at all, i.e.
+/// whether a `TerminalAdapter` exists for the current platform. v1 ships only
+/// `TerminalAppAdapter` (macOS Terminal.app), so this is currently equivalent
+/// to "running on macOS". It is NOT a guarantee that a given `focus_session_window`
+/// call will succeed — that can still fail for other reasons (session not
+/// live, terminal app not recognized, Automation permission denied, etc.) —
+/// only that the capability exists in principle on this platform.
+pub fn can_focus() -> bool {
+    cfg!(target_os = "macos")
+}
+
+pub fn focus_session_window_impl(session_id: &str) -> Result<(), FocusError> {
+    let pid = crate::parser::session::live_pid_for(session_id).ok_or(FocusError::NotLive)?;
+    if !is_pid_alive(pid) {
+        return Err(FocusError::NotLive);
+    }
+    let app = detect_terminal_app(pid);
+    let tty = resolve_tty(pid).ok_or(FocusError::NoTerminal)?;
+    let adapter = pick_adapter(&app).ok_or(FocusError::Unsupported(app))?;
+    adapter.focus(pid, &tty)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn osascript_targets_the_tty_tab() {
+        let s = osascript_focus_for_tty("/dev/ttys002");
+        assert!(s.contains("/dev/ttys002"));
+        assert!(s.contains("set frontmost"));
+        assert!(s.contains("activate"));
+        // must guard windows without tabs (Settings window) so one -1728 doesn't abort
+        assert!(
+            s.contains("try"),
+            "per-window tab enumeration must be wrapped in try"
+        );
+    }
+
+    #[test]
+    fn unknown_app_selects_unsupported() {
+        assert!(pick_adapter("Ghostty").is_none()); // v1: only Terminal.app supported
+        assert!(pick_adapter("Terminal").is_some());
+    }
+
+    #[test]
+    fn focus_error_messages_are_distinct_and_accurate() {
+        let unsupported = FocusError::Unsupported("Ghostty".to_string()).user_message();
+        assert_eq!(unsupported, "Focus for Ghostty not supported yet");
+
+        let osascript = FocusError::Osascript("nonzero".to_string()).user_message();
+        assert!(!osascript.to_lowercase().contains("not supported yet"));
+        assert!(osascript.to_lowercase().contains("automation permission"));
+
+        let not_live = FocusError::NotLive.user_message();
+        assert_eq!(not_live, "Session is not currently running");
+
+        let no_terminal = FocusError::NoTerminal.user_message();
+        assert_eq!(no_terminal, "Couldn't find the session's terminal");
+
+        // All four messages must be pairwise distinct.
+        let all = [unsupported, osascript, not_live, no_terminal];
+        for i in 0..all.len() {
+            for j in (i + 1)..all.len() {
+                assert_ne!(all[i], all[j]);
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn can_focus_is_true_on_macos() {
+        assert!(can_focus());
+    }
+
+    #[test]
+    fn app_name_extracts_bundle_from_comm_path() {
+        assert_eq!(
+            app_name_from_comm("/Applications/Utilities/Terminal.app/Contents/MacOS/Terminal"),
+            Some("Terminal".to_string())
+        );
+        assert_eq!(app_name_from_comm("/usr/bin/zsh"), None);
+    }
+}

--- a/src-tauri/src/http_api.rs
+++ b/src-tauri/src/http_api.rs
@@ -102,6 +102,7 @@ async fn run_server(state: Arc<HttpState>) {
         .route("/api/picker/unwatch", post(api_unwatch_picker))
         .route("/api/git-info", get(api_get_git_info))
         .route("/api/debug-log", get(api_get_debug_log))
+        .route("/api/focus", post(api_focus_session_window))
         .route("/api/events", get(api_events));
 
     if let Some(dir) = resolve_static_dir() {
@@ -549,6 +550,23 @@ async fn api_get_debug_log(Query(q): Query<DebugQuery>) -> Response {
 }
 
 // ---------------------------------------------------------------------------
+// Focus
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct FocusBody {
+    #[serde(rename = "sessionId")]
+    session_id: String,
+}
+
+async fn api_focus_session_window(Json(body): Json<FocusBody>) -> Response {
+    match crate::commands::terminal::focus_session_window_impl(&body.session_id) {
+        Ok(()) => ok_json(&serde_json::json!({ "ok": true })),
+        Err(e) => err_response(axum::http::StatusCode::BAD_REQUEST, e.user_message()),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // SSE events
 // ---------------------------------------------------------------------------
 
@@ -619,5 +637,22 @@ mod tests {
     #[test]
     fn pick_port_uses_parsed_value() {
         assert_eq!(pick_port(Some("8080".to_string())), 8080);
+    }
+
+    // -----------------------------------------------------------------------
+    // Focus
+    // -----------------------------------------------------------------------
+
+    // Full route registration (via `run_server`) needs a live `AppState`/bound
+    // port; instead this calls the handler directly to verify it's wired to
+    // `focus_session_window_impl` and shapes errors like the other POST
+    // handlers in this file (BAD_REQUEST + `{ "error": ... }` envelope).
+    #[tokio::test]
+    async fn focus_route_reports_bad_request_for_a_session_that_is_not_live() {
+        let body = FocusBody {
+            session_id: "does-not-exist".to_string(),
+        };
+        let resp = api_focus_session_window(Json(body)).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod commands;
 mod convert;
 mod http_api;
 mod parser;
+mod process;
 mod session_load;
 mod settings;
 mod state;
@@ -73,6 +74,7 @@ pub fn run() {
             commands::settings::set_projects_dir,
             commands::wsl::list_wsl_distros,
             commands::wsl::set_wsl_distros,
+            commands::terminal::focus_session_window,
             switch_to_browser,
         ])
         .setup(move |app| {

--- a/src-tauri/src/parser/dategroup.rs
+++ b/src-tauri/src/parser/dategroup.rs
@@ -83,6 +83,7 @@ mod tests {
             first_message: "test".to_string(),
             recap: None,
             name: None,
+            liveness: None,
             mod_time,
             turn_count: 1,
             model: "claude-sonnet-4-20250514".to_string(),

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs;
@@ -30,6 +30,10 @@ pub struct SessionInfo {
     /// it is removed, which is harmless because the match uses the unique
     /// `sessionId`.
     pub name: Option<String>,
+    /// Liveness (status/idle time) joined from the `~/.claude/sessions/*.json`
+    /// registry, staleness-guarded against the recorded `pid`. `None` when the
+    /// session isn't running, has no registry entry, or its pid is dead.
+    pub liveness: Option<Liveness>,
     pub turn_count: i32,
     pub is_ongoing: bool,
     pub total_tokens: i64,
@@ -43,6 +47,20 @@ pub struct SessionInfo {
     pub cwd: String,
     pub git_branch: String,
     pub permission_mode: String,
+}
+
+/// Liveness of a running session, derived from the `~/.claude/sessions/*.json`
+/// registry and staleness-guarded against a live `pid` (see [`apply_liveness`]).
+/// `status` is kept as an OPEN string on purpose — it mirrors whatever Claude
+/// Code currently writes (`"busy"` / `"idle"` today), so a future Claude Code
+/// release adding a new status value degrades to "render the raw token"
+/// instead of failing to parse (same idiom as `hook_event`-as-String).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Liveness {
+    pub status: String,
+    /// `now - statusUpdatedAt`, in seconds, clamped to >= 0.
+    pub idle_seconds: i64,
+    pub pid: i64,
 }
 
 /// SessionMeta holds session-level metadata extracted from a JSONL file.
@@ -470,6 +488,7 @@ pub fn discover_project_sessions(project_dir: &str) -> Result<Vec<SessionInfo>, 
             first_message: meta.first_msg,
             recap: meta.recap,
             name: None,
+            liveness: None,
             turn_count: meta.turn_count,
             is_ongoing,
             total_tokens: meta.total_tokens,
@@ -525,9 +544,27 @@ pub fn live_session_names_dir() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|home| home.join(".claude").join("sessions"))
 }
 
-/// Build the `session_id -> name` map from a session registry directory. Split
-/// out from [`live_session_names`] so it can be unit-tested against a fixture dir.
-pub(crate) fn session_names_from_dir(dir: &std::path::Path) -> HashMap<String, String> {
+/// A single `~/.claude/sessions/*.json` registry entry, parsed defensively:
+/// every field is optional so a missing/renamed/retyped field silently
+/// degrades instead of dropping (or panicking on) the whole entry. Fields
+/// read: `sessionId` (the map key), `name`, `status`, `statusUpdatedAt`,
+/// `pid`, `bridgeSessionId`. Track this shape like cctrace tracks transcript
+/// drift: [`registry_reads_status_and_guards_stale_pid`] pins it, so a
+/// Claude-Code rename fails a test rather than silently killing the feature.
+pub(crate) struct RegEntry {
+    pub name: Option<String>,
+    pub status: Option<String>,
+    pub status_updated_at: Option<i64>,
+    pub pid: Option<i64>,
+    pub bridge_session_id: Option<String>,
+}
+
+/// Build the `session_id -> RegEntry` map from a session registry directory.
+/// Split out from [`live_session_names`] so it can be unit-tested against a
+/// fixture dir. Lenient `serde_json::Value` parse, skip-on-error per file —
+/// matches the format-drift idiom already used here (never panic on a
+/// malformed or partially-written registry file).
+pub(crate) fn read_session_registry(dir: &std::path::Path) -> HashMap<String, RegEntry> {
     let mut map = HashMap::new();
     let entries = match fs::read_dir(dir) {
         Ok(e) => e,
@@ -546,17 +583,64 @@ pub(crate) fn session_names_from_dir(dir: &std::path::Path) -> HashMap<String, S
             Ok(v) => v,
             Err(_) => continue,
         };
-        let session_id = value.get("sessionId").and_then(|v| v.as_str());
+        let Some(session_id) = value.get("sessionId").and_then(|v| v.as_str()) else {
+            continue;
+        };
         let name = value
             .get("name")
             .and_then(|v| v.as_str())
             .map(str::trim)
-            .filter(|s| !s.is_empty());
-        if let (Some(session_id), Some(name)) = (session_id, name) {
-            map.insert(session_id.to_string(), name.to_string());
-        }
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let status = value
+            .get("status")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        let status_updated_at = value.get("statusUpdatedAt").and_then(|v| v.as_i64());
+        let pid = value.get("pid").and_then(|v| v.as_i64());
+        let bridge_session_id = value
+            .get("bridgeSessionId")
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        map.insert(
+            session_id.to_string(),
+            RegEntry {
+                name,
+                status,
+                status_updated_at,
+                pid,
+                bridge_session_id,
+            },
+        );
     }
     map
+}
+
+/// Resolve the live pid for `session_id` from the `~/.claude/sessions`
+/// registry, staleness-guarded the same way as [`apply_liveness`]: the pid is
+/// only returned if [`crate::process::is_pid_alive`] confirms the process is
+/// still running. Used by the Focus-window command (desktop only) to find
+/// the process whose terminal window/tab should be brought to the front.
+pub fn live_pid_for(session_id: &str) -> Option<i64> {
+    let dir = live_session_names_dir()?;
+    let reg = read_session_registry(&dir);
+    let pid = reg.get(session_id)?.pid?;
+    if crate::process::is_pid_alive(pid) {
+        Some(pid)
+    } else {
+        None
+    }
+}
+
+/// Build the `session_id -> name` map from a session registry directory. Thin
+/// derive over [`read_session_registry`], filtered to non-empty names — kept
+/// so the existing name-join behaviour (and its tests) are unaffected by the
+/// registry read growing to also carry liveness fields.
+pub(crate) fn session_names_from_dir(dir: &std::path::Path) -> HashMap<String, String> {
+    read_session_registry(dir)
+        .into_iter()
+        .filter_map(|(session_id, entry)| entry.name.map(|name| (session_id, name)))
+        .collect()
 }
 
 /// Fill in `SessionInfo::name` from a `session_id -> name` map. Sessions absent
@@ -566,6 +650,100 @@ pub fn apply_session_names(sessions: &mut [SessionInfo], names: &HashMap<String,
         if let Some(name) = names.get(&session.session_id) {
             session.name = Some(name.clone());
         }
+    }
+}
+
+/// Fill in `SessionInfo::liveness` from the registry, staleness-guarded: an
+/// entry only counts as live if its recorded `pid` is a currently-running
+/// process (checked via [`crate::process::is_pid_alive`]). The name-join above
+/// deliberately tolerates a stale (process-exited) registry file; liveness
+/// does not, since showing "busy" for a session that's actually gone would be
+/// actively misleading rather than merely stale cosmetics.
+pub fn apply_liveness(sessions: &mut [SessionInfo], reg: &HashMap<String, RegEntry>, now_ms: i64) {
+    let map = liveness_map_from_registry(reg, now_ms);
+    apply_liveness_map(sessions, &map);
+}
+
+/// Compute the `session_id -> Liveness` map from a registry snapshot, applying
+/// the same staleness guard as [`apply_liveness`] (dead pid → dropped). Split
+/// out so [`LivenessCache`] can compute-and-cache the result — including the
+/// `is_pid_alive` ("kill -0") checks — once per TTL window instead of once per
+/// [`apply_liveness`] call.
+pub(crate) fn liveness_map_from_registry(
+    reg: &HashMap<String, RegEntry>,
+    now_ms: i64,
+) -> HashMap<String, Liveness> {
+    let mut map = HashMap::new();
+    for (session_id, e) in reg.iter() {
+        let (Some(pid), Some(status)) = (e.pid, e.status.as_deref()) else {
+            continue;
+        };
+        if !crate::process::is_pid_alive(pid) {
+            continue; // staleness guard
+        }
+        let idle_ms = (now_ms - e.status_updated_at.unwrap_or(now_ms)).max(0);
+        map.insert(
+            session_id.clone(),
+            Liveness {
+                status: status.to_string(),
+                idle_seconds: idle_ms / 1000,
+                pid,
+            },
+        );
+    }
+    map
+}
+
+/// Fill in `SessionInfo::liveness` from a precomputed `session_id -> Liveness`
+/// map (e.g. from [`LivenessCache`]). Unlike [`apply_liveness`], this never
+/// re-checks `is_pid_alive`: the staleness guard was already applied when the
+/// map was built.
+pub fn apply_liveness_map(sessions: &mut [SessionInfo], map: &HashMap<String, Liveness>) {
+    for s in sessions.iter_mut() {
+        if let Some(liveness) = map.get(&s.session_id) {
+            s.liveness = Some(liveness.clone());
+        }
+    }
+}
+
+/// Short-TTL cache for computed liveness, mirroring [`SessionNamesCache`]: the
+/// registry scan AND the per-entry `is_pid_alive` ("kill -0") checks are done
+/// at most once per TTL window, so a burst of `discover_sessions_cached` calls
+/// — and the picker-refresh broadcast fan-out across all connected clients —
+/// share one round of liveness checks instead of spawning a `kill` subprocess
+/// per live session on every call. Idle seconds may be up to one TTL window
+/// stale, which is fine since the badge only ever shows whole minutes.
+#[derive(Default)]
+pub struct LivenessCache {
+    /// `(captured_at, map)` of the last computed liveness, or `None` before
+    /// the first read.
+    entry: Option<(std::time::Instant, HashMap<String, Liveness>)>,
+}
+
+impl LivenessCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the cached `session_id -> Liveness` map if the last scan is
+    /// younger than `ttl`, otherwise re-scan `dir`, recompute liveness (via
+    /// [`liveness_map_from_registry`], including the `is_pid_alive` checks),
+    /// and cache it.
+    pub fn get_or_load(
+        &mut self,
+        dir: &std::path::Path,
+        ttl: std::time::Duration,
+        now_ms: i64,
+    ) -> HashMap<String, Liveness> {
+        if let Some((captured_at, ref map)) = self.entry {
+            if captured_at.elapsed() < ttl {
+                return map.clone();
+            }
+        }
+        let reg = read_session_registry(dir);
+        let map = liveness_map_from_registry(&reg, now_ms);
+        self.entry = Some((std::time::Instant::now(), map.clone()));
+        map
     }
 }
 
@@ -630,6 +808,7 @@ pub fn session_info_from_metadata(
         first_message: meta.first_msg,
         recap: meta.recap,
         name: None,
+        liveness: None,
         turn_count: meta.turn_count,
         is_ongoing,
         total_tokens: meta.total_tokens,
@@ -1564,6 +1743,7 @@ mod tests {
             first_message: "first".to_string(),
             recap: None,
             name: None,
+            liveness: None,
             turn_count: 0,
             is_ongoing: false,
             total_tokens: 0,
@@ -1754,6 +1934,164 @@ mod tests {
 
         assert_eq!(sessions[0].name.as_deref(), Some("my-cache"));
         assert_eq!(sessions[1].name, None);
+    }
+
+    #[test]
+    fn registry_reads_status_and_guards_stale_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        // live: our own pid, busy
+        let me = std::process::id();
+        std::fs::write(
+            dir.path().join("a.json"),
+            format!(
+                r#"{{"pid":{me},"sessionId":"sid-live","status":"busy","statusUpdatedAt":1000,"bridgeSessionId":"session_01TESTBRIDGE"}}"#
+            ),
+        )
+        .unwrap();
+        // stale: dead pid — must be dropped from liveness
+        std::fs::write(
+            dir.path().join("b.json"),
+            r#"{"pid":2000000000,"sessionId":"sid-stale","status":"idle","statusUpdatedAt":1000}"#,
+        )
+        .unwrap();
+
+        let reg = read_session_registry(dir.path());
+        let mut sessions = vec![make_info("sid-live"), make_info("sid-stale")];
+        apply_liveness(&mut sessions, &reg, 4000);
+
+        assert_eq!(sessions[0].liveness.as_ref().unwrap().status, "busy");
+        assert_eq!(sessions[0].liveness.as_ref().unwrap().idle_seconds, 3); // (4000-1000)/1000
+        assert!(
+            sessions[1].liveness.is_none(),
+            "stale pid must not read as live"
+        );
+        assert_eq!(
+            reg.get("sid-live").unwrap().bridge_session_id.as_deref(),
+            Some("session_01TESTBRIDGE")
+        );
+    }
+
+    #[test]
+    fn apply_liveness_skips_entry_missing_pid_or_status() {
+        // Guards the `let (Some(pid), Some(status)) = ... else { continue }`
+        // destructure in `apply_liveness`: a registry entry with only one of
+        // the two fields present must leave `liveness: None`, not panic or
+        // partially populate it.
+        let mut reg = HashMap::new();
+        reg.insert(
+            "sid-no-status".to_string(),
+            RegEntry {
+                name: None,
+                status: None,
+                status_updated_at: None,
+                pid: Some(std::process::id() as i64),
+                bridge_session_id: None,
+            },
+        );
+        reg.insert(
+            "sid-no-pid".to_string(),
+            RegEntry {
+                name: None,
+                status: Some("busy".to_string()),
+                status_updated_at: None,
+                pid: None,
+                bridge_session_id: None,
+            },
+        );
+
+        let mut sessions = vec![make_info("sid-no-status"), make_info("sid-no-pid")];
+        apply_liveness(&mut sessions, &reg, 1000);
+
+        assert!(
+            sessions[0].liveness.is_none(),
+            "pid present but status missing must not read as live"
+        );
+        assert!(
+            sessions[1].liveness.is_none(),
+            "status present but pid missing must not read as live"
+        );
+    }
+
+    #[test]
+    fn liveness_cache_serves_hits_without_rescanning() {
+        use std::time::Duration;
+        let dir = tempfile::tempdir().unwrap();
+        let me = std::process::id();
+        std::fs::write(
+            dir.path().join("a.json"),
+            format!(
+                r#"{{"pid":{me},"sessionId":"sid-live","status":"busy","statusUpdatedAt":1000}}"#
+            ),
+        )
+        .unwrap();
+
+        let mut cache = LivenessCache::new();
+        // Long TTL: the first load populates the cache.
+        let first = cache.get_or_load(dir.path(), Duration::from_secs(60), 4000);
+        assert_eq!(first.get("sid-live").unwrap().status, "busy");
+        assert_eq!(first.get("sid-live").unwrap().idle_seconds, 3);
+
+        // Change the registry on disk; a cache hit must not see it yet (status
+        // stays "busy" and idle_seconds stays computed from the first read).
+        std::fs::write(
+            dir.path().join("a.json"),
+            format!(
+                r#"{{"pid":{me},"sessionId":"sid-live","status":"idle","statusUpdatedAt":3000}}"#
+            ),
+        )
+        .unwrap();
+        let cached = cache.get_or_load(dir.path(), Duration::from_secs(60), 4500);
+        assert_eq!(cached.get("sid-live").unwrap().status, "busy");
+        assert_eq!(cached.get("sid-live").unwrap().idle_seconds, 3);
+    }
+
+    #[test]
+    fn liveness_cache_reloads_after_expiry() {
+        use std::time::Duration;
+        let dir = tempfile::tempdir().unwrap();
+        let me = std::process::id();
+        std::fs::write(
+            dir.path().join("a.json"),
+            format!(
+                r#"{{"pid":{me},"sessionId":"sid-live","status":"busy","statusUpdatedAt":1000}}"#
+            ),
+        )
+        .unwrap();
+
+        let mut cache = LivenessCache::new();
+        let first = cache.get_or_load(dir.path(), Duration::from_secs(60), 4000);
+        assert_eq!(first.get("sid-live").unwrap().status, "busy");
+
+        std::fs::write(
+            dir.path().join("a.json"),
+            format!(
+                r#"{{"pid":{me},"sessionId":"sid-live","status":"idle","statusUpdatedAt":3000}}"#
+            ),
+        )
+        .unwrap();
+        // Force expiry with a zero TTL: the entry is always older than zero,
+        // so the next call re-scans and picks up the new status/idle time.
+        let reloaded = cache.get_or_load(dir.path(), Duration::ZERO, 4500);
+        assert_eq!(reloaded.get("sid-live").unwrap().status, "idle");
+        assert_eq!(reloaded.get("sid-live").unwrap().idle_seconds, 1); // (4500-3000)/1000
+    }
+
+    #[test]
+    fn liveness_cache_drops_dead_pid_even_when_cached() {
+        use std::time::Duration;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("a.json"),
+            r#"{"pid":2000000000,"sessionId":"sid-stale","status":"busy","statusUpdatedAt":1000}"#,
+        )
+        .unwrap();
+
+        let mut cache = LivenessCache::new();
+        let map = cache.get_or_load(dir.path(), Duration::from_secs(60), 4000);
+        assert!(
+            !map.contains_key("sid-stale"),
+            "dead pid must not be cached as live"
+        );
     }
 
     #[test]

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -1,0 +1,51 @@
+//! "Is this pid a running process?" for the liveness guard. Shells out to
+//! `kill -0`, matching cctrace's existing OS-integration idiom (git.rs, wsl.rs
+//! already use `std::process::Command`) — no new dependency, no `unsafe`. The
+//! spawn cost is bounded by the caller's TTL cache (`LivenessCache` in
+//! `parser::session`, wired via `AppState::live_liveness_cached`): the
+//! registry scan and every `is_pid_alive` check in it run at most once per
+//! cache window, not once per `discover_sessions_cached` call. Windows has no
+//! `kill`: liveness degrades to "closed" there.
+
+use std::process::Command;
+
+/// True if `pid` is a live process. `kill -0 <pid>` sends no signal — it only
+/// performs the permission/existence check and exits 0 iff the process exists.
+pub fn is_pid_alive(pid: i64) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        match Command::new("kill").args(["-0", &pid.to_string()]).status() {
+            Ok(s) => s.success(),
+            Err(e) => {
+                // Distinguish "couldn't run kill at all" (PATH/sandbox/resource
+                // issue — every session would silently read as dead) from a
+                // clean "process doesn't exist". Safe to log per call: this sits
+                // behind the registry's TTL cache, not a per-render hot path.
+                eprintln!("is_pid_alive: failed to spawn `kill -0 {pid}`: {e}");
+                false
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn own_pid_is_alive() {
+        let me = std::process::id() as i64;
+        assert!(is_pid_alive(me));
+    }
+    #[test]
+    fn absurd_pid_is_not_alive() {
+        assert!(!is_pid_alive(2_000_000_000));
+    }
+}

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 
 use crate::convert::{DisplayMessage, LoadResult};
 use crate::parser::cache::SessionCache;
-use crate::parser::session::{SessionInfo, SessionNamesCache};
+use crate::parser::session::{Liveness, LivenessCache, SessionInfo, SessionNamesCache};
 use crate::session_load::{
     build_light_session, build_session, slice_light, LightBuild, LoadOptions, TimeFilter,
 };
@@ -37,6 +37,11 @@ const SESSIONS_CACHE_TTL: Duration = Duration::from_secs(2);
 /// long enough that a burst of refreshes shares a single scan.
 const SESSION_NAMES_CACHE_TTL: Duration = Duration::from_secs(1);
 
+/// TTL for the computed-liveness cache (registry scan + `is_pid_alive` checks).
+/// Mirrors [`SESSION_NAMES_CACHE_TTL`] so both registry joins share the same
+/// freshness window and the same picker-refresh cache-sharing story.
+const LIVENESS_CACHE_TTL: Duration = Duration::from_secs(1);
+
 /// A lightened session build cached for the active session, keyed by
 /// `(path, size)`. Lets range fetches during list scrolling slice an
 /// already-built session instead of re-parsing the file on every scroll step.
@@ -66,6 +71,12 @@ pub struct AppState {
     /// Short-TTL cache for the live `/rename` session-name registry, shared by
     /// all concurrent `discover_sessions_cached` callers.
     session_names_cache: Mutex<SessionNamesCache>,
+    /// Short-TTL cache for computed session liveness (registry scan + the
+    /// per-entry `is_pid_alive`/`kill -0` checks), shared by all concurrent
+    /// `discover_sessions_cached` callers so the picker-refresh broadcast
+    /// fan-out shares one round of liveness checks instead of spawning a
+    /// `kill` subprocess per live session per client.
+    liveness_cache: Mutex<LivenessCache>,
     /// Lightened-build cache for the active session so windowed list fetches
     /// slice an existing build instead of re-parsing the file on every scroll.
     /// Never holds heavy tool bodies — see [`CachedLight`].
@@ -84,6 +95,7 @@ impl AppState {
             event_tx,
             sessions_cache: Mutex::new(None),
             session_names_cache: Mutex::new(SessionNamesCache::new()),
+            liveness_cache: Mutex::new(LivenessCache::new()),
             session_light_cache: Mutex::new(None),
         }
     }
@@ -166,6 +178,26 @@ impl AppState {
         match self.session_names_cache.lock() {
             Ok(mut cache) => cache.get_or_load(&dir, SESSION_NAMES_CACHE_TTL),
             Err(_) => crate::parser::session::live_session_names(),
+        }
+    }
+
+    /// Read computed liveness (registry scan + `is_pid_alive`/`kill -0` checks)
+    /// through a short-TTL cache so concurrent/rapid callers — and the
+    /// picker-refresh broadcast fan-out — share one scan and one round of
+    /// liveness checks instead of spawning a `kill` subprocess per live
+    /// session on every call. Falls back to an uncached scan+compute if the
+    /// cache lock is poisoned.
+    fn live_liveness_cached(&self, dir: &std::path::Path) -> HashMap<String, Liveness> {
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+        match self.liveness_cache.lock() {
+            Ok(mut cache) => cache.get_or_load(dir, LIVENESS_CACHE_TTL, now_ms),
+            Err(_) => {
+                let reg = crate::parser::session::read_session_registry(dir);
+                crate::parser::session::liveness_map_from_registry(&reg, now_ms)
+            }
         }
     }
 
@@ -267,6 +299,16 @@ impl AppState {
             &mut sessions,
             &self.live_session_names_cached(),
         );
+        // Liveness reads the same registry directory but needs the richer
+        // per-entry data (status/pid), not just names, so it joins through its
+        // own short-TTL cache (`liveness_cache`) rather than reusing the name
+        // cache above. That cache covers both the registry scan and the
+        // per-entry `is_pid_alive` ("kill -0") checks, so a burst of refreshes
+        // and the broadcast fan-out share one round of liveness checks.
+        if let Some(dir) = crate::parser::session::live_session_names_dir() {
+            let liveness = self.live_liveness_cached(&dir);
+            crate::parser::session::apply_liveness_map(&mut sessions, &liveness);
+        }
         Ok(sessions)
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,10 @@ export function App() {
 
   const session = useSession();
   const picker = usePicker(selectedProject);
+  // The open session's full SessionInfo (liveness, session_id), looked up from
+  // the picker's list by path — useSession's meta only carries cwd/branch/mode.
+  const selectedSessionInfo =
+    picker.allSessions.find((s) => s.path === session.sessionPath) ?? null;
   const projectKeys = useProjectKeys(picker.allSessions, collapsedKeys);
   const projectItems = useProjectItems(picker.allSessions, collapsedKeys);
 
@@ -94,6 +98,11 @@ export function App() {
     }
   }, [discoverSessions]);
 
+  // Whether this backend can focus a session's terminal window (macOS +
+  // local, whether we're the Tauri app or a browser talking to the HTTP
+  // API) — gates the Focus action instead of `isTauri`.
+  const [canFocus, setCanFocus] = useState(false);
+
   // Auto-discover sessions on mount; show settings if no path configured
   const discoveredRef = useRef(false);
   useEffect(() => {
@@ -105,8 +114,10 @@ export function App() {
         const settings = await invoke<{
           projects_dir: string | null;
           effective_dir_exists: boolean;
+          can_focus: boolean;
         }>("get_settings");
         dirExists = settings.effective_dir_exists;
+        setCanFocus(settings.can_focus);
       } catch {
         // no settings file yet
       }
@@ -473,6 +484,8 @@ export function App() {
           sessionTotals={session.sessionTotals}
           sessionPath={session.sessionPath}
           ongoing={session.ongoing}
+          sessionInfo={selectedSessionInfo}
+          canFocus={canFocus}
         />
       )}
 

--- a/src/components/InfoBar.test.tsx
+++ b/src/components/InfoBar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { InfoBar } from "./InfoBar";
-import type { SessionMeta, SessionTotals, GitInfo } from "../types";
+import type { SessionMeta, SessionTotals, GitInfo, SessionInfo } from "../types";
 
 function makeMeta(overrides: Partial<SessionMeta> = {}): SessionMeta {
   return {
@@ -25,6 +25,12 @@ function makeTotals(overrides: Partial<SessionTotals> = {}): SessionTotals {
   };
 }
 
+const baseSessionInfo = {
+  session_id: "u1",
+  cwd: "/home/user/my-project",
+  path: "",
+} as any as SessionInfo;
+
 describe("InfoBar", () => {
   it("shows project name from shortPath(meta.cwd)", () => {
     render(
@@ -35,6 +41,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("my-project")).toBeInTheDocument();
@@ -49,6 +56,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath="/some/path/abc123.jsonl"
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("abc123")).toBeInTheDocument();
@@ -64,6 +72,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("feature-x")).toBeInTheDocument();
@@ -79,6 +88,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     const branchEl = screen.getByText("main");
@@ -95,6 +105,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     const branchEl = screen.getByText("main");
@@ -110,6 +121,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("yolo")).toBeInTheDocument();
@@ -124,6 +136,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("auto-edit")).toBeInTheDocument();
@@ -138,6 +151,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("plan")).toBeInTheDocument();
@@ -152,6 +166,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.queryByText("default")).not.toBeInTheDocument();
@@ -166,6 +181,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.queryByText("manual")).not.toBeInTheDocument();
@@ -180,6 +196,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("ctx 50%")).toBeInTheDocument();
@@ -194,6 +211,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.queryByText(/ctx/)).not.toBeInTheDocument();
@@ -208,6 +226,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals({ total_tokens: 5000 })}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText(/5\.0k tok/)).toBeInTheDocument();
@@ -222,12 +241,13 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals({ cost_usd: 1.5 })}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.getByText("1.50")).toBeInTheDocument();
   });
 
-  it("shows active spinner when ongoing=true", () => {
+  it("shows active spinner when ongoing=true and there is no liveness info", () => {
     render(
       <InfoBar
         meta={makeMeta()}
@@ -236,6 +256,7 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={true}
+        canFocus={false}
       />,
     );
     expect(screen.getByText(/active/)).toBeInTheDocument();
@@ -250,8 +271,86 @@ describe("InfoBar", () => {
         sessionTotals={makeTotals()}
         sessionPath=""
         ongoing={false}
+        canFocus={false}
       />,
     );
     expect(screen.queryByText(/active/)).not.toBeInTheDocument();
+  });
+
+  describe("liveness badge supersedes the transcript 'active' indicator", () => {
+    it("shows the liveness badge when sessionInfo.liveness is present", () => {
+      render(
+        <InfoBar
+          meta={makeMeta()}
+          gitInfo={null}
+          contextTokens={0}
+          sessionTotals={makeTotals()}
+          sessionPath=""
+          ongoing={true}
+          canFocus={false}
+          sessionInfo={{
+            ...baseSessionInfo,
+            liveness: { status: "idle", idle_seconds: 180, pid: 1 },
+          }}
+        />,
+      );
+      expect(screen.getByText(/idle 3m/i)).toBeInTheDocument();
+    });
+
+    it("floors idle minutes (90s reads as 1m, not 2m) to match the TUI badge", () => {
+      render(
+        <InfoBar
+          meta={makeMeta()}
+          gitInfo={null}
+          contextTokens={0}
+          sessionTotals={makeTotals()}
+          sessionPath=""
+          ongoing={true}
+          canFocus={false}
+          sessionInfo={{
+            ...baseSessionInfo,
+            liveness: { status: "idle", idle_seconds: 90, pid: 1 },
+          }}
+        />,
+      );
+      expect(screen.getByText(/idle 1m/i)).toBeInTheDocument();
+    });
+
+    it("suppresses the 'active' indicator when liveness is present, even if ongoing=true", () => {
+      render(
+        <InfoBar
+          meta={makeMeta()}
+          gitInfo={null}
+          contextTokens={0}
+          sessionTotals={makeTotals()}
+          sessionPath=""
+          ongoing={true}
+          canFocus={false}
+          sessionInfo={{
+            ...baseSessionInfo,
+            liveness: { status: "busy", idle_seconds: 0, pid: 1 },
+          }}
+        />,
+      );
+      expect(screen.getByText(/busy/i)).toBeInTheDocument();
+      expect(screen.queryByText(/active/)).not.toBeInTheDocument();
+    });
+
+    it("still shows the 'active' indicator normally when there is no liveness info", () => {
+      render(
+        <InfoBar
+          meta={makeMeta()}
+          gitInfo={null}
+          contextTokens={0}
+          sessionTotals={makeTotals()}
+          sessionPath=""
+          ongoing={true}
+          canFocus={false}
+          sessionInfo={{ ...baseSessionInfo, liveness: null }}
+        />,
+      );
+      expect(screen.getByText(/active/)).toBeInTheDocument();
+      expect(screen.queryByText(/busy|idle/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/InfoBar.tsx
+++ b/src/components/InfoBar.tsx
@@ -1,4 +1,4 @@
-import type { SessionMeta, SessionTotals, GitInfo } from "../types";
+import type { SessionMeta, SessionTotals, GitInfo, SessionInfo } from "../types";
 import {
   shortPath,
   shortMode,
@@ -9,6 +9,18 @@ import {
 } from "../lib/format";
 import { getContextColor } from "../lib/theme";
 import { TokensIcon, CostIcon } from "./Icons";
+import { SessionActions } from "./SessionActions";
+
+/** Format a session's liveness into the status-row badge text, or `null` when
+ *  there's no liveness info. Moved here (verbatim) from `SessionActions` —
+ *  liveness is the authoritative real-time status signal, so it now lives
+ *  alongside the (mutually exclusive) `active`/`info-bar__ongoing` indicator. */
+function badge(l: SessionInfo["liveness"]): string | null {
+  if (!l) return null;
+  if (l.status === "busy") return "● busy";
+  if (l.status === "idle") return `○ idle ${Math.floor(l.idle_seconds / 60)}m`;
+  return `○ ${l.status}`; // forward-compat: render an unknown status, don't assume the set is closed
+}
 
 interface InfoBarProps {
   meta: SessionMeta;
@@ -18,6 +30,11 @@ interface InfoBarProps {
   sessionTotals: SessionTotals;
   sessionPath: string;
   ongoing: boolean;
+  /** Full SessionInfo for the open session (liveness, session_id), when known
+   *  from the picker's session list; null while it hasn't loaded/matched yet. */
+  sessionInfo?: SessionInfo | null;
+  /** Whether this backend can focus a session's terminal window. */
+  canFocus: boolean;
 }
 
 export function InfoBar({
@@ -27,6 +44,8 @@ export function InfoBar({
   sessionTotals,
   sessionPath,
   ongoing,
+  sessionInfo,
+  canFocus,
 }: InfoBarProps) {
   const projectName = shortPath(meta.cwd);
   const sessionId = sessionPath.split("/").pop()?.replace(".jsonl", "") || "";
@@ -36,6 +55,11 @@ export function InfoBar({
   const ctxPct = contextPercentFromTokens(contextTokens);
 
   const totalCost = sessionTotals.cost_usd;
+  // Liveness (from the session registry) is the more authoritative real-time
+  // signal — when present it supersedes the transcript-derived `ongoing`
+  // indicator so only one status signal is ever shown at once.
+  const liveness = sessionInfo?.liveness;
+  const livenessBadge = badge(liveness);
 
   const pillClass =
     mode === "bypassPermissions"
@@ -88,11 +112,17 @@ export function InfoBar({
         </span>
       )}
 
-      {ongoing && (
-        <span className="info-bar__ongoing">
-          <span className="braille-spinner" /> active
-        </span>
+      {livenessBadge ? (
+        <span className="info-bar__status-badge">{livenessBadge}</span>
+      ) : (
+        ongoing && (
+          <span className="info-bar__ongoing">
+            <span className="braille-spinner" /> active
+          </span>
+        )
       )}
+
+      {sessionInfo && <SessionActions session={sessionInfo} canFocus={canFocus} />}
     </div>
   );
 }

--- a/src/components/SessionActions.test.tsx
+++ b/src/components/SessionActions.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SessionActions } from "./SessionActions";
+
+const mockInvoke = vi.fn();
+vi.mock("../lib/invoke", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+const writeText = vi.fn();
+beforeEach(() => {
+  writeText.mockReset();
+  mockInvoke.mockReset();
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+const base = { session_id: "u1", cwd: "/w" /* …other SessionInfo fields… */ } as any;
+
+describe("SessionActions", () => {
+  it("copies the resume command", () => {
+    render(<SessionActions session={{ ...base, liveness: null }} canFocus={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy resume/i }));
+    expect(writeText).toHaveBeenCalledWith("cd '/w' && claude --resume u1");
+  });
+
+  it("copies a fork command", () => {
+    render(<SessionActions session={{ ...base, liveness: null }} canFocus={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /fork/i }));
+    expect(writeText).toHaveBeenCalledWith("cd '/w' && claude --resume u1 --fork-session");
+  });
+
+  it("gives visual feedback (Copied!) after a successful copy", async () => {
+    render(<SessionActions session={{ ...base, liveness: null }} canFocus={false} />);
+    // accessible name stays the honest aria-label; the visible label flips to "Copied!"
+    fireEvent.click(screen.getByRole("button", { name: /copy resume/i }));
+    expect(await screen.findByText(/copied!/i)).toBeInTheDocument();
+  });
+
+  it("shows an inline error when the clipboard write fails", async () => {
+    writeText.mockRejectedValueOnce(new Error("clipboard blocked"));
+    render(<SessionActions session={{ ...base, liveness: null }} canFocus={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /copy resume/i }));
+    expect(await screen.findByText(/couldn't copy: clipboard blocked/i)).toBeInTheDocument();
+  });
+
+  describe("Focus window button", () => {
+    it("shows Focus when canFocus and the session is live", () => {
+      render(
+        <SessionActions
+          session={{ ...base, liveness: { status: "idle", idle_seconds: 60, pid: 9 } }}
+          canFocus={true}
+        />,
+      );
+      expect(screen.getByRole("button", { name: /focus window/i })).toBeEnabled();
+    });
+
+    it("hides Focus when canFocus is false, even when the session is live", () => {
+      render(
+        <SessionActions
+          session={{ ...base, liveness: { status: "idle", idle_seconds: 60, pid: 9 } }}
+          canFocus={false}
+        />,
+      );
+      expect(screen.queryByRole("button", { name: /focus window/i })).toBeNull();
+    });
+
+    it("hides Focus when the session isn't live, even when canFocus is true", () => {
+      render(<SessionActions session={{ ...base, liveness: null }} canFocus={true} />);
+      expect(screen.queryByRole("button", { name: /focus window/i })).toBeNull();
+    });
+
+    it("invokes focus_session_window with the session id when clicked", () => {
+      mockInvoke.mockResolvedValue(undefined);
+      render(
+        <SessionActions
+          session={{ ...base, liveness: { status: "idle", idle_seconds: 60, pid: 9 } }}
+          canFocus={true}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /focus window/i }));
+      expect(mockInvoke).toHaveBeenCalledWith("focus_session_window", { sessionId: "u1" });
+    });
+
+    it("renders an inline error when focus_session_window rejects", async () => {
+      mockInvoke.mockRejectedValue(new Error("boom"));
+      render(
+        <SessionActions
+          session={{ ...base, liveness: { status: "idle", idle_seconds: 60, pid: 9 } }}
+          canFocus={true}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /focus window/i }));
+      expect(await screen.findByText(/boom/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SessionActions.tsx
+++ b/src/components/SessionActions.tsx
@@ -1,0 +1,90 @@
+import { useState } from "react";
+import { VscCopy, VscCheck, VscWindow } from "react-icons/vsc";
+import type { SessionInfo } from "../types";
+import { resumeCommand } from "../lib/resumeCommand";
+import { invoke } from "../lib/invoke";
+
+export function SessionActions({
+  session,
+  canFocus,
+}: {
+  session: SessionInfo;
+  /** Whether this backend can focus a session's terminal window (see
+   *  `commands::terminal::can_focus` on the Rust side) — gates the Focus
+   *  action instead of `isTauri`, since any local + macOS backend (Tauri app
+   *  or browser talking to the HTTP API) can focus a terminal window. */
+  canFocus: boolean;
+}) {
+  const [copied, setCopied] = useState<"resume" | "fork" | null>(null);
+  const [copyError, setCopyError] = useState<string | null>(null);
+  const [focusError, setFocusError] = useState<string | null>(null);
+  const copy = async (fork: boolean) => {
+    setCopyError(null);
+    const cmd = resumeCommand(session.cwd, session.session_id, { fork });
+    try {
+      await navigator.clipboard.writeText(cmd);
+      setCopied(fork ? "fork" : "resume");
+      window.setTimeout(() => setCopied(null), 1500);
+    } catch (err) {
+      setCopyError(err instanceof Error ? err.message : String(err));
+    }
+  };
+  const focus = async () => {
+    setFocusError(null);
+    try {
+      await invoke("focus_session_window", { sessionId: session.session_id });
+    } catch (err) {
+      setFocusError(err instanceof Error ? err.message : String(err));
+    }
+  };
+  // Shown in the tooltip so the button is honest about exactly what it copies.
+  const resumeCmd = resumeCommand(session.cwd, session.session_id, { fork: false });
+  const forkCmd = resumeCommand(session.cwd, session.session_id, { fork: true });
+  return (
+    <div className="session-actions">
+      {/* Copy actions: the clipboard icon signals "this copies a command to paste in a terminal". */}
+      <button
+        className={`session-actions__button${copied === "resume" ? " session-actions__button--copied" : ""}`}
+        onClick={() => copy(false)}
+        aria-label="Copy resume command"
+        title={resumeCmd}
+      >
+        {copied === "resume" ? <VscCheck aria-hidden /> : <VscCopy aria-hidden />}
+        {copied === "resume" ? "Copied!" : "Resume"}
+      </button>
+      <button
+        className={`session-actions__button${copied === "fork" ? " session-actions__button--copied" : ""}`}
+        onClick={() => copy(true)}
+        aria-label="Copy fork command"
+        title={forkCmd}
+      >
+        {copied === "fork" ? <VscCheck aria-hidden /> : <VscCopy aria-hidden />}
+        {copied === "fork" ? "Copied!" : "Fork"}
+      </button>
+      {/* Execute action (backend can focus + session live): no clipboard icon — it acts immediately, not a copy. */}
+      {canFocus && session.liveness && (
+        <>
+          <span className="session-actions__separator" aria-hidden />
+          <button
+            className="session-actions__button"
+            onClick={focus}
+            title="Bring this session's terminal window to the front"
+          >
+            <VscWindow aria-hidden />
+            Focus window
+          </button>
+        </>
+      )}
+      {copyError && (
+        <span className="session-actions__error" role="alert">
+          Couldn't copy: {copyError}
+        </span>
+      )}
+      {focusError && (
+        <span className="session-actions__error" role="alert">
+          {focusError}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/invoke.ts
+++ b/src/lib/invoke.ts
@@ -75,6 +75,11 @@ const routes: Record<string, Route> = {
       return `/api/debug-log?${params}`;
     },
   },
+  focus_session_window: {
+    method: "POST",
+    path: "/api/focus",
+    body: (a) => ({ sessionId: a.sessionId }),
+  },
 };
 
 // ---------------------------------------------------------------------------

--- a/src/lib/resumeCommand.test.ts
+++ b/src/lib/resumeCommand.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { resumeCommand } from "./resumeCommand";
+
+describe("resumeCommand", () => {
+  it("builds a quoted cd + resume", () => {
+    expect(resumeCommand("/a b/c", "uuid-1")).toBe("cd '/a b/c' && claude --resume uuid-1");
+  });
+  it("adds --fork-session when fork", () => {
+    expect(resumeCommand("/x", "u2", { fork: true })).toBe(
+      "cd '/x' && claude --resume u2 --fork-session",
+    );
+  });
+  it("escapes single quotes in the path", () => {
+    expect(resumeCommand("/it's/here", "u3")).toBe("cd '/it'\\''s/here' && claude --resume u3");
+  });
+});

--- a/src/lib/resumeCommand.ts
+++ b/src/lib/resumeCommand.ts
@@ -1,0 +1,10 @@
+/** Shell-single-quote a string (POSIX): wrap in '…', escape embedded ' as '\''. */
+function shq(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/** The command to paste in a terminal to resume (or fork) a session in its cwd. */
+export function resumeCommand(cwd: string, sessionId: string, opts?: { fork?: boolean }): string {
+  const base = `cd ${shq(cwd)} && claude --resume ${sessionId}`;
+  return opts?.fork ? `${base} --fork-session` : base;
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -643,6 +643,73 @@ body {
   animation: pulse 1.5s ease-in-out infinite;
 }
 
+/* ---- Session Actions (in Info Bar) ---- */
+
+.session-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  /* push to the right edge of the info-bar so actions sit on the right (info left,
+     actions right) regardless of how much session metadata precedes them */
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.info-bar__status-badge {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.session-actions__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 8px;
+  height: 22px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.1s,
+    border-color 0.1s;
+  white-space: nowrap;
+}
+
+.session-actions__button:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* transient "Copied!" confirmation — clear filled state, distinct from hover */
+.session-actions__button--copied,
+.session-actions__button--copied:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--bg-elevated);
+}
+
+/* divides the copy actions from the immediate Focus action (copy vs execute) */
+.session-actions__separator {
+  width: 1px;
+  align-self: stretch;
+  min-height: 14px;
+  margin: 0 3px;
+  background: var(--border);
+}
+
+.session-actions__error {
+  font-size: 11px;
+  color: var(--error);
+  white-space: nowrap;
+}
+
 @keyframes pulse {
   0%,
   100% {

--- a/tui-py/app.py
+++ b/tui-py/app.py
@@ -30,6 +30,7 @@ from data_types import (
     SessionTotals,
 )
 from format_utils import project_key as _project_key
+from resume_command import resume_command
 from sse import SSEClient
 from widgets.debug_viewer import DebugViewer
 from widgets.detail_view import DetailView
@@ -107,6 +108,10 @@ class CCTraceApp(App):
         Binding("r", "refresh", "Refresh", show=True, priority=True),
         Binding("h", "focus_sidebar", "◀ Sidebar", show=True, priority=True),
         Binding("l", "focus_content", "Content ▶", show=False, priority=True),
+        # Per-view: only relevant (and shown) once a session is in context —
+        # see check_action. Deliberately NOT priority=True and NOT shown in
+        # the picker footer, which already overflows on narrow terminals.
+        Binding("y", "copy_resume", "Copy resume", show=True),
     ]
 
     # ---- State ----
@@ -147,6 +152,10 @@ class CCTraceApp(App):
         self._sse: SSEClient | None = None
         self._subagent_expanded_msgs: set[int] = set()
         self._subagent_detail_item_idx: int = 0
+        # The SessionInfo backing the currently open session (list/detail
+        # views) — needed for copy_resume (cwd + session_id). None in the
+        # picker, where no session is selected yet.
+        self._current_session: SessionInfo | None = None
 
     # ----------------------------------------------------------------
     # Layout
@@ -321,6 +330,7 @@ class CCTraceApp(App):
                 self.expanded_items = set()
                 self.subagent_item = None
                 self.subagent_detail_msg = None
+                self._current_session = session
                 self.run_worker(
                     self._load_session(session.path),
                     exclusive=True,
@@ -484,6 +494,21 @@ class CCTraceApp(App):
     def action_show_teams(self) -> None:
         if self.view == "list" and self.teams:
             self.view = "team"
+
+    def action_copy_resume(self) -> None:
+        """y: copy the `claude --resume` command for the current session."""
+        sel = self._current_session
+        if sel is None:
+            return
+        self.copy_to_clipboard(resume_command(sel.cwd, sel.session_id))
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Hide copy_resume outside the list/detail views (no session in
+        context in the picker) — kept a per-view binding rather than a global
+        footer key so it doesn't add to the picker footer's known overflow."""
+        if action == "copy_resume":
+            return self.view in ("list", "detail") and self._current_session is not None
+        return True
 
     def action_d_action(self) -> None:
         """d: scroll down in current view, or show debug log from list view."""

--- a/tui-py/data_types.py
+++ b/tui-py/data_types.py
@@ -105,6 +105,22 @@ class DisplayMessage:
 
 
 # ---------------------------------------------------------------------------
+# Liveness
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Liveness:
+    """Live-session liveness from the pid-keyed registry (see shared/types.ts
+    and src-tauri/src/parser/session.rs `Liveness`). `status` is kept as an
+    open string (not an enum) — a new Claude-Code status must not break us."""
+
+    status: str = ""
+    idle_seconds: int = 0
+    pid: int = 0
+
+
+# ---------------------------------------------------------------------------
 # SessionInfo
 # ---------------------------------------------------------------------------
 
@@ -130,6 +146,7 @@ class SessionInfo:
     cwd: str = ""
     git_branch: str = ""
     permission_mode: str = ""
+    liveness: Liveness | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +330,24 @@ def _msg_from_dict(d: dict) -> DisplayMessage:
     )
 
 
+def _liveness_from_dict(d: dict | None) -> Liveness | None:
+    """Parse the nested `liveness` key: `{status, idle_seconds, pid} | null`.
+
+    Silent-degrade to None on any missing/retyped field — never raise, matching
+    the format-drift idiom the rest of this module follows.
+    """
+    if not d:
+        return None
+    try:
+        return Liveness(
+            status=str(d.get("status", "")),
+            idle_seconds=int(d.get("idle_seconds", 0)),
+            pid=int(d.get("pid", 0)),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
 def session_info_from_dict(d: dict) -> SessionInfo:
     return SessionInfo(
         path=d.get("path", ""),
@@ -334,6 +369,7 @@ def session_info_from_dict(d: dict) -> SessionInfo:
         cwd=d.get("cwd", ""),
         git_branch=d.get("git_branch", ""),
         permission_mode=d.get("permission_mode", ""),
+        liveness=_liveness_from_dict(d.get("liveness")),
     )
 
 

--- a/tui-py/resume_command.py
+++ b/tui-py/resume_command.py
@@ -1,0 +1,16 @@
+"""Builds the shell command to resume (or fork) a Claude Code session.
+
+Mirrors `src/lib/resumeCommand.ts` — same POSIX single-quoting for `cwd`,
+with an embedded `'` escaped as `'\\''`.
+"""
+
+from __future__ import annotations
+
+
+def _shq(s: str) -> str:
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def resume_command(cwd: str, session_id: str, fork: bool = False) -> str:
+    base = f"cd {_shq(cwd)} && claude --resume {session_id}"
+    return f"{base} --fork-session" if fork else base

--- a/tui-py/tests/test_copy_resume.py
+++ b/tui-py/tests/test_copy_resume.py
@@ -1,0 +1,100 @@
+"""Tests for CCTraceApp's copy_resume binding — copies `claude --resume …`
+for the currently selected session, and is only relevant (visible) once a
+session is in context (list/detail views), not in the picker's global footer,
+which already overflows on narrow terminals (see check_action)."""
+
+from __future__ import annotations
+
+import pytest
+
+import api
+import app as app_module
+from data_types import SessionInfo
+
+
+class _NoopSSE:
+    """Stands in for SSEClient so App.on_mount doesn't open a real connection."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def on(self, *_args, **_kwargs):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+
+async def _fake_get_project_dirs():
+    return []
+
+
+@pytest.fixture(autouse=True)
+def _stub_network(monkeypatch):
+    """Keep App.on_mount's background workers from touching a real backend."""
+    monkeypatch.setattr(app_module, "SSEClient", _NoopSSE)
+    monkeypatch.setattr(api, "get_project_dirs", _fake_get_project_dirs)
+
+
+@pytest.mark.asyncio
+async def test_action_copy_resume_copies_the_resume_command(monkeypatch):
+    async with app_module.CCTraceApp().run_test() as pilot:
+        app = pilot.app
+        app.view = "list"
+        app._current_session = SessionInfo(cwd="/it's", session_id="u1")
+
+        copied: list[str] = []
+        monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+        app.action_copy_resume()
+
+        assert copied == ["cd '/it'\\''s' && claude --resume u1"]
+
+
+@pytest.mark.asyncio
+async def test_action_copy_resume_is_noop_without_a_selected_session():
+    async with app_module.CCTraceApp().run_test() as pilot:
+        app = pilot.app
+        app.view = "list"
+        app._current_session = None
+
+        # Must not raise — there's nothing to copy.
+        app.action_copy_resume()
+
+
+@pytest.mark.asyncio
+async def test_copy_resume_hidden_in_picker_view():
+    async with app_module.CCTraceApp().run_test() as pilot:
+        app = pilot.app
+        app.view = "picker"
+        app._current_session = None
+
+        assert app.check_action("copy_resume", ()) is False
+
+
+@pytest.mark.asyncio
+async def test_copy_resume_visible_in_list_view_with_a_selected_session():
+    async with app_module.CCTraceApp().run_test() as pilot:
+        app = pilot.app
+        app.view = "list"
+        app._current_session = SessionInfo(cwd="/x", session_id="u2")
+
+        assert app.check_action("copy_resume", ()) is True
+
+
+@pytest.mark.asyncio
+async def test_y_key_copies_resume_command_via_pilot(monkeypatch):
+    async with app_module.CCTraceApp().run_test() as pilot:
+        app = pilot.app
+        app.view = "detail"
+        app._current_session = SessionInfo(cwd="/x", session_id="u3")
+
+        copied: list[str] = []
+        monkeypatch.setattr(app, "copy_to_clipboard", copied.append)
+
+        await pilot.press("y")
+
+        assert copied == ["cd '/x' && claude --resume u3"]

--- a/tui-py/tests/test_data_types_liveness.py
+++ b/tui-py/tests/test_data_types_liveness.py
@@ -1,0 +1,32 @@
+"""Tests for the nested `liveness` object mapping in session_info_from_dict."""
+
+from __future__ import annotations
+
+from data_types import session_info_from_dict
+
+
+def test_liveness_parsed_from_nested_dict():
+    info = session_info_from_dict(
+        {
+            "path": "p",
+            "session_id": "id",
+            "first_message": "hi",
+            "liveness": {"status": "idle", "idle_seconds": 60, "pid": 123},
+        }
+    )
+    assert info.liveness is not None
+    assert info.liveness.status == "idle"
+    assert info.liveness.idle_seconds == 60
+    assert info.liveness.pid == 123
+
+
+def test_liveness_degrades_to_none_on_malformed_shape():
+    info = session_info_from_dict(
+        {
+            "path": "p",
+            "session_id": "id",
+            "first_message": "hi",
+            "liveness": {"status": "idle", "idle_seconds": "notanumber"},
+        }
+    )
+    assert info.liveness is None

--- a/tui-py/tests/test_resume_command.py
+++ b/tui-py/tests/test_resume_command.py
@@ -1,0 +1,18 @@
+"""Tests for resume_command — mirrors the TypeScript src/lib/resumeCommand.ts
+(same POSIX single-quoting, `'` escaped as `'\\''`)."""
+
+from __future__ import annotations
+
+from resume_command import resume_command
+
+
+def test_quotes_cwd():
+    assert resume_command("/a b", "u1") == "cd '/a b' && claude --resume u1"
+
+
+def test_fork():
+    assert resume_command("/x", "u2", fork=True) == "cd '/x' && claude --resume u2 --fork-session"
+
+
+def test_escapes_quote():
+    assert resume_command("/it's", "u3") == "cd '/it'\\''s' && claude --resume u3"

--- a/tui-py/tests/test_session_picker_badge.py
+++ b/tui-py/tests/test_session_picker_badge.py
@@ -1,0 +1,73 @@
+"""Tests for the liveness badge text rendered in the session picker."""
+
+from __future__ import annotations
+
+import theme
+from data_types import Liveness, SessionInfo
+from widgets.session_picker import _liveness_badge, _render_session
+
+
+def test_liveness_badge_busy():
+    assert _liveness_badge(Liveness(status="busy", idle_seconds=0, pid=1)) == "● busy"
+
+
+def test_liveness_badge_idle_shows_minutes():
+    assert _liveness_badge(Liveness(status="idle", idle_seconds=180, pid=1)) == "○ idle 3m"
+
+
+def test_liveness_badge_unknown_status_falls_back():
+    assert _liveness_badge(Liveness(status="compacting", idle_seconds=0, pid=1)) == "○ compacting"
+
+
+# ---------------------------------------------------------------------------
+# _render_session — the badge splice into line 2
+# ---------------------------------------------------------------------------
+
+
+def _spans_with(text, needle):
+    """Return (covered_text, style) for spans whose style contains `needle`."""
+    return [
+        (text.plain[s.start : s.end], str(s.style)) for s in text.spans if needle in str(s.style)
+    ]
+
+
+def _content_text(session: SessionInfo):
+    """The rendered `Text` (line1 [+ subtitle] + line2) for `session`, pulled
+    out of the `Group(content, sep)` returned by `_render_session`."""
+    group = _render_session(session)
+    content = group.renderables[0]
+    assert content.plain  # sanity: it's the assembled Text, not the Rule
+    return content
+
+
+def test_render_session_busy_shows_badge_with_ongoing_style():
+    session = SessionInfo(
+        session_id="sid-busy12345",
+        liveness=Liveness(status="busy", idle_seconds=0, pid=123),
+    )
+    text = _content_text(session)
+    assert "● busy" in text.plain
+    matches = _spans_with(text, theme.ONGOING)
+    assert any("● busy" in covered for covered, _ in matches), (
+        "busy badge must be styled with theme.ONGOING"
+    )
+
+
+def test_render_session_idle_shows_badge_with_dim_style():
+    session = SessionInfo(
+        session_id="sid-idle12345",
+        liveness=Liveness(status="idle", idle_seconds=120, pid=123),
+    )
+    text = _content_text(session)
+    assert "○ idle 2m" in text.plain
+    matches = _spans_with(text, theme.TEXT_DIM)
+    assert any("○ idle 2m" in covered for covered, _ in matches), (
+        "idle badge must be styled with theme.TEXT_DIM (not the ongoing/busy style)"
+    )
+
+
+def test_render_session_no_liveness_omits_badge():
+    session = SessionInfo(session_id="sid-none12345", liveness=None)
+    text = _content_text(session)
+    assert "busy" not in text.plain
+    assert "idle" not in text.plain

--- a/tui-py/widgets/session_picker.py
+++ b/tui-py/widgets/session_picker.py
@@ -10,7 +10,7 @@ from rich.text import Text
 from textual.widgets import ListItem, Static
 
 import theme
-from data_types import SessionInfo
+from data_types import Liveness, SessionInfo
 from format_utils import format_cost, format_tokens, short_model, time_ago
 from theme import get_model_color
 from widgets.highlight_list import HighlightListView
@@ -21,6 +21,20 @@ ICON_BRANCH = "*"
 ICON_CHAT = "#"
 ICON_CLOCK = "~"
 ICON_SESSION = "@"
+
+
+def _liveness_badge(liveness: Liveness | None) -> str:
+    """Render a liveness badge. Forward-compatible: an unknown `status` value
+    (a future Claude-Code release) falls back to a neutral "○ <status>" rather
+    than disappearing or raising."""
+    if liveness is None:
+        return ""
+    if liveness.status == "busy":
+        return "● busy"
+    if liveness.status == "idle":
+        minutes = liveness.idle_seconds // 60
+        return f"○ idle {minutes}m"
+    return f"○ {liveness.status}"
 
 
 def _group_by_date(sessions: list[SessionInfo]) -> list[tuple[str, list[SessionInfo]]]:
@@ -85,6 +99,12 @@ def _render_session(s: SessionInfo, anim_frame: int = 0) -> object:
         line2.append(f" {format_cost(s.cost_usd)}", style=theme.TOKEN_HIGH)
     line2.append(f" {ICON_SESSION} {s.session_id[:8]}", style=theme.TEXT_DIM)
     line2.append(f" {ICON_CLOCK} {time_ago(s.mod_time)}", style=theme.TEXT_DIM)
+    badge = _liveness_badge(s.liveness)
+    if badge:
+        badge_style = (
+            theme.ONGOING if s.liveness and s.liveness.status == "busy" else theme.TEXT_DIM
+        )
+        line2.append(f"  {badge}", style=badge_style)
 
     if s.name and s.first_message:
         subtitle = Text(s.first_message, style=theme.TEXT_DIM)


### PR DESCRIPTION
## Summary

cctrace is a read-only viewer, so continuing a session you're looking at means copying its id off the screen and retyping `claude --resume` by hand.

This adds an action panel to the session view: Resume, Fork, and Focus. A status badge shows whether the session is still running.

## What it adds

- A live status badge on the open session (`● busy` / `○ idle Nm`), read from Claude Code's session registry at `~/.claude/sessions/*.json`. A stale entry (dead pid) never shows as live.
- Copy resume / Copy fork: both copy `cd '<cwd>' && claude --resume <id>` to the clipboard (Fork adds `--fork-session`). The full command is in the tooltip, and the button shows "Copied!".
- Focus window: brings the session's terminal window to the front. To find it, the backend walks up the process tree from the session's pid to the terminal app, then matches the session's tty (`/dev/ttysNNN`) to the right Terminal.app tab with AppleScript. Terminal.app only in v1, behind an adapter so other terminals can be added later.

## How it works

- The backend already reads `~/.claude/sessions/*.json` for `/rename` names. It now reads liveness from there too and adds it to the `SessionInfo` every frontend fetches, so the badge works on web, desktop, and the TUI.
- The resume/fork command is built in the frontend from the `session_id` and `cwd` it already has, shell-quoted. Nothing is executed, so it behaves the same everywhere.
- Focus runs in the backend (it calls `osascript`), so it isn't desktop-only. It's both a Tauri command and an HTTP endpoint (`POST /api/focus`), gated on a `can_focus` flag from `/api/settings`. A local web UI can focus a window; a remote or non-macOS backend hides the button.

## Notes

- The registry is undocumented internal state, so parsing is lenient: `status` is a plain string, and missing or changed fields just mean "no badge" instead of an error. A test pins the fields we read, so a format change fails the test instead of going unnoticed.
- When the badge shows, it replaces the old transcript-based "active" text, so you don't see both at once.
- Failures from `osascript`/`ps`/`kill` are logged, not swallowed. Those commands only ever take a numeric pid or a tty from `ps`. The session id is just a lookup key, never part of a command line.

## Verification

`npm run check` passes (tsc, lint, format, clippy, vitest, cargo test), plus the TUI's ruff and pytest. Tests cover the command quoting, the liveness parse and staleness guard, the badge states, the Focus adapter and its error messages, and the `can_focus` gating.

## Screenshots

The panel in the open session view: the live status badge, with Resume / Fork / Focus on the right.

<img width="1320" height="860" alt="session-control panel" src="https://github.com/user-attachments/assets/c949da1a-8986-45d4-8900-7474e7df2a6d" />

---
<sub>🤖 drafted with Claude Code, reviewed before submitting.</sub>
