### PR TITLE
feat(build): add "desktop" cargo feature for headless-only builds without Tauri/WebKit

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -8,12 +8,26 @@ rust-version = "1.77.2"
 name = "claude_code_trace_lib"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# `desktop` (default) builds the full Tauri desktop app, which links the
+# webview runtime (wry -> webkit2gtk on Linux). Disable it
+# (`--no-default-features`) to build a headless-only HTTP server binary with no
+# Tauri/webkit dependency — suitable for containers and web/TUI deployments.
+default = ["desktop"]
+desktop = [
+  "dep:tauri",
+  "dep:tauri-build",
+  "dep:tauri-plugin-fs",
+  "dep:tauri-plugin-opener",
+  "dep:tauri-plugin-single-instance",
+]
+
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2", features = [], optional = true }
 
 [dependencies]
-tauri = { version = "2", features = [] }
-tauri-plugin-fs = "2"
+tauri = { version = "2", features = [], optional = true }
+tauri-plugin-fs = { version = "2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -23,8 +37,8 @@ notify = "8"
 tokio = { version = "1", features = ["full"] }
 thiserror = "2"
 dirs = "6"
-tauri-plugin-opener = "2.5.4"
-tauri-plugin-single-instance = "2"
+tauri-plugin-opener = { version = "2.5.4", optional = true }
+tauri-plugin-single-instance = { version = "2", optional = true }
 axum = { version = "0.8", features = ["json"] }
 tower-http = { version = "0.7", features = ["cors", "fs"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,7 @@
 fn main() {
-    tauri_build::build()
+    // The Tauri build step (context codegen, etc.) is only needed for the
+    // desktop app. Headless-only builds (`--no-default-features`) skip it so
+    // they don't require the tauri-build dependency or a frontend bundle.
+    #[cfg(feature = "desktop")]
+    tauri_build::build();
 }

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -10,7 +10,10 @@ pub struct GitInfo {
 }
 
 /// Get git info (branch, dirty state, worktree dirs) for a directory.
-#[tauri::command]
+///
+/// Called directly by the HTTP API (`GET /api/git-info`) in all builds; the
+/// `#[tauri::command]` wrapper is applied only in desktop builds.
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn get_git_info(cwd: String) -> GitInfo {
     if cwd.is_empty() {
         return GitInfo {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,7 +1,16 @@
+// Command modules only wired into the Tauri `invoke_handler` (desktop build).
+// The HTTP API does not call into these, so they compile out entirely in
+// headless-only builds.
+#[cfg(feature = "desktop")]
 pub mod debug;
-pub mod git;
+#[cfg(feature = "desktop")]
 pub mod picker;
+#[cfg(feature = "desktop")]
 pub mod session;
+
+// Modules with impl functions the HTTP API also uses. These stay compiled in
+// all builds; only their `#[tauri::command]` wrappers are desktop-gated.
+pub mod git;
 pub mod settings;
 pub mod terminal;
 pub mod wsl;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,8 +1,11 @@
-use std::sync::Arc;
-
 use serde::Serialize;
+
+#[cfg(feature = "desktop")]
+use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::State;
 
+#[cfg(feature = "desktop")]
 use crate::state::AppState;
 
 /// Response for the frontend — always includes both the configured and default paths.
@@ -50,12 +53,14 @@ pub fn build_response_pub(settings: &crate::settings::Settings) -> SettingsRespo
     }
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn get_settings(state: State<'_, Arc<AppState>>) -> Result<SettingsResponse, String> {
     let guard = state.settings.lock().map_err(|e| e.to_string())?;
     Ok(build_response_pub(&guard))
 }
 
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn set_projects_dir(
     path: Option<String>,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -206,6 +206,7 @@ pub fn resolve_tty(pid: i64) -> Option<String> {
 /// `focus_session_window_impl`, over the HTTP API (`POST /api/focus`) — any
 /// frontend whose backend is local + macOS can focus a terminal window, not
 /// just the Tauri app.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn focus_session_window(session_id: String) -> Result<(), String> {
     focus_session_window_impl(&session_id).map_err(|e| e.user_message())

--- a/src-tauri/src/commands/wsl.rs
+++ b/src-tauri/src/commands/wsl.rs
@@ -1,9 +1,13 @@
 use std::collections::HashSet;
-use std::sync::Arc;
 
+#[cfg(feature = "desktop")]
+use std::sync::Arc;
+#[cfg(feature = "desktop")]
 use tauri::State;
 
+#[cfg(feature = "desktop")]
 use crate::commands::settings::{build_response_pub, SettingsResponse};
+#[cfg(feature = "desktop")]
 use crate::state::AppState;
 
 /// Trim, drop empty entries, and de-duplicate distro names while preserving order.
@@ -18,12 +22,14 @@ pub fn sanitize_distros(distros: Vec<String>) -> Vec<String> {
 
 /// List installed WSL distributions. Empty on non-Windows hosts or when WSL is
 /// not installed.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn list_wsl_distros() -> Result<Vec<String>, String> {
     Ok(crate::wsl::list_distros())
 }
 
 /// Persist the set of WSL distros whose projects should be discovered.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 pub async fn set_wsl_distros(
     distros: Vec<String>,

--- a/src-tauri/src/http_api.rs
+++ b/src-tauri/src/http_api.rs
@@ -9,7 +9,6 @@ use axum::response::{IntoResponse, Json, Response};
 use axum::routing::{get, post};
 use axum::Router;
 use serde::Deserialize;
-use tauri::{AppHandle, Manager};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 use tower_http::cors::CorsLayer;
@@ -19,6 +18,7 @@ use crate::parser::debuglog::*;
 use crate::parser::session::extract_session_meta;
 use crate::state::AppState;
 use crate::watcher::{start_picker_watcher, start_session_watcher};
+use crate::AppHandle;
 
 /// Shared state for axum handlers.
 #[derive(Clone)]
@@ -64,7 +64,9 @@ pub fn resolve_static_dir() -> Option<String> {
 }
 
 /// Start the HTTP API server from a Tauri AppHandle (desktop/web mode).
+#[cfg(feature = "desktop")]
 pub async fn start_http_server(app: AppHandle) {
+    use tauri::Manager;
     let app_state: Arc<AppState> = app.state::<Arc<AppState>>().inner().clone();
     run_server(Arc::new(HttpState {
         app_state,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,26 +13,56 @@ mod wsl;
 
 use std::sync::Arc;
 
+#[cfg(feature = "desktop")]
 use tauri::Manager;
 
-pub fn run() {
-    let args: Vec<String> = std::env::args().collect();
-    let web_only = args.iter().any(|a| a == "--web");
-    let headless = args.iter().any(|a| a == "--headless");
-    let no_open = args.iter().any(|a| a == "--no-open");
-    let desktop = !web_only && !headless;
+/// Handle to the running desktop app, used to emit events to the webview.
+///
+/// In headless-only builds (the `desktop` feature disabled, e.g.
+/// `--no-default-features`) there is no webview and no Tauri runtime, so this
+/// is an uninhabited type: every `Option<AppHandle>` is always `None` and the
+/// emit-to-webview code paths compile out entirely.
+#[cfg(feature = "desktop")]
+pub use tauri::AppHandle;
+#[cfg(not(feature = "desktop"))]
+#[derive(Clone)]
+pub enum AppHandle {}
 
-    // Headless mode: skip Tauri/WebKit entirely — run only the HTTP server.
-    // This eliminates the WebKitWebProcess + WebKitNetworkProcess that Tauri
-    // unconditionally spawns even when no window is displayed, which was the
-    // dominant cause of high CPU usage in Docker containers.
-    if headless {
-        eprintln!("Headless mode: HTTP API on http://127.0.0.1:11423");
-        let app_state = Arc::new(state::AppState::new());
-        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
-        rt.block_on(http_api::start_http_server_headless(app_state));
-        return;
+pub fn run() {
+    // With the `desktop` feature disabled, headless is the only mode: there is
+    // no Tauri/WebKit compiled in, so we always run just the HTTP server.
+    #[cfg(not(feature = "desktop"))]
+    run_headless();
+
+    #[cfg(feature = "desktop")]
+    {
+        let args: Vec<String> = std::env::args().collect();
+        if args.iter().any(|a| a == "--headless") {
+            run_headless();
+        } else {
+            run_desktop(&args);
+        }
     }
+}
+
+/// Run only the axum HTTP API server, with no Tauri/WebKit. This eliminates the
+/// WebKitWebProcess + WebKitNetworkProcess that Tauri unconditionally spawns
+/// even when no window is displayed, which was the dominant cause of high CPU
+/// usage in Docker containers.
+fn run_headless() {
+    eprintln!("Headless mode: HTTP API on http://127.0.0.1:11423");
+    let app_state = Arc::new(state::AppState::new());
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    rt.block_on(http_api::start_http_server_headless(app_state));
+}
+
+/// Run the Tauri desktop app (or `--web`, which still hosts the webview runtime
+/// and just points a browser at it). Requires the `desktop` feature.
+#[cfg(feature = "desktop")]
+fn run_desktop(args: &[String]) {
+    let web_only = args.iter().any(|a| a == "--web");
+    let no_open = args.iter().any(|a| a == "--no-open");
+    let desktop = !web_only;
 
     let app_state = Arc::new(state::AppState::new());
 
@@ -102,6 +132,7 @@ pub fn run() {
 }
 
 /// Open the web UI in the default browser and hide the desktop window.
+#[cfg(feature = "desktop")]
 #[tauri::command]
 async fn switch_to_browser(app: tauri::AppHandle) -> Result<(), String> {
     tauri_plugin_opener::open_url("http://localhost:1420", None::<&str>)

--- a/src-tauri/src/watcher.rs
+++ b/src-tauri/src/watcher.rs
@@ -3,12 +3,28 @@ use std::sync::Arc;
 use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc;
+
+#[cfg(feature = "desktop")]
+use tauri::Emitter;
+
+use crate::AppHandle;
 
 use crate::parser::session::IncrementalTokenScanner;
 use crate::session_load::{build_view, TimeFilter};
 use crate::state::AppState;
+
+/// Emit an event to the desktop webview, if one is attached. Compiles to a
+/// no-op in headless-only builds (no Tauri), where `app` is always `None`.
+#[cfg(feature = "desktop")]
+fn emit_to_webview<P: serde::Serialize + Clone>(app: &Option<AppHandle>, event: &str, payload: P) {
+    if let Some(handle) = app {
+        let _ = handle.emit(event, payload);
+    }
+}
+
+#[cfg(not(feature = "desktop"))]
+fn emit_to_webview<P>(_app: &Option<AppHandle>, _event: &str, _payload: P) {}
 
 const WATCHER_DEBOUNCE: Duration = Duration::from_millis(1000);
 
@@ -248,9 +264,7 @@ pub fn start_session_watcher(
                         state.broadcast("session-update", &json);
                     }
 
-                    if let Some(ref app_handle) = app {
-                        let _ = app_handle.emit("session-update", payload);
-                    }
+                    emit_to_webview(&app, "session-update", payload);
                 }
             }
         }
@@ -338,9 +352,7 @@ pub fn start_picker_watcher(
                     // server-side cache coalesces concurrent requests.
                     state.broadcast("picker-refresh", "{}");
 
-                    if let Some(ref app_handle) = app {
-                        let _ = app_handle.emit("picker-refresh", serde_json::json!({}));
-                    }
+                    emit_to_webview(&app, "picker-refresh", serde_json::json!({}));
                 }
             }
         }


### PR DESCRIPTION
## Summary
I'm interested in playing around with claude-code-trace, but don't have easy access to webkit2gtk.  The change here enables me to build without that feature set and then still use the tui or webui at runtime.

Adds a default-on `desktop` cargo feature to the `src-tauri` crate. Building with `--no-default-features` produces a **headless-only HTTP server binary that does not link the Tauri webview runtime** (`wry` → `libwebkit2gtk-4.1` on Linux).

Today the backend links `webkit2gtk` unconditionally, even though `--headless` already skips Tauri/WebKit *at runtime* (see the comment in `lib.rs`: *"Headless mode: skip Tauri/WebKit entirely"*). So a container that only ever runs `--headless` still has to ship `libwebkit2gtk` (and the Dockerfile installs `xvfb`) purely to satisfy the dynamic linker. This change lets the headless server **build** without the webview too.

**Desktop behavior is unchanged** — the feature is on by default, so `cargo build` / `tauri build` / `tauri dev` behave exactly as before.

## What changed

- **`Cargo.toml`**: `tauri`, `tauri-build`, and the `tauri-plugin-*` deps are now `optional`; `[features] default = ["desktop"]`.
- **`build.rs`**: `tauri_build::build()` runs only under `desktop`.
- **`lib.rs`**: `run()` splits into `run_headless()` (always compiled) and `run_desktop()` (`desktop` only). `AppHandle` is re-exported from `tauri` under `desktop`, and is an uninhabited type otherwise (so `Option<AppHandle>` is always `None` and the emit-to-webview paths compile out).
- **`http_api.rs` / `watcher.rs`**: the `AppHandle`-typed field/params are gated behind `desktop`, and the `.emit()`-to-webview calls go through a small `emit_to_webview()` helper (a no-op when `desktop` is off). The SSE `broadcast()` path (used by the HTTP/web/TUI clients) is untouched.
- **`commands/`**: `session`, `picker`, `debug` are desktop-only (only wired into the Tauri `invoke_handler`). For `settings`/`git`/`wsl`/`terminal`, the plain impl functions the HTTP API calls stay compiled in all builds; only their `#[tauri::command]` wrappers and `use tauri::*` imports are gated — e.g. `git.rs` uses `#[cfg_attr(feature = "desktop", tauri::command)]` on a single definition, so the command name is preserved for the webview frontend.

No changes to request handling, file access, or the shell-outs in `commands` — this only controls whether the Tauri desktop layer is compiled in.

## Testing

With `--no-default-features` (headless-only):

- `cargo build --no-default-features --bin claude-code-trace` — compiles; **no `tauri`/`wry`/`webkit`/`gtk` crates built**.
- `ldd` on the resulting binary — **no `libwebkit2gtk`/GTK/soup**.
- `cargo test --no-default-features` — **581 passed**.
- `cargo clippy --no-default-features` and `cargo fmt --check` — clean.
- Ran `--headless` and hit `GET /api/settings` → `HTTP 200` with the expected JSON, and served the built web UI (`CCTRACE_STATIC_DIR`) on the same port.

The default (desktop) feature build is unchanged but was not compiled in my environment (no `webkit2gtk` dev headers available here) — CI / a Debian or macOS environment covers that path.

## Notes / open questions

- Feature name: I used `desktop` (default-on). Happy to rename (e.g. `tauri`, or invert to an opt-in `headless`) if you prefer a different convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
