### PR TITLE
fix(parser): handle inlined system-reminder in Sonnet 5 user entries (v2.1.201+)

### DIFF
--- a/src-tauri/src/parser/classify.rs
+++ b/src-tauri/src/parser/classify.rs
@@ -529,8 +529,15 @@ pub fn classify(e: Entry) -> Option<ClassifiedMsg> {
     // User message.
     if e.entry_type == "user" && !e.is_meta {
         let trimmed = content_str.trim();
+        // v2.1.201+ (Sonnet 5): harness reminders are inlined as <system-reminder> tags inside
+        // user entries rather than delivered as separate JSONL entries. Do not exclude entries
+        // that merely START with <system-reminder> — is_user_noise() already dropped the
+        // pure-reminder case (starts AND ends with the tag). Entries that pass is_user_noise()
+        // and start with <system-reminder> contain additional user content after the reminder;
+        // classify them as UserMsg and let sanitize_content() strip the reminder block.
         let excluded = SYSTEM_OUTPUT_TAGS
             .iter()
+            .filter(|&&tag| tag != "<system-reminder>")
             .any(|tag| trimmed.starts_with(tag));
         if !excluded && has_user_content(&e.message.content, &content_str) {
             return Some(ClassifiedMsg::User(UserMsg {
@@ -1167,6 +1174,54 @@ mod tests {
         let content = "<system-reminder>some reminder</system-reminder>";
         let e = make_entry("user", Some(json!(content)));
         assert!(classify(e).is_none());
+    }
+
+    // v2.1.201+ (Sonnet 5) compat: harness reminders are inlined at the start of user entries.
+    // The entry must be classified as UserMsg with the reminder stripped, not dropped/meta-AI.
+    #[test]
+    fn classify_v2_1_201_reminder_prefix_string_content_becomes_user_msg() {
+        let content =
+            "<system-reminder>Context from previous turns.</system-reminder>\nWhat is 2+2?";
+        let e = make_entry("user", Some(json!(content)));
+        match classify(e) {
+            Some(ClassifiedMsg::User(u)) => {
+                assert!(
+                    !u.text.contains("<system-reminder>"),
+                    "reminder tag must be stripped: {:?}",
+                    u.text
+                );
+                assert!(
+                    u.text.contains("What is 2+2?"),
+                    "user question must be preserved: {:?}",
+                    u.text
+                );
+            }
+            other => panic!("Expected User, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_v2_1_201_reminder_prefix_array_content_becomes_user_msg() {
+        let content = json!([
+            {"type": "text", "text": "<system-reminder>Harness context.</system-reminder>"},
+            {"type": "text", "text": "Explain recursion."}
+        ]);
+        let e = make_entry("user", Some(content));
+        match classify(e) {
+            Some(ClassifiedMsg::User(u)) => {
+                assert!(
+                    !u.text.contains("<system-reminder>"),
+                    "reminder tag must be stripped: {:?}",
+                    u.text
+                );
+                assert!(
+                    u.text.contains("Explain recursion."),
+                    "user question must be preserved: {:?}",
+                    u.text
+                );
+            }
+            other => panic!("Expected User, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1516,8 +1516,16 @@ fn is_user_chunk_for_turn_count(
     }
 
     // System output tags.
+    // v2.1.201+ (Sonnet 5): <system-reminder> tags may be inlined at the start of user entries
+    // that also contain real user content. Only exclude when the ENTIRE content is a reminder
+    // (starts AND ends with the tag); mixed entries must still count as user turns.
     for tag in SYSTEM_OUTPUT_TAGS {
-        if trimmed.starts_with(tag) {
+        if *tag == "<system-reminder>" {
+            let close_tag = tag.replace('<', "</");
+            if trimmed.starts_with(tag) && trimmed.ends_with(close_tag.as_str()) {
+                return false;
+            }
+        } else if trimmed.starts_with(tag) {
             return false;
         }
     }
@@ -3530,5 +3538,51 @@ mod tests {
         assert_eq!(meta.git_branch, "main");
 
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    // --- is_user_chunk_for_turn_count compat tests (v2.1.201+) ---
+
+    fn make_user_raw(content: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": content
+            }
+        })
+    }
+
+    #[test]
+    fn turn_count_excludes_pure_system_reminder_entry() {
+        let raw = make_user_raw(serde_json::json!(
+            "<system-reminder>Some context reminder.</system-reminder>"
+        ));
+        assert!(
+            !is_user_chunk_for_turn_count(&raw, "user", false, false),
+            "pure reminder must not count as a turn"
+        );
+    }
+
+    #[test]
+    fn turn_count_includes_v2_1_201_reminder_plus_user_message_string() {
+        let raw = make_user_raw(serde_json::json!(
+            "<system-reminder>Reminder context.</system-reminder>\nActual user question"
+        ));
+        assert!(
+            is_user_chunk_for_turn_count(&raw, "user", false, false),
+            "reminder-prefixed entry with additional content must count as a turn"
+        );
+    }
+
+    #[test]
+    fn turn_count_includes_v2_1_201_reminder_plus_user_message_array() {
+        let raw = make_user_raw(serde_json::json!([
+            {"type": "text", "text": "<system-reminder>Harness context.</system-reminder>"},
+            {"type": "text", "text": "Tell me about recursion."}
+        ]));
+        assert!(
+            is_user_chunk_for_turn_count(&raw, "user", false, false),
+            "reminder-prefixed array entry with additional content must count as a turn"
+        );
     }
 }


### PR DESCRIPTION
Fixes #199

## Problem

Claude Code v2.1.201 (Sonnet 5) changed how harness reminders are delivered: instead of separate JSONL entries with `message.role == "system"`, they are now inlined as `<system-reminder>` tags at the start of existing **user** entries. For example:

```
{"type":"user","message":{"role":"user","content":"<system-reminder>…context…</system-reminder>\nActual user question"}}
```

Two parser locations checked `SYSTEM_OUTPUT_TAGS` with a simple `starts_with` test, which caused these mixed-content user entries to be silently dropped (misclassified as non-user or not counted as turns):

1. **`classify.rs`** — the `UserMsg` classification path excluded any user entry whose content started with `<system-reminder>`, causing them to fall through to the meta-AI fallback.
2. **`session.rs`** — `is_user_chunk_for_turn_count()` excluded the same entries, causing conversation turn counts to be wrong.

`is_user_noise()` already handled the pure-reminder case correctly (starts **AND** ends with the tag), and `sanitize_content()` already strips `<system-reminder>` blocks from display text — so only the two exclusion checks needed fixing.

## Fix

**`src-tauri/src/parser/classify.rs`** — In the `UserMsg` classification path, filter `<system-reminder>` out of the `SYSTEM_OUTPUT_TAGS` exclusion check. Entries that are entirely a reminder are already dropped earlier by `is_user_noise()` (starts AND ends with the tag). Entries that pass `is_user_noise()` and still start with `<system-reminder>` contain real user content after the reminder; they are classified as `UserMsg` and `sanitize_content()` strips the reminder tag from the display text.

**`src-tauri/src/parser/session.rs`** — In `is_user_chunk_for_turn_count()`, apply the same starts-AND-ends logic for `<system-reminder>`: only exclude the entry from the turn count when the **entire** content is a reminder block. Mixed entries (reminder prefix + user text) correctly count as user turns.

## Tests

Five new Rust tests:

- `classify_v2_1_201_reminder_prefix_string_content_becomes_user_msg` — string content with reminder prefix classifies as `UserMsg` with reminder stripped
- `classify_v2_1_201_reminder_prefix_array_content_becomes_user_msg` — array content with reminder block classifies as `UserMsg` with reminder stripped
- `turn_count_excludes_pure_system_reminder_entry` — pure-reminder entry still does not count as a user turn
- `turn_count_includes_v2_1_201_reminder_plus_user_message_string` — mixed string entry counts as a user turn
- `turn_count_includes_v2_1_201_reminder_plus_user_message_array` — mixed array entry counts as a user turn

All 587 Rust tests pass. `cargo clippy -- -D warnings` clean.
