### PR TITLE
fix(ui): show empty-state note when a team has no tracked tasks

### DIFF
--- a/src/components/TeamBoard.test.tsx
+++ b/src/components/TeamBoard.test.tsx
@@ -103,4 +103,11 @@ describe("TeamBoard", () => {
     expect(screen.getByText("pending")).toBeInTheDocument();
     expect(screen.getByText("Tasks (3)")).toBeInTheDocument();
   });
+
+  it("shows an empty-state note when a team has no tasks", () => {
+    const teams = [makeTeam({ tasks: [] })];
+    render(<TeamBoard teams={teams} />);
+    expect(screen.getByText("Tasks (0)")).toBeInTheDocument();
+    expect(screen.getByText(/No tasks tracked in this session/)).toBeInTheDocument();
+  });
 });

--- a/src/components/TeamBoard.tsx
+++ b/src/components/TeamBoard.tsx
@@ -56,10 +56,15 @@ export function TeamBoard({ teams }: TeamBoardProps) {
             )}
 
             {/* Tasks */}
-            {team.tasks.length > 0 && (
-              <div className="team-board__section">
-                <div className="team-board__section-title">Tasks ({team.tasks.length})</div>
-                {team.tasks.map((task) => {
+            <div className="team-board__section">
+              <div className="team-board__section-title">Tasks ({team.tasks.length})</div>
+              {team.tasks.length === 0 ? (
+                <div className="team-board__section-empty">
+                  No tasks tracked in this session — task-tracking tools may be disabled for this
+                  model
+                </div>
+              ) : (
+                team.tasks.map((task) => {
                   const statusIcon = taskStatusIcons[task.status] ?? taskStatusIcons.pending;
                   const statusClass = task.status.replace(/\s+/g, "_");
 
@@ -85,9 +90,9 @@ export function TeamBoard({ teams }: TeamBoardProps) {
                       </span>
                     </div>
                   );
-                })}
-              </div>
-            )}
+                })
+              )}
+            </div>
           </div>
         </div>
       ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2190,6 +2190,12 @@ body {
   margin-bottom: 8px;
 }
 
+.team-board__section-empty {
+  font-size: 12px;
+  color: var(--text-dim);
+  font-style: italic;
+}
+
 .team-task {
   display: flex;
   align-items: flex-start;

--- a/tui-py/tests/test_team_board.py
+++ b/tui-py/tests/test_team_board.py
@@ -1,0 +1,29 @@
+"""Tests for TeamBoard's task list rendering, including the empty-tasks note."""
+
+from __future__ import annotations
+
+from data_types import TeamSnapshot, TeamTask
+from widgets.team_board import TeamBoard
+
+
+def _make_widget(teams: list[TeamSnapshot]) -> TeamBoard:
+    widget = TeamBoard()
+    widget.teams = teams
+    return widget
+
+
+def test_shows_no_tasks_note_when_team_has_no_tasks():
+    team = TeamSnapshot(name="alpha", members=["alice"], tasks=[])
+    content = _make_widget([team])._build_content()
+    assert "No tasks tracked in this session" in content
+
+
+def test_renders_tasks_when_present():
+    team = TeamSnapshot(
+        name="alpha",
+        members=["alice"],
+        tasks=[TeamTask(id="1", subject="Fix bug", status="completed", owner="alice")],
+    )
+    content = _make_widget([team])._build_content()
+    assert "Fix bug" in content
+    assert "No tasks tracked in this session" not in content

--- a/tui-py/widgets/team_board.py
+++ b/tui-py/widgets/team_board.py
@@ -114,12 +114,18 @@ class TeamBoard(Widget):
                 lines.append("  " + "".join(member_parts))
 
             # Tasks
-            for task in team.tasks:
-                icon = _status_icon(task.status)
-                clr = _status_color(task.status)
-                owner_str = f"  [{theme.TEXT_DIM}]{task.owner}[/]" if task.owner else ""
+            if team.tasks:
+                for task in team.tasks:
+                    icon = _status_icon(task.status)
+                    clr = _status_color(task.status)
+                    owner_str = f"  [{theme.TEXT_DIM}]{task.owner}[/]" if task.owner else ""
+                    lines.append(
+                        f"  [{theme.TEXT_DIM}]#{task.id}[/] [{clr}]{icon}[/] {task.subject}{owner_str}"
+                    )
+            else:
                 lines.append(
-                    f"  [{theme.TEXT_DIM}]#{task.id}[/] [{clr}]{icon}[/] {task.subject}{owner_str}"
+                    f"  [{theme.TEXT_DIM}]No tasks tracked in this session — task-tracking "
+                    f"tools may be disabled for this model[/]"
                 )
 
             lines.append("")


### PR DESCRIPTION
## What changed

Claude Code v2.1.233 disables the task-tracking tools (`TaskCreate`/`TaskUpdate`/`TaskList`/`TaskGet`, `TodoWrite`) by default on newer models (Opus 4.8, Sonnet 5, Fable 5, Mythos 5+), unless `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` is set.

The Teams board's Tasks section (both the web `TeamBoard` component and the TUI `team_board` widget) was only rendered when a team had at least one task. With task-tracking tools disabled, a team can now exist with members but zero tasks, and the Tasks section simply vanished — indistinguishable from a parsing bug.

This PR makes the Tasks section always render, showing an explanatory note ("No tasks tracked in this session — task-tracking tools may be disabled for this model") when there are no tasks, on both the web and TUI surfaces.

## Why

Fixes #251. No parser change was needed — the content block shape for these tools is unchanged. This is purely a UI clarity fix so an empty Tasks section reads as expected model behavior rather than a rendering regression.

## Testing

- Added a vitest case for the web `TeamBoard` empty-tasks state.
- Added `tui-py/tests/test_team_board.py` covering the TUI's empty and non-empty task rendering.
- `npx oxfmt`, `npx oxlint`, `npx tsc --noEmit`, `npx vitest run` (496 tests), `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (666 + 2 tests) all pass.
- `python3.11 -m pytest tui-py/tests` (77 tests) and `python3.11 -m ruff check tui-py` pass.
- `claude --debug-file` confirmed trace capture is unaffected (this change touches no parser code).
