### PR TITLE
fix(projectTree): nest by real cwd path, not the opaque directory-name key

### DIFF
--- a/shared/projectTree.test.ts
+++ b/shared/projectTree.test.ts
@@ -90,6 +90,17 @@ describe("buildProjectNodes", () => {
     expect(buildProjectNodes(sessions)[0].name).toBe("proj-a");
   });
 
+  it("records the origin dir on the node for downstream real-path nesting checks", () => {
+    const sessions = [
+      makeSession({
+        path: "/home/user/.claude/projects/session-abc/s1.jsonl",
+        cwd: "/srv/backend",
+      }),
+    ];
+    const nodes = buildProjectNodes(sessions);
+    expect(nodes[0].origin).toBe("/srv/backend");
+  });
+
   it("tracks ongoing status", () => {
     const sessions = [
       makeSession({
@@ -230,6 +241,71 @@ describe("buildTree", () => {
     ];
     const roots = buildTree(nodes);
     expect(roots).toHaveLength(2);
+  });
+
+  // --- Issue #259: CLAUDE_CODE_PROJECT_DIR_NAME lets hosts assign arbitrary,
+  // path-unrelated directory names, so nesting can no longer trust a key-prefix match alone.
+
+  it("nests via real cwd path even when host-assigned keys share no prefix", () => {
+    const nodes = [
+      {
+        name: "backend",
+        key: "session-abc",
+        origin: "/srv/backend",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+      {
+        name: "hotfix",
+        key: "session-xyz",
+        origin: "/srv/backend/.claude-worktrees/hotfix",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+    ];
+    const roots = buildTree(nodes);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].node.key).toBe("session-abc");
+    expect(roots[0].children).toHaveLength(1);
+    expect(roots[0].children[0].node.key).toBe("session-xyz");
+  });
+
+  it("does not nest two unrelated projects whose host-assigned keys coincidentally share a prefix", () => {
+    const nodes = [
+      {
+        name: "backend",
+        key: "backend",
+        origin: "/srv/backend",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+      {
+        name: "backend-hotfix",
+        key: "backend-hotfix",
+        origin: "/tools/backend-hotfix",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+    ];
+    const roots = buildTree(nodes);
+    expect(roots).toHaveLength(2);
+  });
+
+  it("falls back to key-prefix matching when origin is unknown for either side", () => {
+    const nodes = [
+      {
+        name: "backend",
+        key: "-Users-me-backend",
+        origin: "/Users/me/backend",
+        sessionCount: 1,
+        hasOngoing: false,
+      },
+      { name: "tools", key: "-Users-me-backend-tools", sessionCount: 1, hasOngoing: false },
+    ];
+    const roots = buildTree(nodes);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].children).toHaveLength(1);
+    expect(roots[0].children[0].node.key).toBe("-Users-me-backend-tools");
   });
 
   it("creates virtual intermediate node for -- segments between parent and worktree", () => {

--- a/shared/projectTree.ts
+++ b/shared/projectTree.ts
@@ -11,6 +11,10 @@ import { projectKey, projectDisplayName, shortPath } from "./format.js";
 export interface ProjectNode {
   name: string;
   key: string;
+  /** Real filesystem path this node is anchored at (the anchor's origin dir, falling back
+   *  to its cwd), when known. Used to verify tree nesting against actual content instead
+   *  of the opaque `~/.claude/projects/<dir>` name — see `isRealDescendant`. */
+  origin?: string;
   sessionCount: number;
   hasOngoing: boolean;
 }
@@ -63,6 +67,7 @@ export function buildProjectNodes(sessions: SessionInfo[]): ProjectNode[] {
       map.set(key, {
         name: shortPath(origin) || projectDisplayName(key),
         key,
+        origin: origin || undefined,
         sessionCount: 1,
         hasOngoing: s.is_ongoing,
       });
@@ -97,6 +102,28 @@ function hasRealAncestor(key: string, keys: ReadonlySet<string>): boolean {
   return false;
 }
 
+/**
+ * True when `child` is a real filesystem descendant of `parent`. A host can rename a
+ * project's `~/.claude/projects/<dir>` transcript folder to an arbitrary short name via
+ * `CLAUDE_CODE_PROJECT_DIR_NAME` (Claude Code v2.1.234+), so the directory-name `key` is
+ * no longer guaranteed to encode the real path — two unrelated projects could coincidentally
+ * share a key prefix, or a genuinely nested project (real worktree) could have an unrelated
+ * key. See #259.
+ */
+function isRealDescendant(child: string | undefined, parent: string | undefined): boolean {
+  if (!child || !parent || child === parent) return false;
+  return child.startsWith(parent.replace(/\/+$/, "") + "/");
+}
+
+/** Whether `node` nests under `candidate` — prefers the real cwd-derived path relationship
+ *  over the opaque key when both are known, falling back to key-prefix matching otherwise. */
+function nestsUnder(node: ProjectNode, candidate: ProjectNode): boolean {
+  if (node.origin && candidate.origin) {
+    return isRealDescendant(node.origin, candidate.origin);
+  }
+  return node.key.startsWith(candidate.key + "-");
+}
+
 export function buildTree(nodes: ProjectNode[]): TreeNode[] {
   // A worktree session whose orchestrator never opens a session at the repo root (headless
   // / deterministic runs that only ever execute agent phases inside per-item worktrees) has
@@ -126,7 +153,7 @@ export function buildTree(nodes: ProjectNode[]): TreeNode[] {
     let parent: TreeNode | undefined;
     for (const candidate of all) {
       if (
-        node.key.startsWith(candidate.node.key + "-") &&
+        nestsUnder(node, candidate.node) &&
         (!parent || candidate.node.key.length > parent.node.key.length)
       ) {
         parent = candidate;

--- a/specs/07-data-types.md
+++ b/specs/07-data-types.md
@@ -226,6 +226,7 @@ classDiagram
     class ProjectNode {
         +key: string
         +label: string
+        +origin: string
         +sessions: SessionInfo[]
         +children: ProjectNode[]
         +is_ongoing: boolean
@@ -234,7 +235,10 @@ classDiagram
 ```
 
 `buildProjectTree(sessions)` partitions sessions by project key (derived from the JSONL file path)
-and nests worktree sessions under their parent project.
+and nests worktree sessions under their parent project. `origin` (the real cwd-derived path the
+node is anchored at, when known) is preferred over the key for that nesting decision, since a host
+can assign the `~/.claude/projects/<dir>` folder an arbitrary name unrelated to the real path via
+`CLAUDE_CODE_PROJECT_DIR_NAME` — see [11-project-tree.md](11-project-tree.md).
 
 ---
 

--- a/specs/11-project-tree.md
+++ b/specs/11-project-tree.md
@@ -59,12 +59,16 @@ classDiagram
     class ProjectNode {
         +String key
         +String label
+        +String origin
         +SessionInfo[] sessions
         +ProjectNode[] children
         +bool is_ongoing
         +number total_sessions
     }
 ```
+
+`origin` is the real cwd-derived path the node is anchored at (when known) — see "Real
+path takes precedence over the key" above.
 
 `label` is the human-readable display name. It is derived from the session's **origin
 working directory** — `dirs[0]`, the first `cwd` seen in the JSONL, which is the directory
@@ -96,6 +100,24 @@ flowchart LR
     PARENT --> CHILD["nest under parent node\nas child"]
     CHILD --> LABEL["label: 'feature-branch'"]
 ```
+
+### Real path takes precedence over the key (issue #259)
+
+Claude Code v2.1.234 added `CLAUDE_CODE_PROJECT_DIR_NAME`, letting a host assign an
+arbitrary short name to a project's `~/.claude/projects/<dir>` folder instead of the
+usual path-derived encoding above. When that happens the project key carries no
+relation to the real path at all, so string-prefix matching on the key alone could
+wrongly nest two unrelated projects that happen to share a prefix, or fail to nest two
+genuinely related ones.
+
+Each `ProjectNode` also carries `origin` — the real cwd-derived path used for its label
+(see "ProjectNode Structure" below). `buildTree`'s parent search (`nestsUnder` in
+`shared/projectTree.ts`) checks this first: when both the candidate node and its
+prospective parent have a known `origin`, nesting requires the child's origin to be a
+real filesystem descendant of the parent's origin (`isRealDescendant`). The key-prefix
+check above is used only as a fallback, when `origin` is unavailable for either side
+(e.g. synthesized orphan-worktree nodes, which have no session of their own to derive a
+real path from — see below).
 
 ### Orphan worktrees (no anchor session)
 

--- a/src/components/ProjectTree.test.tsx
+++ b/src/components/ProjectTree.test.tsx
@@ -364,10 +364,12 @@ describe("ProjectTree", () => {
     expect(children.length).toBe(2);
   });
 
-  it("does not nest projects with similar prefix but no parent project", () => {
-    // -Users-me-backend and -Users-me-backend-v2 are both root projects
-    // because neither is a parent of the other unless both exist as project keys
-    // Here -Users-me-backend IS a project, so -Users-me-backend-v2 nests under it
+  it("keeps sibling directories as roots even though their keys share a prefix", () => {
+    // -Users-me-backend and -Users-me-backend-v2 share a key prefix, but their real
+    // cwds (/home/user/backend and /home/user/backend-v2) are sibling directories, not
+    // nested — backend-v2 is not a subdirectory of backend. Nesting must follow the real
+    // cwd relationship, not the encoded key, or two unrelated projects could be wrongly
+    // grouped together (see #259).
     const sessions = [
       makeSession({
         path: "/home/user/.claude/projects/-Users-me-backend/s1.jsonl",
@@ -386,9 +388,8 @@ describe("ProjectTree", () => {
         onRefresh={vi.fn()}
       />,
     );
-    // backend-v2 nests under backend since backend is a real project key prefix
     const children = container.querySelectorAll(".project-tree__item--child");
-    expect(children.length).toBe(1);
+    expect(children.length).toBe(0);
   });
 
   it("keeps projects as roots when no parent project key exists", () => {


### PR DESCRIPTION
Fixes #259

## Problem

Claude Code v2.1.234 added `CLAUDE_CODE_PROJECT_DIR_NAME`, letting a host assign an arbitrary short name to a project's `~/.claude/projects/<dir>` transcript folder instead of the usual path-derived (sanitized-path) name.

I audited the whole path from directory discovery through to the UI:

- Session discovery/enumeration (Rust) was already safe — it only enumerates existing directories and never recomputes a directory name from a path for the active flow. `Entry.cwd` is parsed straight from the JSONL `cwd` field and is already the authoritative source used for project identity.
- The one real gap was in the sidebar tree builder (`shared/projectTree.ts`). `buildTree` decided worktree/parent-child nesting purely by string-prefix-matching the opaque `~/.claude/projects/<dir>` name, which silently assumes that name encodes the real path. Under an arbitrary host-assigned name that assumption breaks: two unrelated projects with a coincidentally similar name could get nested together in the sidebar, or two genuinely related projects (a repo and its real worktree) with unrelated names would fail to nest at all.

## Fix

`buildTree` now prefers the real cwd-derived path relationship (each `ProjectNode` already carries an `origin`, the real filesystem path it's anchored at) over the directory-name key when both are known, falling back to the existing key-prefix heuristic only when real path data is unavailable (e.g. synthesized orphan-worktree nodes that have no session of their own).

This also fixes the same latent bug for ordinary filesystem paths — `/home/user/backend` and `/home/user/backend-v2` are sibling directories, not nested, but the old key-prefix check nested them anyway. Updated the one existing test that had encoded that incorrect expectation.

## Testing

- Added regression tests in `shared/projectTree.test.ts` covering: nesting via real cwd when keys share no prefix (arbitrary host-assigned names), NOT nesting when keys coincidentally share a prefix but real paths are unrelated, and falling back to key-prefix matching when origin is unknown.
- Updated `src/components/ProjectTree.test.tsx`'s sibling-directory test to assert the corrected (no false nesting) behavior.
- `npx oxfmt --check`, `npx oxlint`, `npx tsc --noEmit`: clean
- `npx vitest run`: 502/502 passed
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`: clean, 687/687 passed (no Rust files changed)
- Deep-read and updated `specs/11-project-tree.md` and `specs/07-data-types.md` to document the new real-path-first nesting rule
