### PR TITLE
Fix #271: pin no-fixed-retention-window invariant for session discovery

### DIFF
--- a/src-tauri/src/parser/session.rs
+++ b/src-tauri/src/parser/session.rs
@@ -1885,6 +1885,36 @@ mod tests {
         }
     }
 
+    /// Claude Code v2.1.248 introduced `desktopSessionCleanupPeriodDays`, making
+    /// upstream transcript retention vary per-session (Desktop/Cowork sessions can
+    /// outlive CLI ones) instead of one uniform window. Session discovery must not
+    /// bake in any assumed lifespan of its own — it has to treat whatever files are
+    /// actually present on disk as the full truth, however old their mtime is.
+    #[test]
+    fn discover_project_sessions_does_not_filter_by_file_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("old-session.jsonl");
+        std::fs::write(
+            &path,
+            "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":\"hi\"}}\n",
+        )
+        .unwrap();
+
+        // Back-date the file far past any plausible cleanup window (e.g. the old
+        // uniform 30-day rule, or any org-configured `desktopSessionCleanupPeriodDays`).
+        let ancient = std::time::SystemTime::now() - std::time::Duration::from_secs(400 * 86400);
+        filetime::set_file_mtime(&path, filetime::FileTime::from_system_time(ancient)).unwrap();
+
+        let sessions = discover_project_sessions(dir.path().to_str().unwrap()).unwrap();
+        assert_eq!(
+            sessions.len(),
+            1,
+            "a session file must be discovered purely from its presence on disk, \
+             regardless of how old its mtime is"
+        );
+        assert_eq!(sessions[0].session_id, "old-session");
+    }
+
     #[test]
     fn recap_from_entry_matches_away_summary_string() {
         let v = serde_json::json!({"type":"system","subtype":"away_summary","content":"Migrated X, decided Y."});


### PR DESCRIPTION
Fixes #271

## What

Claude Code v2.1.248 introduced `desktopSessionCleanupPeriodDays`, making transcript retention for Desktop/Cowork-written sessions vary rather than following one uniform 30-day cleanup window. Issue #271 flags the risk that claude-code-trace's session discovery or caching might assume a fixed retention window somewhere.

## Investigation

I audited `src-tauri/src/parser/project.rs`, `src-tauri/src/parser/session.rs`, `src-tauri/src/watcher.rs`, and every cache in `state.rs` for any hard-coded retention/eviction/disk-usage assumption. There isn't one:

- `discover_project_sessions` / `discover_project_sessions_with_scan` enumerate whatever `.jsonl` files exist via `fs::read_dir` and sort by mtime — there is no age-based filtering anywhere in the discovery path.
- The only "30" constant in the codebase is in `dategroup.rs`, and it's a purely cosmetic UI calendar bucket ("This Month" vs "Older") for the session picker. It re-labels old sessions, it never drops them — already covered by the existing `old_session_goes_in_older` test.
- All caches (`SessionCache`, `session_light_cache`, the liveness/name-registry caches) key on `(path, mtime, size)` and are invalidated by file changes, not by a time-based expiry tied to any assumed session lifespan.

So the codebase already does exactly what the issue recommends: treat file presence/mtime on disk as the sole source of truth, with no assumption about expected lifespan. No production code needed to change.

## Change

Added a regression test, `discover_project_sessions_does_not_filter_by_file_age`, that backdates a session file 400 days (well past any plausible retention window, old or new) and asserts it is still discovered. This pins the invariant so a future change can't accidentally introduce an age-based filter into session discovery.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test` — 695/695 pass (including the new test)
- `npx vitest run` — 487/504 pass; the 17 failures are pre-existing and unrelated (`localStorage is undefined` in the jsdom test setup, in files this PR does not touch)
- `claude --debug -p "say hello"` — confirmed trace capture still writes a fresh session JSONL
