### PR TITLE
fix(ui): resolve React ref-during-render and set-state-in-effect violations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import {
 
 export function App() {
   const [view, setView] = useState<ViewState>("picker");
-  const [selectedMessage, setSelectedMessage] = useState(0);
+  const [storedSelectedMessage, setSelectedMessage] = useState(0);
   const [pickerSelectedIndex, setPickerSelectedIndex] = useState(0);
   const [showKeybinds, setShowKeybinds] = useState(true);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
@@ -159,6 +159,10 @@ export function App() {
     if (restoredRef.current) return;
     restoredRef.current = true;
     const pending = takeRestoreState();
+    // This is the "synchronizing with an external system" case the rule carves out:
+    // takeRestoreState() reads and *consumes* pending state from session storage, so it
+    // cannot run during render, and the resulting navigation is inherently a state update.
+    // oxlint-disable-next-line react/set-state-in-effect
     if (pending) openSessionByPath(pending.sessionPath);
   }, [openSessionByPath]);
 
@@ -179,12 +183,14 @@ export function App() {
     [openSessionByPath],
   );
 
-  // Auto-select newest message (last index) when messages load
-  useEffect(() => {
-    if (session.count > 0 && view === "list") {
-      setSelectedMessage((prev) => (prev >= session.count ? session.count - 1 : prev));
-    }
-  }, [session.count, view]);
+  // Clamp the selection to the loaded message range during render rather than correcting it
+  // from an effect. When a shorter session loads, the stored index can point past the end;
+  // deriving here keeps every read in this render pass consistent, where the effect version
+  // rendered once with the stale index before fixing it up.
+  const selectedMessage =
+    session.count > 0 && view === "list"
+      ? Math.min(storedSelectedMessage, session.count - 1)
+      : storedSelectedMessage;
 
   // Open detail view. The list holds only lightened messages, so fetch the full
   // (heavy-body) message on demand. Guard against out-of-order resolves when the

--- a/src/components/DebugViewer.tsx
+++ b/src/components/DebugViewer.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { useState, useRef, useMemo, useCallback } from "react";
 import type { DebugEntry } from "../types";
 import { useToggleSet } from "../hooks/useToggleSet";
 import { useScrollToSelected } from "../hooks/useScrollToSelected";
@@ -15,9 +15,8 @@ export function DebugViewer({ entries, viewActionsRef }: DebugViewerProps) {
   const [levelFilter, setLevelFilter] = useState<DebugLevel>("all");
   const [searchText, setSearchText] = useState("");
   const { set: expandedSet, toggle: toggleExpand, clear: clearExpanded, addAll } = useToggleSet();
-  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [storedSelectedIndex, setSelectedIndex] = useState(0);
   const bodyRef = useRef<HTMLDivElement>(null);
-  const selectedRef = useScrollToSelected(selectedIndex);
 
   // Filter entries
   const filtered = useMemo(() => {
@@ -42,12 +41,12 @@ export function DebugViewer({ entries, viewActionsRef }: DebugViewerProps) {
     return result;
   }, [entries, levelFilter, searchText]);
 
-  // Clamp selected index
-  useEffect(() => {
-    if (selectedIndex >= filtered.length && filtered.length > 0) {
-      setSelectedIndex(filtered.length - 1);
-    }
-  }, [filtered.length, selectedIndex]);
+  // Clamp during render rather than from an effect: filtering can shrink the list below the
+  // stored index, and correcting that in an effect renders once with an out-of-range index
+  // (scrolling to a row that no longer exists) before fixing it up.
+  const selectedIndex =
+    filtered.length > 0 ? Math.min(storedSelectedIndex, filtered.length - 1) : storedSelectedIndex;
+  const selectedRef = useScrollToSelected(selectedIndex);
 
   const debugExpandAll = useCallback(() => {
     const indices = filtered.map((_, i) => i).filter((i) => !!filtered[i].extra);

--- a/src/components/MessageDetail.tsx
+++ b/src/components/MessageDetail.tsx
@@ -137,6 +137,11 @@ export function MessageDetail({
   // Only updates state when something meaningful changed to avoid extra re-renders.
   useEffect(() => {
     if (panelStack.length === 0) return;
+    // Synchronizing with an external system (the session watcher, which rebuilds the message
+    // tree out-of-band) — the panel stack is also user-mutated via push/pop, so it cannot be
+    // derived during render. The updater below returns `prev` unless something actually
+    // changed, so this only re-renders when fresh data genuinely arrived.
+    // oxlint-disable-next-line react/set-state-in-effect
     setPanelStack((prev) => {
       let changed = false;
       const next = prev.map((entry) => {
@@ -578,15 +583,21 @@ function AgentListColumn({
     expandAll: () => expandAllMsgs(messages.map((_, i) => i)),
     collapseAll: () => clearMsgs(),
   });
-  navRef.current.moveUp = () => setSelectedMsg((i) => Math.max(i - 1, 0));
-  navRef.current.moveDown = () => setSelectedMsg((i) => Math.min(i + 1, messages.length - 1));
-  navRef.current.toggle = () => toggleMsg(selectedMsg);
-  navRef.current.enter = () => {
-    if (messages[selectedMsg]) onOpenDetail(messages[selectedMsg]);
-  };
-  navRef.current.itemCount = () => messages.length;
-  navRef.current.expandAll = () => expandAllMsgs(messages.map((_, i) => i));
-  navRef.current.collapseAll = () => clearMsgs();
+  // Refresh the registered nav callbacks after commit rather than during render —
+  // writing a ref while rendering is unsafe under concurrent rendering. The object
+  // identity stays stable, so the parent's registration is unaffected, and the
+  // callbacks are only invoked from keyboard handlers after the commit.
+  useEffect(() => {
+    navRef.current.moveUp = () => setSelectedMsg((i) => Math.max(i - 1, 0));
+    navRef.current.moveDown = () => setSelectedMsg((i) => Math.min(i + 1, messages.length - 1));
+    navRef.current.toggle = () => toggleMsg(selectedMsg);
+    navRef.current.enter = () => {
+      if (messages[selectedMsg]) onOpenDetail(messages[selectedMsg]);
+    };
+    navRef.current.itemCount = () => messages.length;
+    navRef.current.expandAll = () => expandAllMsgs(messages.map((_, i) => i));
+    navRef.current.collapseAll = () => clearMsgs();
+  });
 
   // Register/unregister nav on mount/unmount
   useLayoutEffect(() => {
@@ -703,23 +714,27 @@ function AgentDetailColumn({
     expandAll: () => expandAllDetailItems(msg.items.map((_, i) => i)),
     collapseAll: () => clearDetailItems(),
   });
-  navRef.current.moveUp = () => setSelectedItem((i) => Math.max(i - 1, 0));
-  navRef.current.moveDown = () => setSelectedItem((i) => Math.min(i + 1, msg.items.length - 1));
-  navRef.current.toggle = () => {
-    const it = msg.items[selectedItem];
-    if (it) handleItemClick(selectedItem, it);
-  };
-  navRef.current.enter = () => {
-    const it = msg.items[selectedItem];
-    if (it && it.subagent_messages.length > 0) {
-      onOpenSubagent(it);
-    } else if (it) {
-      toggleItem(selectedItem);
-    }
-  };
-  navRef.current.itemCount = () => msg.items.length;
-  navRef.current.expandAll = () => expandAllDetailItems(msg.items.map((_, i) => i));
-  navRef.current.collapseAll = () => clearDetailItems();
+  // Refresh the registered nav callbacks after commit rather than during render — see
+  // the matching note in MessageList above.
+  useEffect(() => {
+    navRef.current.moveUp = () => setSelectedItem((i) => Math.max(i - 1, 0));
+    navRef.current.moveDown = () => setSelectedItem((i) => Math.min(i + 1, msg.items.length - 1));
+    navRef.current.toggle = () => {
+      const it = msg.items[selectedItem];
+      if (it) handleItemClick(selectedItem, it);
+    };
+    navRef.current.enter = () => {
+      const it = msg.items[selectedItem];
+      if (it && it.subagent_messages.length > 0) {
+        onOpenSubagent(it);
+      } else if (it) {
+        toggleItem(selectedItem);
+      }
+    };
+    navRef.current.itemCount = () => msg.items.length;
+    navRef.current.expandAll = () => expandAllDetailItems(msg.items.map((_, i) => i));
+    navRef.current.collapseAll = () => clearDetailItems();
+  });
 
   useLayoutEffect(() => {
     onRegisterNav(navRef.current);

--- a/src/hooks/useKeyboard.ts
+++ b/src/hooks/useKeyboard.ts
@@ -2,7 +2,12 @@ import { useEffect, useRef } from "react";
 
 export function useKeyboard(keyMap: Record<string, () => void>) {
   const keyMapRef = useRef(keyMap);
-  keyMapRef.current = keyMap;
+  // Refresh after commit rather than during render — writing a ref while rendering is
+  // unsafe under concurrent rendering, and the map is only read from the keydown
+  // listener, which cannot fire before the commit anyway.
+  useEffect(() => {
+    keyMapRef.current = keyMap;
+  });
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/src/hooks/useTauriEvent.ts
+++ b/src/hooks/useTauriEvent.ts
@@ -7,7 +7,12 @@ import { listen, type UnlistenFn } from "../lib/listen";
  */
 export function useTauriEvent<T>(event: string, handler: (payload: T) => void | Promise<void>) {
   const handlerRef = useRef(handler);
-  handlerRef.current = handler;
+  // Refresh after commit rather than during render — writing a ref while rendering is
+  // unsafe under concurrent rendering, and the handler is only ever read from the
+  // listener callback, which cannot run before the commit anyway.
+  useEffect(() => {
+    handlerRef.current = handler;
+  });
 
   const unlistenRef = useRef<UnlistenFn | null>(null);
 

--- a/src/hooks/useVisibleSessions.ts
+++ b/src/hooks/useVisibleSessions.ts
@@ -30,10 +30,21 @@ export function useVisibleSessions(
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handlerRef = useRef(onChange);
-  handlerRef.current = onChange;
   const debounceMsRef = useRef(debounceMs);
-  debounceMsRef.current = debounceMs;
+  // Refresh after commit rather than during render — writing a ref while rendering is
+  // unsafe under concurrent rendering. Both are only read from the IntersectionObserver
+  // callback and its debounce timer, neither of which can run before the commit.
+  useEffect(() => {
+    handlerRef.current = onChange;
+    debounceMsRef.current = debounceMs;
+  });
 
+  // The initializer runs during render, but it only *closes over* the refs below; every
+  // read happens inside the IntersectionObserver callback and its debounce timer, neither
+  // of which can fire before the commit. The observer has to be built here rather than in
+  // an effect so it exists when card refs first attach (see the note above the hook), so
+  // the ref capture is deliberate rather than an oversight.
+  // oxlint-disable-next-line react/refs
   const [observer] = useState<IntersectionObserver | null>(() => {
     if (typeof IntersectionObserver === "undefined") return null;
     return new IntersectionObserver((entries) => {


### PR DESCRIPTION
oxlint 1.79 (queued in #268) enables `react(refs)` and `react(set-state-in-effect)`, which flag 23 pre-existing violations and fail CI. This clears all 23 so the lint bump can land.

The code is clean under **both** oxlint 1.78 (current) and 1.79, so this is safe to merge ahead of #268.

## Ref writes moved out of render (19)

`useKeyboard`, `useTauriEvent`, `useVisibleSessions`, and both `navRef` blocks in `MessageDetail` used the "latest ref" pattern written during render (`ref.current = value`), which is unsafe under concurrent rendering. These move into post-commit effects.

Behaviour is unchanged: every one of these refs is read only from event handlers, listener callbacks, or timers, none of which can run before the commit. The nav object identity also stays stable, so the parent's `onRegisterNav` registration is unaffected.

## Clamping effects became render-time derivations (2)

`App.selectedMessage` and `DebugViewer.selectedIndex` were clamped from an effect after the list shrank. Both previously rendered once with an out-of-range index before the effect corrected it — deriving during render keeps every read in a single pass consistent. `DebugViewer`'s `useScrollToSelected` call moves below the filter memo so it consumes the clamped value.

## Kept as effects, with scoped disables and rationale (3)

Rather than turning the rules off globally, three sites keep their effect with a one-line disable and a written justification:

- **`useVisibleSessions`** — the `IntersectionObserver` must be built in the `useState` initializer so it exists when card refs first attach; moving it to an effect means the first batch of cards is never observed (the hook's existing doc comment already says so). The initializer only *closes over* refs; every read happens in the observer callback or its debounce timer.
- **`App`** — the webview-reload session restore reads and *consumes* pending state from session storage, so it cannot run during render. This is the "synchronizing with an external system" case the rule's own help text carves out.
- **`MessageDetail`** — the panel-stack refresh syncs with the out-of-band session watcher, and the stack is also user-mutated via push/pop so it can't be derived. The updater already returns `prev` unless something actually changed, so it only re-renders when fresh data genuinely arrived.

## Verification

- `oxlint` 1.79: 0 errors (2 pre-existing `exhaustive-effect-dependencies` warnings, unrelated and non-blocking)
- `oxlint` 1.78: clean
- `tsc --noEmit`, `oxfmt --check`: clean
- 512 frontend tests pass

Note: these are behaviour-preserving refactors verified against the test suite and CI; the desktop app was not exercised manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL

---
_Generated by [Claude Code](https://claude.ai/code/session_01TydRdWp6r1R3tiFM1MWVZL)_