### PR TITLE
fix(web): hot-swap the API token over HMR instead of restarting Vite

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -76,11 +76,10 @@ export async function regenerateToken(page: Page): Promise<string> {
   return value;
 }
 
-/** The Vite dev server restarts itself when the token file changes (see the
- * plugin in vite.config.ts). Polling for "is it up" races that restart, so
- * wait for the proof that it finished: the served `apiToken.ts` module now
- * has the new token baked in. Connection errors during the restart are
- * expected and swallowed. */
+/** The `cctrace-api-token` Vite plugin serves the token as a virtual module
+ * and invalidates it when the file changes. The file watcher has latency, so
+ * before asserting on a cold load, wait until the dev server serves the
+ * rotated value. */
 export function waitForInjectedToken(
   baseURL: string,
   token: string,
@@ -97,7 +96,7 @@ export function waitForInjectedToken(
       setTimeout(attempt, 250);
     };
     const attempt = () => {
-      fetch(`${baseURL}/src/lib/apiToken.ts`)
+      fetch(`${baseURL}/@id/__x00__virtual:cctrace-api-token`)
         .then(async (res) => {
           const body = await res.text();
           if (body.includes(token)) {

--- a/e2e/same-origin.spec.ts
+++ b/e2e/same-origin.spec.ts
@@ -45,8 +45,12 @@ test.describe("HTTP API without a browser", () => {
     });
     expect(viaBearer.status()).toBe(200);
 
+    // Flip the last hex digit so the forged token always differs (replacing it
+    // with a fixed "0" collided with the real token one run in sixteen).
+    const forged = `${token.slice(0, -1)}${token.endsWith("0") ? "1" : "0"}`;
+    expect(forged).not.toBe(token);
     const wrong = await request.get("/api/settings", {
-      headers: { "X-CCTrace-Token": `${token.slice(0, -1)}0` },
+      headers: { "X-CCTrace-Token": forged },
     });
     expect(wrong.status()).toBe(401);
   });

--- a/e2e/web-mode.spec.ts
+++ b/e2e/web-mode.spec.ts
@@ -5,6 +5,8 @@
  * on fetch calls and as a query parameter on the EventSource stream.
  */
 import { expect, test } from "@playwright/test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { E2E } from "../playwright.config";
 import {
   expectSecretOnTestPath,
@@ -35,13 +37,15 @@ test("SSE stream carries the token as a query parameter", async ({ page }) => {
   expect(url.searchParams.get("token")).toBe(readToken(configDir));
 });
 
-test("Regenerate switches this tab to the new token on fetch and SSE", async ({
+test("Regenerate hot-swaps the token in this tab — no reload — and SSE + fetch follow", async ({
   page,
   baseURL,
 }) => {
   await page.goto("/");
   await expect(page.getByText(FIXTURE_FIRST_MESSAGE)).toBeVisible();
   const oldToken = readToken(configDir);
+  let loads = 0;
+  page.on("load", () => loads++);
 
   const reconnected = page.waitForRequest(
     (r) => r.url().startsWith(`${api}/api/events`) && !r.url().includes(oldToken),
@@ -52,17 +56,55 @@ test("Regenerate switches this tab to the new token on fetch and SSE", async ({
   expect(readToken(configDir)).toBe(newToken);
   expectSecretOnTestPath(configDir);
 
-  // listen.ts reopens the stream with the rotated token without a reload.
+  // listen.ts reopens the stream with the rotated token, without a reload.
   expect(new URL((await reconnected).url()).searchParams.get("token")).toBe(newToken);
 
-  // The Vite plugin watches the token file and restarts the dev server so a
-  // fresh page load gets the new VITE_API_TOKEN baked in. Wait for that to
-  // land, then prove a cold load authenticates with the rotated token.
+  // The plugin hot-swaps the virtual token module over HMR when the file
+  // changes. Wait for the dev server to serve the rotated value, then prove
+  // the page was NOT reloaded meanwhile: the Settings modal the user clicked
+  // in is still open, showing the new token. (The dev server used to restart
+  // here, and Vite's client full-reloaded the page — exactly what CI caught.)
   await waitForInjectedToken(baseURL!, newToken);
+  expect(loads).toBe(0);
+  await expect(page.getByLabel("API token")).toHaveValue(newToken);
+  await expect(page.getByText(/Token regenerated/)).toBeVisible();
+
+  // A cold load authenticates with the rotated token straight away.
   const nextFetch = page.waitForRequest(
     (r) => r.url().startsWith(`${api}/api/`) && !r.url().includes("/api/events"),
   );
   await page.goto("/");
   expect((await nextFetch).headers()["x-cctrace-token"]).toBe(newToken);
   await expect(page.getByText(FIXTURE_FIRST_MESSAGE)).toBeVisible();
+});
+
+test("a rotation by another process reaches an open tab over HMR", async ({ page, baseURL }) => {
+  await page.goto("/");
+  await expect(page.getByText(FIXTURE_FIRST_MESSAGE)).toBeVisible();
+  const oldToken = readToken(configDir);
+  let loads = 0;
+  page.on("load", () => loads++);
+
+  // Rotate from outside the browser, the way a second cctrace process (or
+  // `Regenerate` in another tab) would: rewrite the file the backend owns.
+  // The backend adopts it on the next mismatch; the dev server pushes it to
+  // this tab; the tab's SSE stream must come back on the new token.
+  const reconnected = page.waitForRequest(
+    (r) => r.url().startsWith(`${api}/api/events`) && !r.url().includes(oldToken),
+  );
+  const rotated = `${"e".repeat(32)}${Date.now().toString(16).padStart(32, "0")}`;
+  writeFileSync(join(configDir, "api-token"), `${rotated}\n`);
+
+  expect(new URL((await reconnected).url()).searchParams.get("token")).toBe(rotated);
+  await waitForInjectedToken(baseURL!, rotated);
+  expect(loads).toBe(0);
+
+  // …and the API accepts the tab's next call with the rotated token.
+  const nextFetch = page.waitForRequest(
+    (r) => r.url().startsWith(`${api}/api/`) && !r.url().includes("/api/events"),
+  );
+  await page.getByTitle("Settings").click();
+  const req = await nextFetch;
+  expect(req.headers()["x-cctrace-token"]).toBe(rotated);
+  expect((await req.response())?.status()).toBe(200);
 });

--- a/specs/04-http-api.md
+++ b/specs/04-http-api.md
@@ -436,10 +436,13 @@ still 404 rather than 401.
 ### How each client gets the token
 
 - **Web/dev mode** (`cctrace --web`, Vite on 1420 → API on 11423): the `cctrace-api-token` Vite
-  plugin in `vite.config.ts` reads the token file at _serve_ time and injects it as
-  `import.meta.env.VITE_API_TOKEN` (never into a production build). `src/lib/apiToken.ts` holds it;
-  `invoke.ts` sends the header and `listen.ts` appends `?token=`. The plugin watches the file and
-  restarts the dev server when it changes.
+  plugin in `vite.config.ts` reads the token file and serves it as the virtual module
+  `virtual:cctrace-api-token` — `""` in production builds, so a bundle never contains a token.
+  `src/lib/apiToken.ts` imports it; `invoke.ts` sends the header and `listen.ts` appends `?token=`.
+  When the file changes on disk (Regenerate from this tab, another tab, or another process) the plugin
+  invalidates the module and pushes it over HMR; `apiToken.ts` accepts the update and every open tab
+  adopts the new token in place — no dev-server restart and no page reload (a restart would make Vite's
+  client full-reload the page and tear down the Settings modal the user just clicked in).
 - **Docker / same-origin** (`CCTRACE_STATIC_DIR` set): `auth::attach_token_cookie` wraps the static
   fallback and adds `Set-Cookie: cctrace_token=<token>; Path=/; HttpOnly; SameSite=Strict` to
   `text/html` responses — but **only when the request `Host` is allowlisted**: `localhost`,

--- a/specs/05-frontend-web.md
+++ b/specs/05-frontend-web.md
@@ -350,12 +350,15 @@ between Tauri IPC and HTTP fetch/EventSource at runtime.
 
 In HTTP mode every call must prove the browser is an accepted client (see
 [04-http-api.md — Authentication](04-http-api.md#authentication)). `src/lib/apiToken.ts` holds
-the shared token: in `cctrace --web` the Vite plugin in `vite.config.ts` injects it as
-`import.meta.env.VITE_API_TOKEN` (serve-time only); `invoke.ts` sends it as `X-CCTrace-Token` and
-`listen.ts` appends `?token=` to the `EventSource` URL. In Docker the value is empty and the
-server's same-origin cookie does the job. A 401 rejects with `ApiAuthError`, which `App` shows as
-a top-level banner instead of opening Settings. Settings → API access → Regenerate calls
-`setApiToken()` and `reconnectSse()` so the current tab keeps working after a rotation.
+the shared token: in `cctrace --web` the `cctrace-api-token` plugin in `vite.config.ts` serves it as
+the virtual module `virtual:cctrace-api-token` (`""` in production builds and under vitest, which
+stubs it in `vitest.config.ts`); `invoke.ts` sends it as `X-CCTrace-Token` and `listen.ts` appends
+`?token=` to the `EventSource` URL. In Docker the value is empty and the server's same-origin cookie
+does the job. A 401 rejects with `ApiAuthError`, which `App` shows as a top-level banner instead of
+opening Settings. `setApiToken()` notifies `onApiTokenChange` subscribers only when the value really
+changes; `listen.ts` subscribes and reopens its stream, so the SSE connection follows the token whether
+the rotation came from Settings → Regenerate in this tab or was pushed over HMR because another process
+rewrote the file. The dev server is never restarted for a rotation.
 
 ```mermaid
 flowchart LR

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -6,10 +6,7 @@ const mockInvoke = vi.fn();
 vi.mock("../lib/invoke", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
-const mockReconnectSse = vi.fn();
-vi.mock("../lib/listen", () => ({
-  reconnectSse: () => mockReconnectSse(),
-}));
+import { getApiToken, setApiToken } from "../lib/apiToken";
 
 const DEFAULT_DIR = "/Users/x/.claude/projects";
 
@@ -35,6 +32,7 @@ describe("SettingsModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    setApiToken(null);
     mockInvoke.mockImplementation((cmd: string) => {
       if (cmd === "get_settings") return Promise.resolve(makeSettings(null));
       if (cmd === "set_projects_dir") return Promise.resolve(makeSettings(null));
@@ -462,7 +460,9 @@ describe("SettingsModal", () => {
     await waitFor(() =>
       expect((screen.getByLabelText("API token") as HTMLInputElement).value).toBe("new-token"),
     );
-    expect(mockReconnectSse).toHaveBeenCalled();
+    // The live token this tab sends from now on was swapped (lib/listen.ts
+    // reopens the SSE stream off this same change).
+    expect(getApiToken()).toBe("new-token");
     expect(screen.getByText(/Token regenerated/)).toBeInTheDocument();
     expect(screen.getByText("Regenerate")).toBeInTheDocument();
     // Regeneration is independent of Save — the modal stays open.
@@ -481,7 +481,7 @@ describe("SettingsModal", () => {
     fireEvent.click(screen.getByText("Regenerate"));
     fireEvent.click(screen.getByText("Confirm regenerate?"));
     await waitFor(() => expect(screen.getByText(/rotation failed/)).toBeInTheDocument());
-    expect(mockReconnectSse).not.toHaveBeenCalled();
+    expect(getApiToken()).toBeNull();
   });
 
   it("disables Regenerate when the token comes from CCTRACE_API_TOKEN", async () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "../lib/invoke";
-import { isTauri } from "../lib/isTauri";
 import { setApiToken as setLiveApiToken } from "../lib/apiToken";
-import { reconnectSse } from "../lib/listen";
 import { PopoutModal } from "./PopoutModal";
 import { FONT_SCALE_PRESETS, formatFontScale } from "../lib/fontScale";
 
@@ -183,10 +181,10 @@ export function SettingsModal({
     try {
       const res = await invoke<SettingsResponse>("regenerate_api_token");
       applyResponse(res);
-      // Keep this tab working: send the new token from now on and reopen the
-      // SSE stream, which was authenticated with the old one.
+      // Keep this tab working: send the new token from now on. lib/listen.ts
+      // subscribes to this change and reopens the SSE stream, which was
+      // authenticated with the old token.
       setLiveApiToken(res.api_token);
-      if (!isTauri) reconnectSse();
       setTokenNotice("Token regenerated — update the TUI and any scripts that used the old one.");
     } catch (err) {
       setError(String(err));

--- a/src/lib/apiToken.test.ts
+++ b/src/lib/apiToken.test.ts
@@ -39,4 +39,21 @@ describe("apiToken", () => {
     setApiToken(undefined);
     expect(getApiToken()).toBeNull();
   });
+
+  it("notifies subscribers only when the token actually changes", async () => {
+    const { onApiTokenChange } = await import("./apiToken");
+    const seen: (string | null)[] = [];
+    const unsubscribe = onApiTokenChange((t) => seen.push(t));
+
+    setApiToken("a");
+    setApiToken("a"); // no-op
+    setApiToken(""); // clears → null
+    setApiToken(undefined); // still null, no-op
+    setApiToken("b");
+    expect(seen).toEqual(["a", null, "b"]);
+
+    unsubscribe();
+    setApiToken("c");
+    expect(seen).toEqual(["a", null, "b"]);
+  });
 });

--- a/src/lib/apiToken.ts
+++ b/src/lib/apiToken.ts
@@ -4,29 +4,50 @@
  * The Rust backend gates every `/api/*` route behind a secret token (see
  * `src-tauri/src/auth.rs`). How this module learns it depends on the mode:
  *
- * - `cctrace --web` (Vite on 1420, API on 11423): the Vite plugin in
- *   `vite.config.ts` reads the token file and injects it as
- *   `import.meta.env.VITE_API_TOKEN` at serve time. `invoke.ts` sends it as an
- *   `X-CCTrace-Token` header; `listen.ts` appends it as `?token=` because
- *   `EventSource` cannot set headers.
- * - Docker (same-origin bundle): this stays empty. The server sets an HttpOnly
- *   cookie on the HTML shell, which the browser attaches automatically.
+ * - `cctrace --web` (Vite on 1420, API on 11423): the `cctrace-api-token`
+ *   plugin in `vite.config.ts` reads the token file and serves it as the
+ *   virtual module imported below. `invoke.ts` sends it as an `X-CCTrace-Token`
+ *   header; `listen.ts` appends it as `?token=` because `EventSource` cannot
+ *   set headers. When the file changes on disk (Regenerate, from this tab or
+ *   any other process) the plugin pushes the new value over HMR and the
+ *   `import.meta.hot.accept` below swaps it in — no dev-server restart, no
+ *   page reload.
+ * - Docker (same-origin bundle): the virtual module is `""` in production
+ *   builds. The server sets an HttpOnly cookie on the HTML shell, which the
+ *   browser attaches automatically.
  * - Tauri desktop: never used — the webview talks over IPC, not HTTP.
  *
- * Kept separate from `invoke.ts` / `listen.ts` so neither imports the other.
+ * Kept separate from `invoke.ts` / `listen.ts` so neither imports the other;
+ * `listen.ts` subscribes via `onApiTokenChange` to reopen its stream.
  */
+import injected from "virtual:cctrace-api-token";
 
-let token: string | null = (import.meta.env.VITE_API_TOKEN as string | undefined) || null;
+type Listener = (token: string | null) => void;
+
+let token: string | null = injected || null;
+const listeners = new Set<Listener>();
 
 /** The token currently sent with HTTP API calls, or null when none is set. */
 export function getApiToken(): string | null {
   return token;
 }
 
-/** Swap the live token — used after Settings → Regenerate so the current tab
- * keeps working without a reload. */
+/** Swap the live token. Notifies subscribers only when the value actually
+ * changes, so redundant sets (e.g. the HMR echo of a rotation this tab
+ * performed itself) are free. */
 export function setApiToken(next: string | null | undefined): void {
-  token = next || null;
+  const value = next || null;
+  if (value === token) return;
+  token = value;
+  for (const listener of listeners) listener(value);
+}
+
+/** Be told whenever the live token changes. Returns an unsubscribe function. */
+export function onApiTokenChange(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
 }
 
 /** Headers to spread into a `fetch` call to the HTTP API. */
@@ -39,4 +60,13 @@ export function withTokenQuery(url: string): string {
   if (!token) return url;
   const sep = url.includes("?") ? "&" : "?";
   return `${url}${sep}token=${encodeURIComponent(token)}`;
+}
+
+if (import.meta.hot) {
+  // Dev server only: the plugin invalidates the virtual module when the token
+  // file changes; accepting that one dependency keeps this module (and the
+  // page) alive and just adopts the new value.
+  import.meta.hot.accept("virtual:cctrace-api-token", (mod) => {
+    setApiToken((mod as { default?: string } | undefined)?.default);
+  });
 }

--- a/src/lib/listen.test.ts
+++ b/src/lib/listen.test.ts
@@ -78,18 +78,17 @@ describe("listen (web/SSE mode)", () => {
   it("reconnectSse closes the stream, reopens with the current token, and re-attaches listeners", async () => {
     const { setApiToken } = await import("./apiToken");
     const { listen, reconnectSse } = await import("./listen");
-    setApiToken("old");
+    setApiToken("tok");
     await listen("session-update", () => {});
     await listen("picker-refresh", () => {});
     expect(mockSource.addEventListener).toHaveBeenCalledTimes(2);
 
-    setApiToken("new");
     reconnectSse();
 
     expect(mockSource.close).toHaveBeenCalledTimes(1);
     expect(constructedUrls).toEqual([
-      "http://127.0.0.1:11423/api/events?token=old",
-      "http://127.0.0.1:11423/api/events?token=new",
+      "http://127.0.0.1:11423/api/events?token=tok",
+      "http://127.0.0.1:11423/api/events?token=tok",
     ]);
     // Both listeners were re-registered on the replacement connection.
     expect(mockSource.addEventListener).toHaveBeenCalledTimes(4);
@@ -120,5 +119,32 @@ describe("listen (web/SSE mode)", () => {
     // A later reconnect has nothing to re-attach and nothing open to replace.
     reconnectSse();
     expect(constructedUrls).toHaveLength(2);
+  });
+
+  it("reopens the stream with the new token when the live token changes", async () => {
+    const { setApiToken } = await import("./apiToken");
+    const { listen } = await import("./listen");
+    setApiToken("before");
+    await listen("session-update", () => {});
+    expect(constructedUrls).toEqual(["http://127.0.0.1:11423/api/events?token=before"]);
+
+    // A rotation — from Settings in this tab, or pushed over HMR because
+    // another process rewrote the file — must not leave the stream on the
+    // dead token.
+    setApiToken("after");
+    expect(mockSource.close).toHaveBeenCalledTimes(1);
+    expect(constructedUrls).toEqual([
+      "http://127.0.0.1:11423/api/events?token=before",
+      "http://127.0.0.1:11423/api/events?token=after",
+    ]);
+    expect(mockSource.addEventListener).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a token change when nothing is listening", async () => {
+    const { setApiToken } = await import("./apiToken");
+    await import("./listen");
+    setApiToken("x");
+    expect(constructedUrls).toEqual([]);
+    expect(mockSource.close).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/listen.ts
+++ b/src/lib/listen.ts
@@ -7,7 +7,7 @@
 import { listen as tauriListen } from "@tauri-apps/api/event";
 import { isTauri } from "./isTauri";
 import { API_BASE } from "./config";
-import { withTokenQuery } from "./apiToken";
+import { onApiTokenChange, withTokenQuery } from "./apiToken";
 
 export type UnlistenFn = () => void;
 
@@ -48,15 +48,19 @@ function releaseSse(): void {
 
 /**
  * Drop the current SSE connection and open a fresh one carrying the *current*
- * token, re-attaching every registered listener. Called after Settings →
- * Regenerate: the old stream was authenticated with the old token and would
- * silently die on its next reconnect. No-op when nothing is listening.
+ * token, re-attaching every registered listener. The old stream was
+ * authenticated with the old token and would silently die on its next
+ * reconnect. No-op when nothing is listening.
  */
 export function reconnectSse(): void {
   if (!sseSource) return;
   sseSource.close();
   sseSource = openSource();
 }
+
+// Wherever the token changes — this tab's Regenerate, or a rotation by another
+// process pushed here over HMR (see lib/apiToken.ts) — the stream follows it.
+onApiTokenChange(() => reconnectSse());
 
 export async function listen<T>(
   event: string,

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,8 +1,13 @@
 /// <reference types="vite/client" />
 
+/** Served by the `cctrace-api-token` plugin in `vite.config.ts`: the shared
+ * HTTP API client token while the dev server runs, `""` in production builds
+ * (Docker uses a cookie instead) and under vitest. */
+declare module "virtual:cctrace-api-token" {
+  const token: string;
+  export default token;
+}
+
 interface ImportMetaEnv {
-  /** Shared HTTP API client token, injected by the Vite plugin in
-   * `vite.config.ts` in dev/web mode only. Empty in production bundles. */
-  readonly VITE_API_TOKEN?: string;
   readonly VITE_API_BASE?: string;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,29 +11,51 @@ const host = process.env.TAURI_DEV_HOST;
  * listens on 11423, so the browser can't get the token as a same-origin
  * cookie the way the Docker bundle does. This plugin reads (or, on a first
  * run, creates) the same token file the backend uses — see
- * `bin/api-token.mjs` — and exposes it as `import.meta.env.VITE_API_TOKEN`
- * for `src/lib/apiToken.ts`.
+ * `bin/api-token.mjs` — and serves it as the virtual module
+ * `virtual:cctrace-api-token`, imported by `src/lib/apiToken.ts`.
  *
- * `apply: "serve"` is load-bearing: a production/Docker `vite build` must
- * never bake a token into the bundle. When the file changes on disk
- * (Settings → Regenerate rewrites it), the dev server restarts so a reload
- * picks up the new value.
+ * Two properties are load-bearing:
+ * - In a production/Docker `vite build` the module is `""` — a bundle must
+ *   never contain a token.
+ * - When the file changes on disk (Settings → Regenerate rewrites it, from
+ *   this tab or another cctrace process), the module is invalidated and pushed
+ *   over HMR. `apiToken.ts` accepts that update, so open tabs adopt the new
+ *   token in place. It must NOT restart the dev server: a restart makes Vite's
+ *   client full-reload the page, which tears down the Settings modal the user
+ *   just clicked Regenerate in.
  */
+const API_TOKEN_MODULE = "virtual:cctrace-api-token";
+const API_TOKEN_MODULE_ID = `\0${API_TOKEN_MODULE}`;
+
 function apiTokenPlugin(): Plugin {
+  let serving = false;
   return {
     name: "cctrace-api-token",
-    apply: "serve",
-    config: () => ({
-      define: {
-        "import.meta.env.VITE_API_TOKEN": JSON.stringify(resolveApiToken() ?? ""),
-      },
-    }),
+    configResolved(config) {
+      serving = config.command === "serve";
+    },
+    resolveId(id) {
+      return id === API_TOKEN_MODULE ? API_TOKEN_MODULE_ID : undefined;
+    },
+    load(id) {
+      if (id !== API_TOKEN_MODULE_ID) return undefined;
+      // Re-read on every (re)load so an invalidation after a rotation serves
+      // the current file contents.
+      const token = serving ? (resolveApiToken() ?? "") : "";
+      return `export default ${JSON.stringify(token)};`;
+    },
     configureServer(server) {
       const path = apiTokenPath();
       server.watcher.add(path);
-      server.watcher.on("change", (changed) => {
-        if (changed === path) void server.restart();
-      });
+      const onTokenFile = (changed: string) => {
+        if (changed !== path) return;
+        const mod = server.moduleGraph.getModuleById(API_TOKEN_MODULE_ID);
+        if (mod) void server.reloadModule(mod);
+      };
+      // Rotation replaces the file via rename, which some watchers report as
+      // add rather than change.
+      server.watcher.on("change", onTokenFile);
+      server.watcher.on("add", onTokenFile);
     },
   };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,18 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
+/** `src/lib/apiToken.ts` imports a virtual module that only the dev-server
+ * plugin in vite.config.ts provides. Under vitest it is always empty, exactly
+ * like a production build. */
+const apiTokenStub = {
+  name: "cctrace-api-token-stub",
+  resolveId: (id: string) =>
+    id === "virtual:cctrace-api-token" ? "\0virtual:cctrace-api-token" : undefined,
+  load: (id: string) => (id === "\0virtual:cctrace-api-token" ? 'export default "";' : undefined),
+};
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), apiTokenStub],
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Why

CI on `main` (run 707, `chore(release): v0.14.0`) failed in the `e2e` job: after **Settings → Regenerate** in web mode, the "Token regenerated" notice never appeared (both attempts).

This was a product bug in `cctrace --web`, not a flaky test. The Vite plugin reacted to the rewritten token file with `server.restart()`, and Vite's client then **full-reloaded the page**, tearing down the Settings modal the user had just clicked in. Locally the restart landed a beat after the assertion; on the CI runner it landed first.

## What

- **`vite.config.ts`**: the plugin now serves the token as a virtual module (`virtual:cctrace-api-token`). When the file changes it invalidates that module and pushes it over **HMR** instead of restarting the dev server. Production/Docker builds get `""` from the module, so a bundle still never contains a token (verified by grepping the built bundle for both scratch tokens).
- **`src/lib/apiToken.ts`**: imports the virtual module and accepts its HMR updates, so every open dev tab adopts a rotated token in place — no restart, no reload. `setApiToken()` notifies `onApiTokenChange` subscribers only when the value actually changes.
- **`src/lib/listen.ts`**: subscribes and reopens the SSE stream on a token change, so the stream follows the token whether the rotation came from this tab, another tab, or another cctrace process. `SettingsModal` drops its direct reconnect call.
- **`vitest.config.ts` / `src/vite-env.d.ts`**: stub + type declaration for the virtual module.
- **e2e**: the web-mode Regenerate test now asserts the page did **not** reload and the modal is still open with the new token. New test: rotate the token file from outside the browser and check the open tab picks it up over HMR and its next API call succeeds.
- Specs 04/05 updated to describe the virtual module / HMR flow.

## Verification

- `npx playwright test --project web-mode --repeat-each 3` → 12 passed; full e2e suite → 11 passed.
- vitest 555 passed; `tsc`, `oxlint`, `oxfmt` clean. No Rust or Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARMV5uP7TQ9NyXsqAjpo2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARMV5uP7TQ9NyXsqAjpo2E)_