### PR TITLE
fix(docker): copy bin/ into the frontend build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN npm ci --no-audit --no-fund
 COPY tsconfig.json tsconfig.node.json vite.config.ts index.html ./
 COPY src ./src
 COPY shared ./shared
+# vite.config.ts imports bin/api-token.mjs at config-load time (the dev-only
+# token plugin), so the config fails to load without it even though the plugin
+# itself never runs in a production build.
+COPY bin ./bin
 
 # Empty VITE_API_BASE → frontend uses relative URLs, matching the single-port
 # axum server that also serves these static assets.

--- a/specs/05-frontend-web.md
+++ b/specs/05-frontend-web.md
@@ -433,6 +433,15 @@ flowchart LR
 
 Static assets are served from `dist/` when `CCTRACE_STATIC_DIR` is set in the Rust backend.
 
+The Docker image builds this bundle in the `frontend-builder` stage, which copies only the
+files the build needs rather than the whole repo. Vite resolves every import in
+`vite.config.ts` when it loads the config, so a local import that the stage doesn't `COPY`
+fails the image build with `UNRESOLVED_IMPORT` — even when the importing code never runs in a
+production build, as is the case for the serve-only `cctrace-api-token` plugin's
+`bin/api-token.mjs`. Nothing in the toolchain ties the config's import list to those `COPY`
+lines, so `src/test/dockerBuildContext.test.ts` reads both files and asserts every local
+import is covered.
+
 ---
 
 ## Related Specs

--- a/src/test/dockerBuildContext.test.ts
+++ b/src/test/dockerBuildContext.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * `vite.config.ts` is loaded (and therefore its imports resolved) before the
+ * Docker frontend build runs, but nothing links the config's import list to
+ * the `COPY` lines in the Dockerfile. Add an import there and forget the
+ * `COPY` here and the image build fails with UNRESOLVED_IMPORT — but only in
+ * Docker, never locally. This test closes that gap.
+ */
+
+const repoRoot = resolve(__dirname, "../..");
+
+/** Repo-relative paths that `vite.config.ts` imports from the local tree. */
+function localImportsOfViteConfig(): string[] {
+  const source = readFileSync(join(repoRoot, "vite.config.ts"), "utf8");
+  const specifiers = [...source.matchAll(/from\s+"(\.[^"]*)"/g)].map((m) => m[1]);
+  return specifiers.map((spec) => spec.replace(/^\.\//, ""));
+}
+
+/** Build-context paths copied into the `frontend-builder` stage. */
+function frontendBuilderCopySources(): string[] {
+  const dockerfile = readFileSync(join(repoRoot, "Dockerfile"), "utf8");
+  const stage = dockerfile.split(/^FROM .*AS frontend-builder$/m)[1]?.split(/^FROM /m)[0];
+  expect(stage, "Dockerfile has no frontend-builder stage").toBeDefined();
+
+  return (stage as string)
+    .split("\n")
+    .filter((line) => line.startsWith("COPY "))
+    .flatMap((line) => {
+      const args = line.slice("COPY ".length).split(/\s+/).filter(Boolean);
+      // Drop `--from=…`-style flags and the trailing destination argument.
+      return args.filter((arg) => !arg.startsWith("--")).slice(0, -1);
+    });
+}
+
+describe("Docker frontend-builder build context", () => {
+  it("copies every local file vite.config.ts imports", () => {
+    const copied = frontendBuilderCopySources();
+
+    for (const imported of localImportsOfViteConfig()) {
+      const covered = copied.some(
+        (source) => source === imported || imported.startsWith(`${source}/`),
+      );
+      expect(covered, `Dockerfile frontend-builder stage never COPYs "${imported}"`).toBe(true);
+    }
+  });
+
+  it("copies vite.config.ts itself", () => {
+    expect(frontendBuilderCopySources()).toContain("vite.config.ts");
+  });
+});


### PR DESCRIPTION
## What

The Docker image build fails at the frontend stage:

```
[UNRESOLVED_IMPORT] Could not resolve './bin/api-token.mjs' in vite.config.ts
```

`vite.config.ts` imports `bin/api-token.mjs` for the serve-only API token plugin, but the `frontend-builder` stage copies files in one by one and never copied `bin/`. Vite resolves every import when it loads its config, so the build fails even though the plugin itself never runs in a production build.

This adds `COPY bin ./bin` to that stage.

## Why the test

Nothing tied the config's import list to the stage's `COPY` lines. Adding an import passes lint, types and the test suite locally, and no CI job builds the image — so the only place it surfaced was a manual `docker build`. `src/test/dockerBuildContext.test.ts` reads both files and asserts every local import in `vite.config.ts` is covered by a `COPY`. The constraint is also written down in `specs/05-frontend-web.md`.

## Verification

- `docker build --target frontend-builder .` succeeds and produces `dist/` (it failed on `main` before this change)
- Guard test verified to fail when the `COPY bin ./bin` line is removed
- `oxfmt --check`, `oxlint`, `tsc --noEmit` (both configs), `vitest run` — 560 tests pass

## Notes

This commit was originally written on 6 September but no PR was opened, so `main` shipped v0.14.0 and v0.15.0 with the Docker build still broken. It has been rebased onto current `main`.

Worth considering separately: a build-only Docker job in CI. This test covers the missing-`COPY` case, but a broken `Cargo.toml` or missing runtime dependency would still only show up when someone builds the image by hand.
