### PR TITLE
fix(web): reopen the SSE stream after the browser gives up on a refused reconnect

### DIFF
--- a/specs/05-frontend-web.md
+++ b/specs/05-frontend-web.md
@@ -360,8 +360,15 @@ shows as a top-level banner instead of opening Settings. `setApiToken()` notifie
 subscribers only when the value really changes; `listen.ts` subscribes and reopens its stream, so the
 SSE connection follows the credential whether the reissue came from Settings → Accepted clients in
 this tab or was pushed over HMR because another client rewrote the file. The dev server is never
-restarted for a reissue. `SettingsModal` owns the **Accepted clients** section: list, Add client
-(credential shown once), Reissue and Revoke (two-click confirms, `web-ui` lock-out warning).
+restarted for a reissue. `EventSource` retries network failures by itself, but a non-200 reply makes
+it fail the connection for good (`readyState` `CLOSED`, one `error`, no retry) — and since
+`/api/events` is authenticated, a reconnect the browser makes with the URL or cookie the stream was
+opened with can now be refused with a 401 (backend restart, sleep/wake, a suspended tab, after the
+credential changed). `listen.ts` watches for that and reopens the stream with the _current_
+credential, backing off from 1 s to 30 s between attempts and resetting once a stream opens, for as
+long as anything is listening; a credential change reopens immediately instead. `SettingsModal`
+owns the **Accepted clients** section: list, Add client (credential shown once), Reissue and Revoke
+(two-click confirms, `web-ui` lock-out warning).
 
 ```mermaid
 flowchart LR

--- a/src/lib/listen.test.ts
+++ b/src/lib/listen.test.ts
@@ -1,70 +1,138 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Stand-in for the browser's `EventSource` with the three things a real one
+ * does that `listen.ts` has to cope with: open a stream (200), *fail the
+ * connection* on a non-200 reply (`readyState` CLOSED, one `error`, no retry —
+ * the 401 case), and retry a network failure by itself (`readyState`
+ * CONNECTING, one `error` per attempt).
+ */
+class FakeEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  static instances: FakeEventSource[] = [];
+
+  readyState = FakeEventSource.CONNECTING;
+  closed = false;
+  private listeners = new Map<string, Set<EventListener>>();
+
+  constructor(public url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: EventListener) {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(fn);
+  }
+
+  removeEventListener(type: string, fn: EventListener) {
+    this.listeners.get(type)?.delete(fn);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  /** The server answered `200 text/event-stream`. */
+  open() {
+    this.readyState = FakeEventSource.OPEN;
+    this.dispatch("open");
+  }
+
+  /** The server answered anything else (e.g. 401): the browser gives up for good. */
+  fail() {
+    this.readyState = FakeEventSource.CLOSED;
+    this.dispatch("error");
+  }
+
+  /** The connection dropped: the browser reconnects on its own. */
+  drop() {
+    this.readyState = FakeEventSource.CONNECTING;
+    this.dispatch("error");
+  }
+
+  message(event: string, data: string) {
+    this.dispatch(event, new MessageEvent(event, { data }));
+  }
+
+  /** Named events with at least one handler attached — the lifecycle listeners
+   * `listen.ts` adds for itself (`open`, `error`) are not part of the contract. */
+  eventNames(): string[] {
+    return [...this.listeners]
+      .filter(([type, set]) => type !== "open" && type !== "error" && set.size > 0)
+      .map(([type]) => type);
+  }
+
+  private dispatch(type: string, ev: Event = new Event(type)) {
+    for (const fn of this.listeners.get(type) ?? []) fn.call(this, ev);
+  }
+}
+
+const urls = () => FakeEventSource.instances.map((s) => s.url);
+const latest = () => FakeEventSource.instances.at(-1)!;
 
 describe("listen (web/SSE mode)", () => {
-  let mockSource: {
-    readyState: number;
-    addEventListener: ReturnType<typeof vi.fn>;
-    removeEventListener: ReturnType<typeof vi.fn>;
-    close: ReturnType<typeof vi.fn>;
-  };
-
   beforeEach(async () => {
     vi.restoreAllMocks();
+    vi.useFakeTimers();
     // Reset module-level SSE state by clearing the module cache.
     vi.resetModules();
-
-    mockSource = {
-      readyState: 0,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      close: vi.fn(),
-    };
-
-    constructedUrls = [];
-    // EventSource must be a constructor (class), not a plain function.
-    vi.stubGlobal(
-      "EventSource",
-      class {
-        static CLOSED = 2;
-        readyState = mockSource.readyState;
-        addEventListener = mockSource.addEventListener;
-        removeEventListener = mockSource.removeEventListener;
-        close = mockSource.close;
-        constructor(url: string) {
-          constructedUrls.push(url);
-        }
-      },
-    );
+    FakeEventSource.instances = [];
+    vi.stubGlobal("EventSource", FakeEventSource);
     const { setApiToken } = await import("./apiToken");
     setApiToken(null);
   });
 
-  let constructedUrls: string[] = [];
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("creates an EventSource and registers event listener", async () => {
     const { listen } = await import("./listen");
-    const handler = vi.fn();
-    const unlisten = await listen("session-update", handler);
+    const unlisten = await listen("session-update", vi.fn());
 
-    expect(mockSource.addEventListener).toHaveBeenCalledWith(
-      "session-update",
-      expect.any(Function),
-    );
+    expect(FakeEventSource.instances).toHaveLength(1);
+    expect(latest().eventNames()).toEqual(["session-update"]);
     expect(typeof unlisten).toBe("function");
   });
 
-  it("unlisten removes the event listener", async () => {
+  it("hands each parsed payload to the handler and ignores malformed data", async () => {
     const { listen } = await import("./listen");
-    const unlisten = await listen("test-event", () => {});
-    unlisten();
+    const handler = vi.fn();
+    await listen("session-update", handler);
 
-    expect(mockSource.removeEventListener).toHaveBeenCalledWith("test-event", expect.any(Function));
+    latest().message("session-update", '{"count":3}');
+    latest().message("session-update", "not json");
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ payload: { count: 3 } });
+  });
+
+  it("unlisten removes the event listener and the last one closes the stream", async () => {
+    const { listen } = await import("./listen");
+    const unlistenA = await listen("test-event", () => {});
+    const unlistenB = await listen("other-event", () => {});
+    const source = latest();
+    expect(source.eventNames()).toEqual(["test-event", "other-event"]);
+
+    unlistenA();
+    expect(source.eventNames()).toEqual(["other-event"]);
+    expect(source.closed).toBe(false);
+
+    unlistenB();
+    expect(source.eventNames()).toEqual([]);
+    expect(source.closed).toBe(true);
   });
 
   it("connects to /api/events without a token when none is set", async () => {
     const { listen } = await import("./listen");
     await listen("session-update", () => {});
-    expect(constructedUrls).toEqual(["http://127.0.0.1:11423/api/events"]);
+    expect(urls()).toEqual(["http://127.0.0.1:11423/api/events"]);
   });
 
   it("carries the API token in the query string (EventSource cannot set headers)", async () => {
@@ -72,7 +140,7 @@ describe("listen (web/SSE mode)", () => {
     setApiToken("tok123");
     const { listen } = await import("./listen");
     await listen("session-update", () => {});
-    expect(constructedUrls).toEqual(["http://127.0.0.1:11423/api/events?token=tok123"]);
+    expect(urls()).toEqual(["http://127.0.0.1:11423/api/events?token=tok123"]);
   });
 
   it("reconnectSse closes the stream, reopens with the current token, and re-attaches listeners", async () => {
@@ -81,44 +149,38 @@ describe("listen (web/SSE mode)", () => {
     setApiToken("tok");
     await listen("session-update", () => {});
     await listen("picker-refresh", () => {});
-    expect(mockSource.addEventListener).toHaveBeenCalledTimes(2);
+    const first = latest();
+    expect(first.eventNames()).toEqual(["session-update", "picker-refresh"]);
 
     reconnectSse();
 
-    expect(mockSource.close).toHaveBeenCalledTimes(1);
-    expect(constructedUrls).toEqual([
+    expect(first.closed).toBe(true);
+    expect(urls()).toEqual([
       "http://127.0.0.1:11423/api/events?token=tok",
       "http://127.0.0.1:11423/api/events?token=tok",
     ]);
     // Both listeners were re-registered on the replacement connection.
-    expect(mockSource.addEventListener).toHaveBeenCalledTimes(4);
-    expect(mockSource.addEventListener).toHaveBeenLastCalledWith(
-      "picker-refresh",
-      expect.any(Function),
-    );
+    expect(latest().eventNames()).toEqual(["session-update", "picker-refresh"]);
   });
 
   it("reconnectSse is a no-op when nothing is listening", async () => {
     const { reconnectSse } = await import("./listen");
     reconnectSse();
-    expect(constructedUrls).toEqual([]);
-    expect(mockSource.close).not.toHaveBeenCalled();
+    expect(urls()).toEqual([]);
   });
 
   it("unlisten after reconnect detaches from the replacement connection and does not re-add it", async () => {
     const { listen, reconnectSse } = await import("./listen");
     const unlisten = await listen("session-update", () => {});
     reconnectSse();
+    const replacement = latest();
     unlisten();
-    expect(mockSource.removeEventListener).toHaveBeenCalledWith(
-      "session-update",
-      expect.any(Function),
-    );
-    // Refcount dropped to zero → connection closed (once for reconnect, once for release).
-    expect(mockSource.close).toHaveBeenCalledTimes(2);
+    expect(replacement.eventNames()).toEqual([]);
+    // Refcount dropped to zero → the replacement is closed too.
+    expect(replacement.closed).toBe(true);
     // A later reconnect has nothing to re-attach and nothing open to replace.
     reconnectSse();
-    expect(constructedUrls).toHaveLength(2);
+    expect(FakeEventSource.instances).toHaveLength(2);
   });
 
   it("reopens the stream with the new token when the live token changes", async () => {
@@ -126,25 +188,136 @@ describe("listen (web/SSE mode)", () => {
     const { listen } = await import("./listen");
     setApiToken("before");
     await listen("session-update", () => {});
-    expect(constructedUrls).toEqual(["http://127.0.0.1:11423/api/events?token=before"]);
+    expect(urls()).toEqual(["http://127.0.0.1:11423/api/events?token=before"]);
 
     // A rotation — from Settings in this tab, or pushed over HMR because
     // another process rewrote the file — must not leave the stream on the
     // dead token.
     setApiToken("after");
-    expect(mockSource.close).toHaveBeenCalledTimes(1);
-    expect(constructedUrls).toEqual([
+    expect(FakeEventSource.instances[0].closed).toBe(true);
+    expect(urls()).toEqual([
       "http://127.0.0.1:11423/api/events?token=before",
       "http://127.0.0.1:11423/api/events?token=after",
     ]);
-    expect(mockSource.addEventListener).toHaveBeenCalledTimes(2);
+    expect(latest().eventNames()).toEqual(["session-update"]);
   });
 
   it("ignores a token change when nothing is listening", async () => {
     const { setApiToken } = await import("./apiToken");
     await import("./listen");
     setApiToken("x");
-    expect(constructedUrls).toEqual([]);
-    expect(mockSource.close).not.toHaveBeenCalled();
+    expect(urls()).toEqual([]);
+  });
+
+  describe("a stream the browser gave up on", () => {
+    it("is reopened with the current credential and its listeners, after a short delay", async () => {
+      const { setApiToken } = await import("./apiToken");
+      const { listen, SSE_REOPEN_MIN_MS } = await import("./listen");
+      setApiToken("tok");
+      const handler = vi.fn();
+      await listen("session-update", handler);
+      const dead = latest();
+
+      // e.g. the backend was restarted and answers the reconnect with a 401.
+      dead.fail();
+      expect(FakeEventSource.instances).toHaveLength(1);
+
+      vi.advanceTimersByTime(SSE_REOPEN_MIN_MS - 1);
+      expect(FakeEventSource.instances).toHaveLength(1);
+      vi.advanceTimersByTime(1);
+      expect(FakeEventSource.instances).toHaveLength(2);
+      expect(latest().url).toBe("http://127.0.0.1:11423/api/events?token=tok");
+      expect(latest().eventNames()).toEqual(["session-update"]);
+
+      // Events on the replacement reach the same handler.
+      latest().message("session-update", '{"count":1}');
+      expect(handler).toHaveBeenCalledWith({ payload: { count: 1 } });
+    });
+
+    it("is left alone while the browser is still retrying a network failure itself", async () => {
+      const { listen, SSE_REOPEN_MAX_MS } = await import("./listen");
+      await listen("session-update", () => {});
+
+      latest().drop();
+      latest().drop();
+      vi.advanceTimersByTime(SSE_REOPEN_MAX_MS * 4);
+      expect(FakeEventSource.instances).toHaveLength(1);
+    });
+
+    it("backs off while the reply stays refused and starts over once a stream opens", async () => {
+      const { listen, SSE_REOPEN_MIN_MS, SSE_REOPEN_MAX_MS } = await import("./listen");
+      await listen("session-update", () => {});
+
+      // 1s, 2s, 4s, 8s, 16s, 30s, 30s, ...
+      let expected = SSE_REOPEN_MIN_MS;
+      for (let attempt = 1; attempt <= 8; attempt++) {
+        const before = FakeEventSource.instances.length;
+        latest().fail();
+        vi.advanceTimersByTime(expected - 1);
+        expect(FakeEventSource.instances).toHaveLength(before);
+        vi.advanceTimersByTime(1);
+        expect(FakeEventSource.instances).toHaveLength(before + 1);
+        expected = Math.min(expected * 2, SSE_REOPEN_MAX_MS);
+      }
+
+      // A stream that opens resets the schedule.
+      latest().open();
+      latest().fail();
+      vi.advanceTimersByTime(SSE_REOPEN_MIN_MS);
+      expect(FakeEventSource.instances).toHaveLength(10);
+    });
+
+    it("is not reopened once the last listener is gone", async () => {
+      const { listen, SSE_REOPEN_MAX_MS } = await import("./listen");
+      const unlisten = await listen("session-update", () => {});
+      latest().fail();
+      unlisten();
+      vi.advanceTimersByTime(SSE_REOPEN_MAX_MS * 4);
+      expect(FakeEventSource.instances).toHaveLength(1);
+    });
+
+    it("is reopened at once, not on the timer, when the credential changes meanwhile", async () => {
+      const { setApiToken } = await import("./apiToken");
+      const { listen, SSE_REOPEN_MAX_MS } = await import("./listen");
+      setApiToken("stale");
+      await listen("session-update", () => {});
+      latest().fail();
+
+      // The reissued credential arrives (Settings in this tab, or HMR) before
+      // the timer fires: the stream follows it immediately…
+      setApiToken("fresh");
+      expect(urls()).toEqual([
+        "http://127.0.0.1:11423/api/events?token=stale",
+        "http://127.0.0.1:11423/api/events?token=fresh",
+      ]);
+      // …and the pending reopen does not open a third one on top.
+      vi.advanceTimersByTime(SSE_REOPEN_MAX_MS * 4);
+      expect(FakeEventSource.instances).toHaveLength(2);
+    });
+
+    it("ignores an error from a stream that has already been replaced", async () => {
+      const { listen, reconnectSse, SSE_REOPEN_MAX_MS } = await import("./listen");
+      await listen("session-update", () => {});
+      const old = latest();
+      reconnectSse();
+      expect(FakeEventSource.instances).toHaveLength(2);
+
+      old.fail();
+      vi.advanceTimersByTime(SSE_REOPEN_MAX_MS * 4);
+      expect(FakeEventSource.instances).toHaveLength(2);
+    });
+
+    it("a new listener arriving on a dead stream opens a fresh one and drops the pending reopen", async () => {
+      const { listen, SSE_REOPEN_MAX_MS } = await import("./listen");
+      await listen("session-update", () => {});
+      latest().fail();
+
+      await listen("picker-refresh", () => {});
+      expect(FakeEventSource.instances).toHaveLength(2);
+      expect(latest().eventNames()).toEqual(["session-update", "picker-refresh"]);
+
+      vi.advanceTimersByTime(SSE_REOPEN_MAX_MS * 4);
+      expect(FakeEventSource.instances).toHaveLength(2);
+    });
   });
 });

--- a/src/lib/listen.ts
+++ b/src/lib/listen.ts
@@ -19,6 +19,33 @@ let sseRefCount = 0;
  * connection (after a credential reissue or a closed stream) can re-attach them. */
 const registered = new Map<string, Set<EventListener>>();
 
+/**
+ * Reopen schedule for a stream the browser has given up on.
+ *
+ * `EventSource` retries network failures on its own, but a non-200 reply makes
+ * it *fail the connection*: `readyState` goes to `CLOSED`, one `error` event
+ * fires, and it never tries again. Before `/api/events` required a credential
+ * that could not happen; now it does whenever a reconnect is refused with a
+ * 401 — the browser reconnects with the URL (and, in Docker, whatever cookie)
+ * the stream was opened with, so a backend restart, a sleep/wake or a
+ * suspended tab that lands after the credential changed leaves the stream
+ * dead while the page looks connected: no `session-update`, no
+ * `picker-refresh`, no live tail. So a `CLOSED` stream is reopened here with
+ * the *current* credential, backing off between attempts, for as long as
+ * anything is listening.
+ */
+export const SSE_REOPEN_MIN_MS = 1_000;
+export const SSE_REOPEN_MAX_MS = 30_000;
+let reopenDelay = SSE_REOPEN_MIN_MS;
+let reopenTimer: ReturnType<typeof setTimeout> | null = null;
+
+function cancelReopen(): void {
+  if (reopenTimer !== null) {
+    clearTimeout(reopenTimer);
+    reopenTimer = null;
+  }
+}
+
 function openSource(): EventSource {
   // `EventSource` can't set headers, so the client credential rides in the
   // query string (see lib/apiToken.ts). Empty in Docker, where the cookie is used.
@@ -26,11 +53,31 @@ function openSource(): EventSource {
   for (const [event, handlers] of registered) {
     for (const handler of handlers) source.addEventListener(event, handler);
   }
+  source.addEventListener("open", () => {
+    // A stream that made it through is proof the credential is good again.
+    if (source === sseSource) reopenDelay = SSE_REOPEN_MIN_MS;
+  });
+  source.addEventListener("error", () => onSourceError(source));
   return source;
+}
+
+function onSourceError(source: EventSource): void {
+  // The last gasp of a stream already replaced or released — nothing to do.
+  if (source !== sseSource || sseRefCount <= 0) return;
+  // `CONNECTING`: a network failure the browser is retrying by itself.
+  if (source.readyState !== EventSource.CLOSED) return;
+  if (reopenTimer !== null) return;
+  reopenTimer = setTimeout(() => {
+    reopenTimer = null;
+    if (sseSource !== source || sseRefCount <= 0) return;
+    sseSource = openSource();
+  }, reopenDelay);
+  reopenDelay = Math.min(reopenDelay * 2, SSE_REOPEN_MAX_MS);
 }
 
 function ensureSse(): EventSource {
   if (!sseSource || sseSource.readyState === EventSource.CLOSED) {
+    cancelReopen();
     sseSource = openSource();
   }
   sseRefCount++;
@@ -39,8 +86,9 @@ function ensureSse(): EventSource {
 
 function releaseSse(): void {
   sseRefCount--;
-  if (sseRefCount <= 0 && sseSource) {
-    sseSource.close();
+  if (sseRefCount <= 0) {
+    cancelReopen();
+    sseSource?.close();
     sseSource = null;
     sseRefCount = 0;
   }
@@ -54,6 +102,10 @@ function releaseSse(): void {
  */
 export function reconnectSse(): void {
   if (!sseSource) return;
+  // A new credential is the likeliest cure for a refused stream: reopen now,
+  // and let the next failure (if any) start the backoff from scratch.
+  cancelReopen();
+  reopenDelay = SSE_REOPEN_MIN_MS;
   sseSource.close();
   sseSource = openSource();
 }


### PR DESCRIPTION
Since /api/events requires a client credential, a reconnect the browser
makes on its own can be answered with a 401: it reuses the URL (and, in
Docker, whatever cookie) the stream was opened with, so after a backend
restart, a sleep/wake or a suspended tab that lands once the credential
has changed, the reply is no longer 200. EventSource treats any non-200
as "fail the connection": readyState goes to CLOSED, one error fires and
it never retries. listen.ts attached no error handler, only replaced the
stream on a credential change or a brand-new listen() call, and the
hooks subscribe once at mount - so the tab looked connected while no
session-update / picker-refresh ever arrived and the live tail and
ongoing indicator froze.

listen.ts now watches each stream for that terminal error (a CONNECTING
error is the browser's own network retry and is left alone) and reopens
it with the current credential and every registered listener, backing
off 1s -> 30s between attempts and resetting once a stream opens. A
credential change still reopens at once and cancels a pending reopen;
releasing the last listener cancels it too; errors from an already
replaced stream are ignored.

Tests replace the shared vi.fn() mock with a fake EventSource that can
open, fail (non-200) and drop (network) like a browser, and cover the
reopen, the backoff and its reset, and every cancellation path.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018tiZSAWWfNJc4fWnQgMxpk